### PR TITLE
feat: Classify tech-center-gated upgrades as Queue: Research across RA1/RA2/RA2mod

### DIFF
--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -1774,7 +1774,7 @@
 		Cost: 5000
 	Buildable:
 		BuildPaletteOrder: 0
-		Queue: Addons
+		Queue: Upgrades
 		Description: Doctrine Description
 		Prerequisites: ~disabled
 	RenderSprites:
@@ -1791,7 +1791,7 @@
 		Cost: 2500
 	Buildable:
 		BuildPaletteOrder: 1
-		Queue: Addons
+		Queue: Upgrades
 		Description: Unit Upgrade Description
 		Prerequisites: ~disabled
 	RenderSprites:

--- a/mods/cameo/rules/redalert.yaml
+++ b/mods/cameo/rules/redalert.yaml
@@ -8021,6 +8021,10 @@ DOME.Soviet:
 		Name: Soviet Radar Dome
 	Buildable:
 		Prerequisites: ~rafact.soviet, raproc.soviet
+	Production@Upgrades:
+		Produces: Upgrades
+	ProductionBar@Upgrades:
+		ProductionType: Upgrades
 
 DOME.Japan:
 	Inherits: ^BaseBuilding
@@ -11868,6 +11872,7 @@ ra_upgrade_heavyteslatank:
 	Tooltip:
 		Name: Heavy Tesla Tank Upgrade
 	Buildable:
+		Queue: Research
 		Description: Upgrades the Hammer Tank to the Heavy Tesla Tank
 		Prerequisites: ~stek, ~ra_doctrine_teslatech, ra_upgrade_hammertank, !ra_upgrade_heavyteslatank
 	RenderSprites:
@@ -11878,6 +11883,7 @@ ra_upgrade_shtoradefensesystem:
 	Tooltip:
 		Name: Shtora Defense System Upgrade
 	Buildable:
+		Queue: Research
 		Description: ra_upgrade_shtoradefensesystem.description
 		Prerequisites: ~stek, ~ra_doctrine_heavyarmor, ra_upgrade_hammertank, !ra_upgrade_shtoradefensesystem
 	RenderSprites:
@@ -11888,6 +11894,7 @@ ra_upgrade_kotintank:
 	Tooltip:
 		Name: Kotin Nuclear Tank Upgrade
 	Buildable:
+		Queue: Research
 		Description: Upgrades the Hammer Tank to the Kotin Nuclear Tank
 		Prerequisites: ~stek, ~ra_doctrine_nuclearwar, ra_upgrade_hammertank, !ra_upgrade_kotintank
 	RenderSprites:

--- a/mods/cameo/rules/redalert2.yaml
+++ b/mods/cameo/rules/redalert2.yaml
@@ -12815,8 +12815,9 @@ ra2_soviets_upgrade_heavyarmorplatings:
 	Tooltip:
 		Name: Heavy Armor Platings
 	Buildable:
+		Queue: Research
 		Description: All Soviet Vehicles and Aircraft have 25% more Damage Resistance but move 10% slower.
-		Prerequisites: ~ra2naradr, ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
+		Prerequisites: ~ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_upgrade_heavyarmorplatings
 	ProvidesPrerequisite@ra2_soviet_doctrine_2:
@@ -12840,8 +12841,9 @@ ra2_soviets_upgrade_reactivearmor:
 	Tooltip:
 		Name: Reactive Armor
 	Buildable:
+		Queue: Research
 		Description: Tanks gain gain 50% Damage Resistance to Area of Effect weapons and 10% Damage Resistance against everything else but move 5% slower.
-		Prerequisites: ~ra2naradr, ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
+		Prerequisites: ~ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_upgrade_reactivearmor
 	ProvidesPrerequisite@ra2_soviet_doctrine_2:
@@ -12879,8 +12881,9 @@ ra2_soviets_upgrade_tesladischargearmor:
 	Tooltip:
 		Name: Tesla Discharge Armor
 	Buildable:
