### PR TITLE
fix: Animation sequences

### DIFF
--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -1943,6 +1943,7 @@ ixian_launchpad:
 	Buildable:
 		Prerequisites: ~construction_yard.ixian, outpost.ixian
 	Building:
+		BuildSounds: BUILD1.WAV
 		Footprint: xx xx
 		Dimensions: 2,2
 	Exit@1:
@@ -1964,6 +1965,10 @@ ixian_launchpad:
 		Modifier: 75
 	ActorStatValues:
 		Upgrades: upgrade_hightech
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithCrumbleOverlay:
+		RequiresCondition: !build-incomplete
 	-WithDeathAnimation:
 	FireProjectilesOnDeath:
 		Weapons: Debris2, Debris3

--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -1449,7 +1449,6 @@ d2k_munitions.ixian:
 	RenderSprites:
 		Image: d2k_munitions.atreides
 	WithSpriteBody:
-	WithMakeAnimation:
 	Power:
 		Amount: -10
 	MustBeDestroyed:
@@ -2441,7 +2440,6 @@ machine_gun_turret:
 		Cost: 600
 	Tooltip:
 		Name: Machine Gun Turret
-	WithMakeAnimation:
 	Health:
 		HP: 75000
 	BodyOrientation:
@@ -2479,7 +2477,6 @@ machine_gun_turret:
 		RequiresCondition: !build-incomplete
 	-WithDeathAnimation:
 	-WithSpriteTurret:
-	-WithMakeAnimation:
 	FireProjectilesOnDeath:
 		Weapons: Debris2, Debris3
 		Pieces: 2, 4
@@ -12359,6 +12356,7 @@ sietch_creep:
 		-Condition:
 	ProvidesPrerequisite@buildingname:
 	-WithMakeAnimation:
+	-WithCrumbleOverlay:
 	-WithBuildingRepairDecoration:
 	-WithDeathAnimation:
 	FireProjectilesOnDeath:
@@ -12975,7 +12973,6 @@ storm_lasher:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	WithMakeAnimation:
 	Health:
 		HP: 200000
 	Shielded:
@@ -13008,7 +13005,6 @@ storm_lasher:
 	WithSpriteBody:
 		Sequence: idle
 	WithMuzzleOverlay:
-	WithMakeAnimation:
 	-WithDeathAnimation:
 	-WithWallSpriteBody:
 	-WithSpriteTurret:
@@ -13033,6 +13029,7 @@ storm_lasher:
 		Range: 5692
 	ActorStatValues:
 		Upgrades: d2k_general_purpose_armor, d2k_advanced_ixian_technology
+
 
 	### Armor Tree
 

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -156,11 +156,19 @@ storm_lasher:
 		Filename: DATA.R16
 		Scale: 1.5
 		Remap: 54F94B
-		Start: 4518
-		Length: 9
+		Start: 4440
+		Length: 8
 		Offset: -48,64
 		Tick: 100
 		AddExtension: false
+	crumble-overlay:
+		Filename: DATA.R16
+		Scale: 1.5
+		Remap: 54F94B
+		Start: 4448
+		Length: 9
+		Offset: -32,64
+		Tick: 100
 	idle-overlay:
 		Filename: d2k_storm_lasher.shp
 		Scale: 1.5

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -158,7 +158,7 @@ storm_lasher:
 		Remap: 54F94B
 		Start: 4440
 		Length: 8
-		Offset: -48,64
+		Offset: -32,64
 		Tick: 100
 		AddExtension: false
 	crumble-overlay:

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -1150,22 +1150,22 @@ ixian_launchpad:
 	idle:
 		Length: 10
 		ZOffset: -1023
-		Tick: 50
+		Tick: 100
 	damaged-idle:
 		Filename: IxHoverpadDamaged.png
 		Length: 10
 		ZOffset: -1023
-		Tick: 50
+		Tick: 100
 	active:
 		Start: 10
 		Length: 6
-		Tick: 60
+		Tick: 100
 		ZOffset: -1023
 	damaged-active:
 		Filename: IxHoverpadDamaged.png
 		Start: 10
 		Length: 6
-		Tick: 60
+		Tick: 100
 		ZOffset: -1023
 	dead:
 		Start: 9
@@ -1177,6 +1177,14 @@ ixian_launchpad:
 		Remap: 54F94B
 		Start: 4477
 		Length: 8
+		Offset: -32,64
+		Tick: 100
+	crumble-overlay:
+		Filename: DATA.R16
+		Scale: 1.5
+		Remap: 54F94B
+		Start: 4485
+		Length: 9
 		Offset: -32,64
 		Tick: 100
 	icon:

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -3604,6 +3604,15 @@ d2k_munitions.atreides:
 		Length: 7
 		Offset: -16,16
 		Tick: 100
+	crumble-overlay:
+		Filename: DATA.R16
+		Scale: 1.5
+		Remap: 54F94B
+		Start: 4584
+		Length: 7
+		Offset: -16,16
+		Tick: 200
+		ZOffset: 1024
 	icon:
 		Filename: d2k_munitions_icon.shp
 		Start: 2

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -3599,14 +3599,14 @@ d2k_munitions.atreides:
 	idle:
 		Filename: d2k_munitions.shp
 		Start: 2
-		Scale: 1.875
+		Scale: 1.5
 	damaged-idle:
 		Filename: d2k_munitions.shp
 		Start: 3
-		Scale: 1.875
+		Scale: 1.5
 	make:
 		Filename: DATA.R16
-		Scale: 1.875
+		Scale: 1.5
 		Remap: 54F94B
 		Start: 4577
 		Length: 7


### PR DESCRIPTION
* Fixed crash on Ixian Munitions Silo and Ixian Storm Lasher because the lack of rock crumble building animation
* Fixed building animation offset for Ixian Storm Lasher
* Added rock crumble building animation for Ixian Launchpad
* Slowed down Ixian Launchpad lights animation
* Fixed scaling for Ixian Munitions Silo -- sprite scale were too large for their 1x1 footprint.
* Removed redundant `WithMakeAnimation:` traits (a lot were rementioned in later lines, for the same entity)