### PR TITLE
feat: Sound improvements

### DIFF
--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2331,8 +2331,14 @@ ORCA.Husk:
 	RenderSprites:
 		Image: orca
 
-^FACT:
+^TDBuilding:
 	Inherits: ^BaseBuilding
+	SoundOnDamageTransition:
+		DamagedSounds: xplobig4.aud
+		DestroyedSounds: crumble.aud, xplobig4.aud
+
+^FACT:
+	Inherits: ^TDBuilding
 	Inherits@shape: ^3x2Shape
 	Inherits@conyard: ^Conyard
 	Inherits@sell: ^TDSpawnActorsOnSell
@@ -2385,7 +2391,7 @@ FACT.NOD:
 		Image: nodfact
 
 NUKE:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@power: ^PowerPlant
 	Inherits@sell: ^TDSpawnActorsOnSell
@@ -2417,7 +2423,7 @@ NUKE:
 	ProvidesPrerequisite@buildingname:
 
 NUK2:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@power: ^PowerPlant
 	Inherits@sell: ^TDSpawnActorsOnSell
@@ -2450,7 +2456,7 @@ NUK2:
 		Prerequisite: nuke
 
 ^TDPROC:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@ref: ^Refinery
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@shape: ^3x3Shape
@@ -2524,7 +2530,7 @@ PROC.NOD:
 		RequiresCondition: stealthharvester
 
 SILO:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x1Shape
 	Inherits@storage: ^StoresResources
 	Valued:
@@ -2559,7 +2565,7 @@ SILO:
 		PipCount: 10
 
 PYLE:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@barr: ^IsBarrack
 	Inherits@shape: ^2x2Shape
@@ -2586,7 +2592,7 @@ PYLE:
 		Prerequisite: cncbarracks
 
 HAND:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@sell: ^TDNodSpawnActorsOnSell
 	Inherits@barr: ^IsBarrack
@@ -2611,7 +2617,7 @@ HAND:
 		Prerequisite: cncbarracks
 
 AFLD:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@sell: ^TDNodSpawnActorsOnSell
 	Inherits@weap: ^IsWeaponFactory
 	# Inherits@weap: ^IsVehicleDropzone
@@ -2677,7 +2683,7 @@ AFLD:
 		RequiresCondition: !build-incomplete
 
 WEAP:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^3x3Shape
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@weap: ^IsWeaponFactory
@@ -2713,7 +2719,7 @@ WEAP:
 		Sequence: place
 
 HPAD.GDI:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@hpad: ^IsAircraftFactory
@@ -2738,7 +2744,7 @@ HPAD.GDI:
 		Image: hpad
 
 HPAD.NOD:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@sell: ^TDNodSpawnActorsOnSell
 	Inherits@hpad: ^IsAircraftFactory
@@ -2768,7 +2774,7 @@ HPAD.NOD:
 		Image: hpad
 
 HQ.GDI:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@radar: ^RadarBuilding
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@spy: ^InfiltrateForSupportPowerReset
@@ -2827,7 +2833,7 @@ HQ.GDI:
 	SupportPowerChargeBar:
 
 HQ.Nod:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@radar: ^RadarBuilding
 	Inherits@sell: ^TDNodSpawnActorsOnSell
 	Inherits@spy: ^InfiltrateForSupportPowerReset
@@ -2851,7 +2857,7 @@ HQ.Nod:
 		Prerequisites: ~fact.nod, proc.nod
 
 FIX.GDI:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@shape: ^3x3Shape
 	Inherits@repair: ^RepairsUnits
@@ -2882,7 +2888,7 @@ FIX.GDI:
 		Prerequisite: fix.gdi
 
 FIX.Nod:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@sell: ^TDSpawnActorsOnSell
 	Inherits@shape: ^3x3Shape
 	Inherits@repair: ^RepairsUnits
@@ -2913,7 +2919,7 @@ FIX.Nod:
 		Prerequisite: fix.nod
 
 EYE:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^2x2Shape
 	Inherits@SW: ^PrimarySuperweapon
 	Inherits@sell: ^TDSpawnActorsOnSell