+		Queue: Research
 		Description: Causes Armor to slowly charge up once enemies are nearby. When fully charged Tesla Arcs discharge upon taking damage. Gives 15% more Damage Resistance. While Tesla Armor is charging up Speed is reduced by 15% but increased by 15% if out of combat.
-		Prerequisites: ~ra2naradr, ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
+		Prerequisites: ~ra2natech, ra2_soviet_doctrine_1, !ra2_soviet_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_upgrade_tesladischargearmor
 	ProvidesPrerequisite@ra2_soviet_doctrine_2:
@@ -12931,8 +12934,9 @@ ra2_soviets_upgrade_fireshells:
 	Tooltip:
 		Name: Fire Munitions
 	Buildable:
+		Queue: Research
 		Description: Rhino, Apocalypse, V3, Kirov, and Siege Chopper weapons spread fire and deal 25% more damage.
-		Prerequisites: ~ra2naradr, ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
+		Prerequisites: ~ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_upgrade_fireshells
 	ProvidesPrerequisite@ra2_soviet_doctrine_3:
@@ -12950,8 +12954,9 @@ ra2_soviets_upgrade_radiationshells:
 	Tooltip:
 		Name: Nuclear Munitions
 	Buildable:
+		Queue: Research
 		Description: Rhino, Apocalypse, V3, Kirov, and Siege Chopper weapons leave radiation and deal 25% more damage.
-		Prerequisites: ~ra2naradr, ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
+		Prerequisites: ~ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_upgrade_radiationshells
 	ProvidesPrerequisite@ra2_soviet_doctrine_3:
@@ -12972,8 +12977,9 @@ ra2_soviets_upgrade_teslashells:
 	Tooltip:
 		Name: Tesla Munitions
 	Buildable:
+		Queue: Research
 		Description: Rhino, Apocalypse, V3, Kirov, and Siege Chopper weapons zap nearby targets on impact and deal 25% more damage.
-		Prerequisites: ~ra2naradr, ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
+		Prerequisites: ~ra2natech, yrngindp, ra2_soviet_doctrine_2, !ra2_soviet_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_upgrade_teslashells
 	ProvidesPrerequisite@ra2_soviet_doctrine_3:
@@ -13012,8 +13018,9 @@ ra2_soviets_upgrade_coilchargers:
 	Tooltip:
 		Name: Tesla Coil Chargers
 	Buildable:
+		Queue: Research
 		Description: Provide all Tesla Coils with chargers.
-		Prerequisites: ~ra2naradr, ra2natech, !ra2_soviets_upgrade_coilchargers
+		Prerequisites: ~ra2natech, !ra2_soviets_upgrade_coilchargers
 	RenderSprites:
 		Image: ra2tesla
 	ProvidesPrerequisite:
@@ -13467,8 +13474,9 @@ ra2_allies_upgrade_compositearmorplating:
 	Tooltip:
 		Name: Composite Armor Plating
 	Buildable:
+		Queue: Research
 		Description: All Allied Vehicles and Aircraft take 20% less damage.
-		Prerequisites: ~ra2gaairc, ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
+		Prerequisites: ~ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_compositearmorplating
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
@@ -13489,8 +13497,9 @@ ra2_allies_upgrade_reflectivearmorplating:
 	Tooltip:
 		Name: Reflective Armor Plating
 	Buildable:
+		Queue: Research
 		Description: Tanks gain gain 50% Damage Resistance to Energy weapons and take 5% less damage overall.
-		Prerequisites: ~ra2gaairc, ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
+		Prerequisites: ~ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_reflectivearmorplating
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
@@ -13519,8 +13528,9 @@ ra2_allies_upgrade_ionpulseplating:
 	Tooltip:
 		Name: Chromium Ion Pulse Plating
 	Buildable:
+		Queue: Research
 		Description: Causes Ion Discharges everytime a Vehicle takes damage with a 5 second cooldown. Gives 10% more Damage Resistance. Ion Discharges mark enemy units in a small radius for additional damage.
-		Prerequisites: ~ra2gaairc, ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
+		Prerequisites: ~ra2gatech, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_ionpulseplating
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
@@ -13591,8 +13601,9 @@ ra2_allies_upgrade_eliterocketeer:
 	Tooltip:
 		Name: Elite Rocketeers
 	Buildable:
