### PR TITLE
fix: Update player.yaml

### DIFF
--- a/mods/cameo/rules/player.yaml
+++ b/mods/cameo/rules/player.yaml
@@ -308,7 +308,7 @@ Player:
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
-		QueuedAudio: Training
+		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
@@ -322,7 +322,7 @@ Player:
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
-		QueuedAudio: Training
+		QueuedAudio: Building
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True


### PR DESCRIPTION
Wrong announcer audio used for "Building" UI order