@@ -3017,7 +3023,7 @@ eye.ionc:
 		Image: eye.ionc
 
 TMPL:
-	Inherits: ^BaseBuilding
+	Inherits: ^TDBuilding
 	Inherits@shape: ^3x3Shape
 	Inherits@SW: ^PrimarySuperweapon
 	Inherits@sell: ^TDNodSpawnActorsOnSell

--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2337,8 +2337,7 @@ ORCA.Husk:
 		BuildSounds: constru2.aud, hvydoor1.aud
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
-		# DestroyedSounds: crumble.aud, xplobig4.aud
-		DestroyedSounds:
+		DestroyedSounds: crumble.aud, xplobig4.aud
 	FireWarheadsOnDeath:
 		Type: Footprint
 		Weapon: TDBuildingExplode
@@ -2350,8 +2349,7 @@ ORCA.Husk:
 		BuildSounds: constru2.aud, hvydoor1.aud
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
-		# DestroyedSounds: crumble.aud, xplobig4.aud
-		DestroyedSounds:
+		DestroyedSounds: crumble.aud, xplobig4.aud
 	FireWarheadsOnDeath:
 		Type: Footprint
 		Weapon: TDBuildingExplode

--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2337,6 +2337,12 @@ ORCA.Husk:
 		DamagedSounds: xplobig4.aud
 		DestroyedSounds: crumble.aud, xplobig4.aud
 
+^TDDefense:
+	Inherits: ^Defense
+	SoundOnDamageTransition:
+		DamagedSounds: xplobig4.aud
+		DestroyedSounds: crumble.aud, xplobig4.aud
+
 ^FACT:
 	Inherits: ^TDBuilding
 	Inherits@shape: ^3x2Shape
@@ -3146,7 +3152,7 @@ tmpl.nuke:
 		Image: tmpl.nuke
 
 GUN:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^BasicDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetGround
@@ -3202,7 +3208,7 @@ GUN:
 		Upgrades: up_improvedartilleries, up_blackmarketupgrades
 
 NodLaserTurret:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^BasicDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@DisabledOverlay: ^DisableOnLowPowerOrPowerDown
@@ -3248,7 +3254,7 @@ NodLaserTurret:
 		Range: 6800
 
 SAM:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^AntiAirDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetAir
@@ -3299,7 +3305,7 @@ SAM:
 		Upgrades: up_guerillatactics, up_advancedguerillatactics
 
 OBLI:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^AdvancedDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetGround
@@ -3356,7 +3362,7 @@ OBLI:
 		Range: 4800
 
 GTWR:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^BasicDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetGround
@@ -3406,7 +3412,7 @@ GTWR:
 		Upgrades: up_longrangesensors, up_armorpiercingbullets, up_cuttingedgeequipment
 
 ATWR:
-	Inherits: ^Defense
+	Inherits: ^TDDefense
 	Inherits@Template: ^AdvancedDefenseTemplate
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetAll
@@ -7029,7 +7035,7 @@ gdirig:
 # 		Upgrades: up_longrangesensors, up_armorpiercingbullets, up_highvelocitycannons, up_advancedmissiletargeting, up_lightweightarmorplating
 
 # gdirigtower:
-# 	Inherits: ^Defense
+# 	Inherits: ^TDDefense
 # 	Inherits@Template: ^SuperDefenseTemplate
 # 	Inherits@exp: ^GainsExperienceTDBuilding
 # 	Inherits@PromotionUnitBuff: ^PromotionUnitBuff

--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2346,7 +2346,12 @@ ORCA.Husk:
 	Inherits: ^Defense
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
-		DestroyedSounds: crumble.aud, xplobig4.aud
+		# DestroyedSounds: crumble.aud, xplobig4.aud
+		DestroyedSounds:
+	FireWarheadsOnDeath:
+		Type: Footprint
+		Weapon: TDBuildingExplode
+		EmptyWeapon: TDBuildingExplode
 
 ^FACT:
 	Inherits: ^TDBuilding