+		Queue: Research
 		Description: Upgrades the Rocketeer with 15% more firepower, 15% faster reload, 15% damage resistance, 10% more range and 10% more speed.
-		Prerequisites: ~ra2gaairc, ra2gatech, !ra2_allies_upgrade_eliterocketeer
+		Prerequisites: ~ra2gatech, !ra2_allies_upgrade_eliterocketeer
 	RenderSprites:
 		Image: ra2_allies_upgrade_eliterocketeer
 
@@ -13601,8 +13612,9 @@ ra2_allies_upgrade_prismlinking:
 	Tooltip:
 		Name: Prism Linking
 	Buildable:
+		Queue: Research
 		Description: Allows Prism Towers to link, boosting damage.
-		Prerequisites: ~ra2gaairc, ra2gatech, !ra2_allies_upgrade_prismlinking
+		Prerequisites: ~ra2gatech, !ra2_allies_upgrade_prismlinking
 	RenderSprites:
 		Image: ra2_allies_upgrade_prismlinking
 
@@ -13611,9 +13623,10 @@ ra2_allies_upgrade_forceshield:
 	Tooltip:
 		Name: Force Shield
 	Buildable:
+		Queue: Research
 		Icon: forceshield
 		Description: Enables the Force Shield power from the Battle Lab.
-		Prerequisites: ~ra2gaairc, ra2gatech, !ra2_allies_upgrade_forceshield
+		Prerequisites: ~ra2gatech, !ra2_allies_upgrade_forceshield
 	RenderSprites:
 		Image: icon
 
@@ -13622,8 +13635,9 @@ ra2_allies_upgrade_heavymiragetank:
 	Tooltip:
 		Name: Unlock Heavy Mirage Tanks
 	Buildable:
+		Queue: Research
 		Description: Allows construction of Heavy Mirage Tanks.
-		Prerequisites: ~ra2gaairc, ra2gatech, !ra2_allies_upgrade_heavymiragetank
+		Prerequisites: ~ra2gatech, !ra2_allies_upgrade_heavymiragetank
 	RenderSprites:
 		Image: ra2hmgtk
 
@@ -14092,8 +14106,9 @@ ra2_yuri_upgrade_lashercannon:
 	Tooltip:
 		Name: Lasher HE Cannon
 	Buildable:
+		Queue: Research
 		Description: Increases Lasher Cannon Firepower by 100%.
-		Prerequisites: ~ra2napsis, yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
+		Prerequisites: ~yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: ra2_yuri_upgrade_lashercannon
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
@@ -14104,8 +14119,9 @@ ra2_yuri_upgrade_lashertoxic:
 	Tooltip:
 		Name: Lasher Toxic Gas Shells
 	Buildable:
+		Queue: Research
 		Description: Replaces the Lasher Cannon with a Toxic Gas Mortar.
-		Prerequisites: ~ra2napsis, yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
+		Prerequisites: ~yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: ra2_yuri_upgrade_lashertoxic
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
@@ -14116,8 +14132,9 @@ ra2_yuri_upgrade_lasherlaser:
 	Tooltip:
 		Name: Lasher Laser Cannon
 	Buildable:
+		Queue: Research
 		Description: Replaces the Lasher Cannon with a powerful Laser Cannon.
-		Prerequisites: ~ra2napsis, yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
+		Prerequisites: ~yrygtech, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: ra2_yuri_upgrade_lasherlaser
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
@@ -14128,8 +14145,9 @@ ra2_yuri_upgrade_scraparmor:
 	Tooltip:
 		Name: Scrap Vehicle Armor
 	Buildable:
+		Queue: Research
 		Description: Yuri Vehicles gain 15% more Damage Resistance and Speed.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
+		Prerequisites: ~yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: ra2_yuri_upgrade_scraparmor
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
@@ -14153,8 +14171,9 @@ ra2_yuri_upgrade_chaosgasemitters:
 	Tooltip:
 		Name: Chaos Gas Emitters
 	Buildable:
