### PR TITLE
feat: Flame impact glow

### DIFF
--- a/OpenRA.Mods.Cameo/Warheads/GlowImpactWarhead.cs
+++ b/OpenRA.Mods.Cameo/Warheads/GlowImpactWarhead.cs
@@ -1,0 +1,46 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Warheads
+{
+	[Desc("Registers a screen-space glow flash at the impact position. Purely visual, no damage.")]
+	public class GlowImpactWarhead : Warhead
+	{
+		[Desc("Color of the glow.")]
+		public readonly Color Color = Color.FromArgb(255, 255, 102, 0);
+
+		[Desc("Scale multiplier on the renderer's GlowRadius and GlowIntensity.")]
+		public readonly float Scale = 1f;
+
+		[Desc("Number of render frames to fade out over. 0 = single-frame flash.")]
+		public readonly int FadeFrames = 90;
+
+		[Desc("Number of render frames to fade in over. 0 = instant on.")]
+		public readonly int FadeInFrames = 0;
+
+		public override bool IsValidAgainst(Actor victim, Actor firedBy) => true;
+
+		public override void DoImpact(in Target target, WarheadArgs args)
+		{
+			if (!Game.Settings.Graphics.LaserGlow)
+				return;
+
+			args.SourceActor.World.WorldActor.TraitOrDefault<GlowRenderer>()
+				?.RegisterGlow(args.ImpactPosition, args.ImpactPosition, Color, Scale, FadeFrames, FadeInFrames);
+		}
+	}
+}

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="bb57413"
+ENGINE_VERSION="e73927d"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -265,6 +265,7 @@ bot-ai =
 support-power-timer = { $player }'s { $support-power }: { $time }
 
 ## settings-display.yaml
+checkbox-laser-glow = Weapon Glow Effects
 checkbox-cross-map-sprite-cache-container = Reuse sprite atlases between maps (faster map loads)
 
 ## settings-gameplay.yaml

--- a/mods/cameo/rules/palettes.yaml
+++ b/mods/cameo/rules/palettes.yaml
@@ -305,8 +305,8 @@
 	MenuPostProcessEffect:
 		MenuEffect: Desaturated
 	GlowRenderer:
-		GlowRadius: 30
-		GlowIntensity: 0.1
+		GlowRadius: 25
+		GlowIntensity: 0.2
 	CloakPaletteEffect:
 	FlashPostProcessEffect@Nuke:
 		Type: Nuke

--- a/mods/cameo/rules/tiberiansun.yaml
+++ b/mods/cameo/rules/tiberiansun.yaml
@@ -3610,12 +3610,12 @@ tsntobel:
 	Armament@PRIMARY:
 		Weapon: TSObeliskLaserFire
 		# LocalOffset: 0,180,1600
-		LocalOffset: 0,320,1480
+		LocalOffset: 0,320,1280
 		RequiresCondition: !up_tiberiumlenses
 	Armament@UPGRADE:
 		Weapon: TSLaserObeliskLaserFire
 		# LocalOffset: 0,180,1600
-		LocalOffset: 0,320,1480
+		LocalOffset: 0,320,1280
 		RequiresCondition: up_tiberiumlenses
 	AttackCharges:
 		RequiresCondition: !build-incomplete

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -470,6 +470,11 @@ BigFlamer:
 		Amount: 14000
 	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
 		Amount: 7000
+	Warhead@Glow: GlowImpact
+		Color: FF6600
+		Scale: 1.5
+		FadeFrames: 90
+		FadeInFrames: 12
 
 FlametankExplode:
 	Inherits: ^MediumFlameWeapon
@@ -1208,6 +1213,15 @@ LaserObelisk:
 	Inherits: ^LaserWeapon
 	ReloadDelay: 96
 	Range: 9600
+	Projectile: LaserZap
+		Width: 100
+		HitAnim: laserfire
+		ZOffset: 3000
+		Blockable: false
+		SecondaryBeam: true
+		SecondaryBeamWidth: 40
+		SecondaryBeamZOffset: 3000
+		SecondaryBeamColor: FFFFFF88
 	Warhead@LaserWeapon: SpreadDamage
 		Damage: 96000
 	Warhead@LaserWeaponPercentage: HealthPercentageDamage
@@ -1797,6 +1811,11 @@ BigFlamer2:
 		Amount: 20000
 	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
 		Amount: 10000
+	Warhead@Glow: GlowImpact
+		Color: FF6600
+		Scale: 2.0
+		FadeFrames: 90
+		FadeInFrames: 12
 
 FlametankExplode2:
 	Inherits: ^HeavyFlameWeapon


### PR DESCRIPTION
- Added a new setting for "Weapon Glow Effects" in the settings display.
- Adjusted glow parameters for the GlowRenderer in palettes.yaml.
- Nudge laser sprite for TS Nod Obelisk laser
- Introduced GlowImpactWarhead to create visual glow effects on impact for specific weapons.
- Added glow parameters to Nod flame weapons.