### PR TITLE
fix: d2k Spice Sifter improvement

### DIFF
--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -784,6 +784,8 @@ OILB.d2k:
 		Prerequisites: ~construction_yard, research_centre, derricklimit
 		Description: actor-oilb.description
 		IconPalette: d2kunit
+	Building:
+		BuildSounds: BUILD1.WAV
 	Tooltip:
 		Name: Spice Sifter
 	RenderSprites:
@@ -808,10 +810,14 @@ OILB.d2k:
 		Condition: damaged
 		ValidDamageStates: Heavy, Critical
 	WithIdleOverlay:
-		RequiresCondition: !damaged
+		RequiresCondition: !damaged && !build-incomplete
+	WithSpriteBody:
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithCrumbleOverlay:
+		RequiresCondition: !build-incomplete
 	-WithDeathAnimation:
 	-ActorPreviewPlaceBuildingPreview:
-	-WithCrumbleOverlay:
 
 construction_yard.ixian:
 	Inherits@D2kBLD: ^D2KBuilding

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -1391,6 +1391,7 @@ research.gold:
 		Filename: d2k_research_center_gold_icon.shp
 		Start: 0
 		Offset: 0,0
+
 palace.atreides:
 	Defaults:
 		AddExtension: false
@@ -7713,8 +7714,18 @@ d2k_spice_sifter:
 		AddExtension: false
 		ZOffset: 50
 		Tick: 100
+	crumble-overlay:
+		Filename: DATA.R16
+		Scale: 1.5
+		Remap: 54F94B
+		Start: 4427
+		Length: 12
+		Offset: -32,64
+		ZOffset: 100
+		Tick: 100
 	icon:
 		Filename: d2k_spice_sifter_icon.shp
+
 d2k_mcv:
 	Defaults:
 		AddExtension: false

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -7690,11 +7690,14 @@ sandworm:
 d2k_spice_sifter:
 	idle:
 		Filename: d2k_spice_sifter.shp
+		Scale: 1.5
 	damaged-idle:
 		Filename: d2k_spice_sifter.shp
+		Scale: 1.5
 		Start: 1
 	idle-overlay:
 		Filename: d2k_spice_sifter.shp
+		Scale: 1.5
 		Start: 2
 		Length: 5
 		Tick: 80


### PR DESCRIPTION
* Spice Sifter now have typical d2k rock crumbling build animation when placed
* Scaled up the sprite 1.5x to fill up footprint and match other d2k buildings