+		Queue: Research
 		Description: Yuri Vehicles periodically emit Chaos Gas in a small radius after taking damage. Increases Damage Resistance and Speed by 5% and doubles if enemies are nearby.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
+		Prerequisites: ~yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: ra2_yuri_upgrade_chaosgasemitters
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
@@ -14208,8 +14227,9 @@ ra2_yuri_upgrade_psionicshields:
 	Tooltip:
 		Name: Psionic Vehicle Shields
 	Buildable:
+		Queue: Research
 		Description: Yuri vehicles charge with psionic shields when enemies are nearby. Psionic shields are also provided to allied units in a small radius. After taking damage the shield quickly charges up.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
+		Prerequisites: ~yrygtech, yrygcomd, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: ra2_yuri_upgrade_psionicshields
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
@@ -14340,8 +14360,9 @@ ra2_yuri_upgrade_gatlingpower:
 	Tooltip:
 		Name: Gatling Firepower Upgrade
 	Buildable:
+		Queue: Research
 		Description: All Gatling weapons have 20% more Firepower and 10% more Range.
-		Prerequisites: ~ra2napsis, yrygtech, !ra2_yuri_upgrade_gatlingpower
+		Prerequisites: ~yrygtech, !ra2_yuri_upgrade_gatlingpower
 	RenderSprites:
 		Image: ra2_yuri_upgrade_gatlingpower
 
@@ -14381,8 +14402,9 @@ ra2_yuri_upgrade_meltingvirus:
 	Tooltip:
 		Name: Melting Virus
 	Buildable:
+		Queue: Research
 		Description: Allows Viruses to attack vehicles and structures. Increases Firepower by 50%.
-		Prerequisites: ~ra2napsis, yrygtech, !ra2_yuri_upgrade_meltingvirus
+		Prerequisites: ~yrygtech, !ra2_yuri_upgrade_meltingvirus
 	RenderSprites:
 		Image: ra2_yuri_upgrade_meltingvirus
 	ProvidesPrerequisite:
@@ -14418,8 +14440,9 @@ ra2_yuri_upgrade_gatlingspeed:
 	Tooltip:
 		Name: Gatling Speed Upgrade
 	Buildable:
+		Queue: Research
 		Description: All Gatling weapons have 30% more Rate of Fire.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2_yuri_upgrade_gatlingpower, !ra2_yuri_upgrade_gatlingspeed
+		Prerequisites: ~yrygtech, yrygcomd, ra2_yuri_upgrade_gatlingpower, !ra2_yuri_upgrade_gatlingspeed
 	RenderSprites:
 		Image: ra2_yuri_upgrade_gatlingspeed
 	ProvidesPrerequisite:
@@ -14437,8 +14460,9 @@ ra2_yuri_upgrade_corrosiveammo:
 	Tooltip:
 		Name: Corrosive Ammo
 	Buildable:
+		Queue: Research
 		Description: Adds a powerful corrosive effect to the Virus Sniper that slows down enemy vehicles and deals damage over time. Increases Firepower by 33%.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2_yuri_upgrade_meltingvirus, !ra2_yuri_upgrade_corrosiveammo
+		Prerequisites: ~yrygtech, yrygcomd, ra2_yuri_upgrade_meltingvirus, !ra2_yuri_upgrade_corrosiveammo
 	RenderSprites:
 		Image: ra2_yuri_upgrade_corrosiveammo
 	ProvidesPrerequisite:
@@ -14448,8 +14472,9 @@ ra2_yuri_upgrade_supermagnets:
 	Tooltip:
 		Name: Super Magnets
 	Buildable:
+		Queue: Research
 		Description: Allows Magnetrons to attack air and gain 25% more Range.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, !ra2_yuri_upgrade_supermagnets
+		Prerequisites: ~yrygtech, yrygcomd, !ra2_yuri_upgrade_supermagnets
 	RenderSprites:
 		Image: ra2_yuri_upgrade_supermagnets
 	ProvidesPrerequisite:
@@ -14459,8 +14484,9 @@ ra2_yuri_upgrade_bioreactorefficiency:
 	Tooltip:
 		Name: Bio Reactor Efficiency
 	Buildable:
