### PR TITLE
fix: Update to quota-mode for multiplayer

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/QuotaProductionManager.cs
+++ b/OpenRA.Mods.Cameo/Traits/QuotaProductionManager.cs
@@ -56,7 +56,8 @@ namespace OpenRA.Mods.Cameo.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			world = self.World;
-			Enabled = Game.Settings.SinglePlayerSettings.QuotaModeEnabled;
+			var isMultiplayer = world.Players.Count(p => !p.IsBot && p.Playable) > 1;
+			Enabled = !isMultiplayer && Game.Settings.SinglePlayerSettings.QuotaModeEnabled;
 		}
 
 		void INotifyOtherProduction.UnitProducedByOther(
@@ -98,13 +99,7 @@ namespace OpenRA.Mods.Cameo.Traits
 					if (!queue.Enabled) continue;
 
 					foreach (var item in queue.AllQueued())
-					{
-						// Infinite mode conflicts with quota — suppress it.
-						if (item.Infinite)
-							item.Infinite = false;
-
 						globalQueued[item.Item] = globalQueued.GetValueOrDefault(item.Item, 0) + 1;
-					}
 
 					ConsumeCreditsFromSnapshot(building.ActorID, queue);
 				}

--- a/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cameo.Traits;
 using OpenRA.Mods.Common.Widgets;
@@ -52,10 +53,15 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			autoSaveNoDropDown.GetText = () => FluentProvider.GetMessage(AutoSaveMaxFileNumber, "saves", Game.Settings.SinglePlayerSettings.AutoSaveMaxFileCount);
 			autoSaveNoDropDown.IsDisabled = () => Game.Settings.SinglePlayerSettings.AutoSaveInterval <= 0;
 
+			var isMultiplayer = worldRenderer?.World != null &&
+				worldRenderer.World.Players.Count(p => !p.IsBot && p.Playable) > 1;
+
 			var quotaCheckbox = panel.Get<CheckboxWidget>("QUOTA_MODE_CHECKBOX");
-			quotaCheckbox.IsChecked = () => Game.Settings.SinglePlayerSettings.QuotaModeEnabled;
+			quotaCheckbox.IsChecked = () => !isMultiplayer && Game.Settings.SinglePlayerSettings.QuotaModeEnabled;
+			quotaCheckbox.IsDisabled = () => isMultiplayer;
 			quotaCheckbox.OnClick = () =>
 			{
+				if (isMultiplayer) return;
 				Game.Settings.SinglePlayerSettings.QuotaModeEnabled ^= true;
 				Game.Settings.Save();
 

--- a/mods/cameo/chrome/settings-gameplay.yaml
+++ b/mods/cameo/chrome/settings-gameplay.yaml
@@ -80,4 +80,6 @@ Container@GAMEPLAY_PANEL:
 									Width: PARENT_WIDTH
 									Height: 20
 									Font: Regular
-									Text: checkbox-quota-mode
+									Text: checkbox-quota-mode.label
+									TooltipText: checkbox-quota-mode.tooltip
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -235,4 +235,8 @@ support-power-timer = { $player }'s { $support-power }: { $time }
 
 ## settings-gameplay.yaml
 label-experimental-section-header = Experimental Features
-checkbox-quota-mode = Quota Mode for Build Orders
+checkbox-quota-mode =
+    .label = Quota Mode (Experimental)
+    .tooltip = Production buildings automatically re-queue units to maintain target alive counts per type.
+        Left-click a unit in the production panel to set its target; right-click to lower it.
+        Due to its instability, this feature is currently single-player only, and disabled in multiplayer.


### PR DESCRIPTION
Completely disable quota mode in multiplayer as it causes desync.

Also remove redundant infinite queue check inside this mode.

Will revisit how to improve this experimental feature in the future.