--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2335,7 +2335,12 @@ ORCA.Husk:
 	Inherits: ^BaseBuilding
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
-		DestroyedSounds: crumble.aud, xplobig4.aud
+		# DestroyedSounds: crumble.aud, xplobig4.aud
+		DestroyedSounds:
+	FireWarheadsOnDeath:
+		Type: Footprint
+		Weapon: TDBuildingExplode
+		EmptyWeapon: TDBuildingExplode
 
 ^TDDefense:
 	Inherits: ^Defense

--- a/mods/cameo/rules/tiberiandawn.yaml
+++ b/mods/cameo/rules/tiberiandawn.yaml
@@ -2333,6 +2333,8 @@ ORCA.Husk:
 
 ^TDBuilding:
 	Inherits: ^BaseBuilding
+	Building:
+		BuildSounds: constru2.aud, hvydoor1.aud
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
 		# DestroyedSounds: crumble.aud, xplobig4.aud
@@ -2344,6 +2346,8 @@ ORCA.Husk:
 
 ^TDDefense:
 	Inherits: ^Defense
+	Building:
+		BuildSounds: constru2.aud, hvydoor1.aud
 	SoundOnDamageTransition:
 		DamagedSounds: xplobig4.aud
 		# DestroyedSounds: crumble.aud, xplobig4.aud

--- a/mods/cameo/weapons/d2k.yaml
+++ b/mods/cameo/weapons/d2k.yaml
@@ -2224,6 +2224,8 @@ D2kBuildingExplode:
 		Explosions: d2k_building, d2k_self_destruct, d2k_large_explosion
 		ImpactActors: false
 		ExplosionPalette: effect75alpha
+	Warhead@Effect: CreateEffect
+		ImpactSounds: EXPLHG1.WAV
 
 D2kBuildingExplodeH:
 	Inherits: D2kBuildingExplode

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -26,6 +26,11 @@
 		ContrailStartWidth: 64
 		ContrailEndWidth: 16
 
+TDBuildingExplode:
+	Inherits: BuildingExplode
+	Warhead@Effect: CreateEffect
+		ImpactSounds: crumble.aud, xplobig4.aud
+
 M16:
 	Inherits: ^SmallArms
 	ReloadDelay: 17

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -29,7 +29,9 @@
 TDBuildingExplode:
 	Inherits: BuildingExplode
 	Warhead@Effect: CreateEffect
+		Explosions: building, building_napalm, med_frag, poof, small_building
 		ImpactSounds: crumble.aud, xplobig4.aud
+		Delay: 0
 
 M16:
 	Inherits: ^SmallArms

--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -3444,7 +3444,7 @@ DefuseKit:
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees, Creep
 	Warhead@Effect: CreateEffect
 		Explosions: self_destruct
-		ImpactSounds: kaboom22.aud
+		# ImpactSounds: kaboom22.aud
 		ValidTargets: Ground, Air, Ship, Trees
 	Warhead@EffectWater: CreateEffect
 		Explosions: large_splash

--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -3444,7 +3444,7 @@ DefuseKit:
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees, Creep
 	Warhead@Effect: CreateEffect
 		Explosions: self_destruct
-		# ImpactSounds: kaboom22.aud
+		ImpactSounds: kaboom22.aud
 		ValidTargets: Ground, Air, Ship, Trees
 	Warhead@EffectWater: CreateEffect
 		Explosions: large_splash


### PR DESCRIPTION
[feat: TDBuildingExplode trait](https://github.com/cameo-mod/Cameo-mod/pull/13/commits/6347056184711a1c8ee6f3ddf013802323769977)

Rework building destroyed sound for Tiberian Dawn buildings

Previously set to some default kaboom22 sound (RA1)

[feat: D2kBuildingExplode impact sound](https://github.com/cameo-mod/Cameo-mod/pull/13/commits/9eccc97c72961cb9c6245b20d180f29831a8f5c6) 

Original d2k building destroyed sound