### PR TITLE
Make d2k carryalls and Starport frigate selectable (again) but at lower priority

### DIFF
--- a/mods/cameo/rules/d2k.yaml
+++ b/mods/cameo/rules/d2k.yaml
@@ -10055,6 +10055,7 @@ combat_tank_ixian:
 carryall.reinforce:
 	Inherits: ^AirstrikePlane
 	Inherits@D2KSprite: ^D2KPaletteRender
+	Inherits@selection: ^SelectableEconomicUnit
 	Tooltip:
 		Name: Autonomous Carryall
 	Valued:
@@ -10063,8 +10064,6 @@ carryall.reinforce:
 		HP: 500000
 	Armor:
 		Type: Bomber
-	-Selectable:
-	Interactable:
 	Aircraft:
 		CruiseAltitude: 2160
 		CruisingCondition: cruising
@@ -10205,6 +10204,7 @@ ordos_carryall:
 frigate:
 	Inherits@D2KSprite: ^D2KPaletteRender
 	Inherits: ^AirstrikePlane
+	Inherits@selection: ^SelectableEconomicUnit
 	ParaDrop:
 		DropRange: 1c0
 	Tooltip:


### PR DESCRIPTION
Carryall variants and the Starport frigate now inherit ^SelectableEconomicUnit (Priority 6), matching harvesters: they can be selected to view health/stats but are excluded from army box-selects. Reverts the carryalls' -Selectable/Interactable override so they are selectable again. RejectsOrders is retained on both, so they remain uncommandable by design.