### PR TITLE
fix: Quota mode supports parallel production slots (Zerg hatchery)

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/QuotaProductionManager.cs
+++ b/OpenRA.Mods.Cameo/Traits/QuotaProductionManager.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.CA.Traits;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -223,10 +224,20 @@ namespace OpenRA.Mods.Cameo.Traits
 				.Where(q => q.Enabled)
 				.ToArray();
 
-			// Only queue one unit at a time per building; re-evaluate when the slot is free.
-			if (queues.Any(q => q.AllQueued().Any())) return;
-			if (autoQueueCredits.TryGetValue(building.ActorID, out var existingCredits) &&
-				existingCredits.Values.Any(c => c > 0)) return;
+			if (queues.Length == 0) return;
+
+			// Parallel-queue capacity (e.g. Zerg hatchery: MaxParallel larvae).
+			// Normal queues fall back to 1 — preserves "one at a time per building".
+			var buildingCapacity = queues.Max(q => q is IHasParallelQueueSlots p
+				? p.AvailableSlots + q.AllQueued().Count()
+				: 1);
+
+			var queuedCount = queues.Sum(q => q.AllQueued().Count());
+			var pendingCredits = autoQueueCredits.TryGetValue(building.ActorID, out var existingCredits)
+				? existingCredits.Values.Sum()
+				: 0;
+
+			if (queuedCount + pendingCredits >= buildingCapacity) return;
 
 			string bestType = null;
 			var bestRatio = float.MaxValue;


### PR DESCRIPTION
AutoQueueDeficit treated any building with a queued item as "busy", so Zerg hatcheries only used 1 of 3 larvae at a time. Now uses IHasParallelQueueSlots.AvailableSlots to fill all parallel slots.

Also guards against empty enabled-queue lists, which crashed when an Ixian captured a Protoss Nexus (faction-gated queue trait, .Max() on empty sequence).