+		Queue: Research
 		Description: Doubles the power output of Bio Reactors.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2yclon, !ra2_yuri_upgrade_bioreactorefficiency
+		Prerequisites: ~yrygtech, yrygcomd, ra2yclon, !ra2_yuri_upgrade_bioreactorefficiency
 	RenderSprites:
 		Image: ra2_yuri_upgrade_bioreactorefficiency
 	ProvidesPrerequisite:
@@ -14470,8 +14496,9 @@ ra2_yuri_upgrade_bioengineering:
 	Tooltip:
 		Name: Bio Engineering
 	Buildable:
+		Queue: Research
 		Description: All Infantry Cost and Build Time is reduced by 40%.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, ra2yclon, !ra2_yuri_upgrade_bioengineering
+		Prerequisites: ~yrygtech, yrygcomd, ra2yclon, !ra2_yuri_upgrade_bioengineering
 	RenderSprites:
 		Image: ra2_yuri_upgrade_bioengineering
 	ProvidesPrerequisite:
@@ -14481,8 +14508,9 @@ ra2_yuri_upgrade_psychicrange:
 	Tooltip:
 		Name: Psychic Range
 	Buildable:
+		Queue: Research
 		Description: Increases Mind Control Range of all Psychic Units by 15%. Pyshic Towers gain 30% more Range.
-		Prerequisites: ~ra2napsis, yrygtech, yrygcomd, !ra2_yuri_upgrade_psychicrange
+		Prerequisites: ~yrygtech, yrygcomd, !ra2_yuri_upgrade_psychicrange
 	RenderSprites:
 		Image: ra2_yuri_upgrade_psychicrange
 

--- a/mods/cameo/rules/redalert2mod.yaml
+++ b/mods/cameo/rules/redalert2mod.yaml
@@ -424,6 +424,10 @@ aa_cgradr:
 	SupportPowerChargeBar:
 	Voiced:
 		VoiceSet: CHSpeakerTowerVoice
+	Production@Upgrades:
+		Produces: Upgrades
+	ProductionBar@Upgrades:
+		ProductionType: Upgrades
 
 aa_cgtech:
 	Inherits: ^RA2Building
@@ -4708,6 +4712,10 @@ latin_radar:
 		TargetCircleColor: ff000080
 		LaunchSound:
 		IncomingSound:
+	Production@Upgrades:
+		Produces: Upgrades
+	ProductionBar@Upgrades:
+		ProductionType: Upgrades
 
 latin_cgair:
 	Inherits: ^RA2Building
@@ -19358,6 +19366,10 @@ futu_egtf:
 		RequiresCondition: !build-incomplete
 	RenderSprites:
 		PlayerPalette: playerra2future2
+	Production@Upgrades:
+		Produces: Upgrades
+	ProductionBar@Upgrades:
+		ProductionType: Upgrades
 
 futu_launchpad:
 	Inherits: ^RA2Building
@@ -21825,6 +21837,7 @@ future_upgrade_equalizer_x2:
 	Tooltip:
 		Name: Equalizer X2
 	Buildable:
+		Queue: Research
 		Description: Increases All Weapon Firepower and Rate of Fire by 10% and Range by 5%.
 		Prerequisites: ~futu_egtf, futu_egtech, future_upgrade_equalizer_x1, !future_upgrade_equalizer_x2
 	RenderSprites:
@@ -21836,6 +21849,7 @@ future_upgrade_equalizer_x3:
 	Tooltip:
 		Name: Equalizer X3
 	Buildable:
+		Queue: Research
 		Description: Increases All Weapon Firepower and Rate of Fire by 10% and Range by 5%.
 		Prerequisites: ~futu_egtf, futu_egtech, futu_egshock, future_upgrade_equalizer_x2, !future_upgrade_equalizer_x3
 	RenderSprites:


### PR DESCRIPTION
Template defaults (^doctrine_template, ^unit_upgrade_template) now use Queue: Upgrades. Items requiring a tech center explicitly override to Queue: Research and anchor on the tech center building instead of the radar building.