### PR TITLE
fix: d2k animation sequences

### DIFF
--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -416,6 +416,11 @@ Player:
 	-ActorPreviewPlaceBuildingPreview:
 	D2kActorPreviewPlaceBuildingPreview:
 	Cloak@TScloak:
+	WithSpriteBody:
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithCrumbleOverlay:
+		RequiresCondition: !build-incomplete
 
 ^D2kUpgradeable:
 	GrantConditionOnPrerequisite@UPGRADEABLE:

--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -811,6 +811,7 @@ OILB.d2k:
 		RequiresCondition: !damaged
 	-WithDeathAnimation:
 	-ActorPreviewPlaceBuildingPreview:
+	-WithCrumbleOverlay:
 
 construction_yard.ixian:
 	Inherits@D2kBLD: ^D2KBuilding
@@ -2302,6 +2303,7 @@ storm_lasher_big:
 	RenderSprites:
 		Image: storm_lasher_big
 		Palette: td_temperat
+	-WithCrumbleOverlay:
 
 # starport_smuggler:
 # 	Inherits: starport

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -7804,15 +7804,14 @@ ordos_harv:
 	dock:
 		Filename: ordos_harv.png
 		Scale: 0.8
-		Start: 128
-		Facings: 8
-		Length: 8
+		Start: 168
+		Facings: 1
+		Length: 6
 	dock-loop:
 		Filename: ordos_harv.png
 		Scale: 0.8
-		Start: 128
-		Facings: 8
-		Length: 8
+		Start: 170
+		Facings: 1
 	icon:
 		Filename: ordos_harv_icon.png
 


### PR DESCRIPTION
* d2k structures now should play their ruck crumble animation when placing them.

Before

https://github.com/user-attachments/assets/4260f983-df0f-4775-ab63-2fb0ebe25b8b

After

https://github.com/user-attachments/assets/6c9e892c-6426-472f-99d3-0446a0d1bdb0



* Ordos harvester docking loop animation is fixed

Before, ordos harvester plays jumping loop when docking in the Ordos refinery.