### PR TITLE
feat: Port mass transport boarding from Combined Arms

### DIFF
--- a/OpenRA.Mods.CA/Traits/MassEnterableCargo.cs
+++ b/OpenRA.Mods.CA/Traits/MassEnterableCargo.cs
@@ -1,0 +1,29 @@
+
+
+#region Copyright & License Information
+/**
+ * Copyright (c) The OpenRA Combined Arms Developers (see CREDITS).
+ * This file is part of OpenRA Combined Arms, which is free software.
+ * It is made available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version. For more information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.CA.Traits
+{
+	[Desc("Actor can be entered en masse.")]
+	public class MassEnterableCargoInfo : ConditionalTraitInfo, Requires<CargoInfo>
+	{
+		public override object Create(ActorInitializer init) { return new MassEnterableCargo(this); }
+	}
+
+	public class MassEnterableCargo : ConditionalTrait<MassEnterableCargoInfo>
+	{
+		public MassEnterableCargo(MassEnterableCargoInfo info)
+			: base(info) { }
+	}
+}

--- a/OpenRA.Mods.CA/Traits/MassEntersCargo.cs
+++ b/OpenRA.Mods.CA/Traits/MassEntersCargo.cs
@@ -1,0 +1,197 @@
+
+
+#region Copyright & License Information
+/**
+ * Copyright (c) The OpenRA Combined Arms Developers (see CREDITS).
+ * This file is part of OpenRA Combined Arms, which is free software.
+ * It is made available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version. For more information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.CA.Traits
+{
+	[Desc("Actor can be entered en masse. Requires Passenger on the actor to take effect.")]
+	public class MassEntersCargoInfo : ConditionalTraitInfo
+	{
+		[CursorReference]
+		[Desc("Cursor to display when able to enter target actor.")]
+		public readonly string EnterCursor = "enter-multi";
+
+		[CursorReference]
+		[Desc("Cursor to display when unable to enter target actor.")]
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
+		public override object Create(ActorInitializer init) { return new MassEntersCargo(init, this); }
+	}
+
+	public class MassEntersCargo : ConditionalTrait<MassEntersCargoInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice
+	{
+		private readonly MassEntersCargoInfo info;
+		private Passenger passenger;
+
+		public int Weight => passenger?.Info.Weight ?? 1;
+
+		public MassEntersCargo(ActorInitializer init, MassEntersCargoInfo info)
+			: base(info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			passenger = self.TraitOrDefault<Passenger>();
+		}
+
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		{
+			get
+			{
+				if (passenger == null)
+					yield break;
+
+				yield return new EnterAlliedActorTargeter<CargoInfo>(
+					"MassEnterTransport",
+					10,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
+					IsCorrectCargoType,
+					CanEnter);
+			}
+		}
+
+		public Order IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
+		{
+			if (order.OrderID == "MassEnterTransport")
+			{
+				return new Order(order.OrderID, self, target, queued);
+			}
+
+			return null;
+		}
+
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
+		{
+			if (passenger == null || order.OrderString != "MassEnterTransport")
+				return null;
+
+			if (order.Target.Type != TargetType.Actor || !CanEnter(order.Target.Actor))
+				return null;
+
+			return passenger.Info.Voice;
+		}
+
+		bool IsCorrectCargoType(Actor target, TargetModifiers modifiers)
+		{
+			if (!modifiers.HasModifier(TargetModifiers.ForceMove))
+				return false;
+
+			if (!target.Info.HasTraitInfo<MassEnterableCargoInfo>())
+				return false;
+
+			return IsCorrectCargoType(target);
+		}
+
+		bool IsCorrectCargoType(Actor target)
+		{
+			var ci = target.Info.TraitInfo<CargoInfo>();
+			return ci.Types.Contains(passenger.Info.CargoType);
+		}
+
+		bool CanEnter(Cargo cargo)
+		{
+			return cargo != null && cargo.HasSpace(passenger.Info.Weight);
+		}
+
+		bool CanEnter(Actor target)
+		{
+			return CanEnter(target.TraitOrDefault<Cargo>());
+		}
+
+		public bool IsValidForTarget(Actor target)
+		{
+			return IsCorrectCargoType(target) && CanEnter(target);
+		}
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (passenger == null || order.OrderString != "MassEnterTransport")
+				return;
+
+			// Enter orders are only valid for own/allied actors,
+			// which are guaranteed to never be frozen.
+			if (order.Target.Type != TargetType.Actor)
+				return;
+
+			var targetActor = order.Target.Actor;
+
+			var selectedWithTrait = self.World.Selection.Actors
+				.Where(a => a.Info.HasTraitInfo<MassEntersCargoInfo>()
+					&& a.Owner == self.Owner
+					&& !a.IsDead
+					&& a.Trait<MassEntersCargo>().IsValidForTarget(targetActor))
+				.OrderBy(a => (a.CenterPosition - targetActor.CenterPosition).LengthSquared)
+				.Select(a => new TraitPair<MassEntersCargo>(a, a.Trait<MassEntersCargo>()));
+
+			// Find the closest actor to the target transport
+			var closestActor = selectedWithTrait.FirstOrDefault();
+
+			// Only perform allocation if the current actor is the closest actor
+			if (closestActor.Actor != self)
+				return;
+
+			// Create a list of available transports
+			var availableTransports = self.World.Actors
+				.Where(a => a.Info.HasTraitInfo<MassEnterableCargoInfo>()
+					&& a.Info.HasTraitInfo<CargoInfo>()
+					&& a.Info.Name == targetActor.Info.Name
+					&& a.Owner == targetActor.Owner
+					&& !a.IsDead
+					&& (a.CenterPosition - targetActor.CenterPosition).HorizontalLengthSquared <= WDist.FromCells(10).LengthSquared)
+				.Select(a => new TransportInfo {
+					Actor = a,
+					Cargo = a.Trait<Cargo>(),
+					UnallocatedSpace = a.Trait<Cargo>().Info.MaxWeight - a.Trait<Cargo>().Passengers.Sum(p => p.Trait<Passenger>().Info.Weight)
+				})
+				.Where(t => t.Cargo != null && t.Cargo.HasSpace(1))
+				.ToList();
+
+			// Allocate passengers to the closest available transport
+			foreach (var pair in selectedWithTrait)
+			{
+				if (availableTransports.Count == 0)
+					break;
+
+				var closestTransport = availableTransports
+					.Where(t => t.UnallocatedSpace >= pair.Trait.Weight)
+					.OrderBy(t => (t.Actor.CenterPosition - pair.Actor.CenterPosition).LengthSquared)
+					.FirstOrDefault();
+
+				if (closestTransport == null)
+					continue;
+
+				self.World.IssueOrder(new Order("EnterTransport", pair.Actor, Target.FromActor(closestTransport.Actor), order.Queued));
+				pair.Actor.ShowTargetLines();
+
+				if (!closestTransport.Cargo.HasSpace(1))
+					availableTransports.Remove(closestTransport);
+				else
+					closestTransport.UnallocatedSpace -= pair.Trait.Weight;
+			}
+		}
+	}
+
+	class TransportInfo
+	{
+		public Actor Actor { get; set; }
+		public Cargo Cargo { get; set; }
+		public int UnallocatedSpace { get; set; }
+	}
+}

--- a/mods/cameo/cursors.yaml
+++ b/mods/cameo/cursors.yaml
@@ -91,6 +91,9 @@ Cursors:
 		enter:
 			Start: 119
 			Length: 3
+		enter-multi:
+			Start: 119
+			Length: 3
 		enter-minimap:
 			Start: 148
 			Length: 3

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2728,6 +2728,7 @@
 			scbehemoth: battlefortresspassenger
 			tsm113: battlefortresspassenger
 			tkmbattlebus: battlefortresspassenger
+	MassEntersCargo:
 	SharedPassenger:
 		CargoType: Infantry
 	Garrisoner:
@@ -8272,6 +8273,7 @@ CPQDEBUGDUMMY:
 	PromotionUpgrade:
 
 ^Cargo:
+	MassEnterableCargo:
 	Targetable@garrisoned:
 		TargetTypes: LoadedVehicle
 		RequiresCondition: loaded


### PR DESCRIPTION
Alt+click a transport with infantry selected to auto-distribute units across nearby transports of the same type.

Original feature by darkademic (OpenRA Combined Arms, commit 46fd04052).