### PR TITLE
Improve promotions tree window UX

### DIFF
--- a/OpenRA.Mods.Cameo/Widgets/CommanderTreeWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/CommanderTreeWidget.cs
@@ -82,6 +82,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 		CommanderNode hoverNode;
 		CommanderNode lastTooltipNode;
+		readonly HashSet<CommanderNode> hoverAncestors = new();
 		int currentTooltipToken;
 		bool commanderTooltipDirty;
 		ProductionTooltipCameoLogic commanderTooltipLogic;
@@ -116,10 +117,13 @@ namespace OpenRA.Mods.Cameo.Widgets
 		public int GroupPadding = 12;
 		public float GroupBorderWidth = 2f;
 		public Color GroupBorderColor = Color.FromArgb(192, 180, 180, 180);
+		public Color AncestorHighlightColor = Color.FromArgb(200, 255, 140, 30);
 
 		public Func<ProductionIcon> GetTooltipIcon;
 		public bool HasHorizontalOverflow => GetMaxHorizontalScroll() > 0;
 		public float HorizontalScrollFraction => HasHorizontalOverflow ? horizontalScroll / Math.Max(1, (float)GetMaxHorizontalScroll()) : 0f;
+		public int ContentWidth => contentWidth;
+		public int ContentHeight => contentHeight;
 
 		[ObjectCreator.UseCtor]
 		public CommanderTreeWidget(World world, WorldRenderer worldRenderer)
@@ -155,6 +159,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 			HoverBorderColor = other.HoverBorderColor;
 			BackgroundColor = other.BackgroundColor;
 			EdgeColor = other.EdgeColor;
+			AncestorHighlightColor = other.AncestorHighlightColor;
 
 			GetTooltipIcon = () => tooltipIcon;
 			tooltipContainer = Exts.Lazy(() => Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
@@ -223,6 +228,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 			tooltipIcon = null;
 
 			hoverNode = null;
+			hoverAncestors.Clear();
 			lastTooltipNode = null;
 		}
 
@@ -235,7 +241,15 @@ namespace OpenRA.Mods.Cameo.Widgets
 				UpdateHover(mi.Location);
 
 			if (mi.Event == MouseInputEvent.Scroll)
+			{
+				if (HasHorizontalOverflow && (mi.Modifiers & Modifiers.Shift) != 0)
+				{
+					SetHorizontalScroll(horizontalScroll - (int)(mi.Delta.Y * Game.Settings.Game.UIScrollSpeed));
+					return true;
+				}
+
 				return false;
+			}
 
 			if (mi.Button != MouseButton.Left && mi.Button != MouseButton.Right && mi.Button != MouseButton.Middle)
 				return false;
@@ -823,6 +837,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 				scrollPanel.ContentHeight = contentHeight;
 
 			layoutDirty = false;
+			RebuildHoverAncestors();
 			UpdateHorizontalScrollLayout();
 		}
 
@@ -891,10 +906,35 @@ namespace OpenRA.Mods.Cameo.Widgets
 			});
 		}
 
+		void RebuildHoverAncestors()
+		{
+			hoverAncestors.Clear();
+			if (hoverNode == null)
+				return;
+
+			var queue = new Queue<CommanderNode>();
+			queue.Enqueue(hoverNode);
+			while (queue.Count > 0)
+			{
+				var current = queue.Dequeue();
+				foreach (var edge in edges)
+				{
+					if (edge.To == current && hoverAncestors.Add(edge.From))
+						queue.Enqueue(edge.From);
+				}
+			}
+		}
+
 		void UpdateHover(int2 mouseLocation)
 		{
 			var local = mouseLocation - RenderOrigin;
-			hoverNode = nodes.Values.FirstOrDefault(n => n.Bounds.Contains(local));
+			var newHover = nodes.Values.FirstOrDefault(n => n.Bounds.Contains(local));
+			if (newHover != hoverNode)
+			{
+				hoverNode = newHover;
+				RebuildHoverAncestors();
+			}
+
 			tooltipIcon = hoverNode?.Icon;
 
 			if (TooltipContainer != null && hoverNode != lastTooltipNode)
@@ -1167,7 +1207,15 @@ namespace OpenRA.Mods.Cameo.Widgets
 				if (!renderedKeys.Add(dedupKey))
 					continue;
 
-				var edgeColor = (!from.Revealed || !to.Revealed) ? Color.FromArgb(EdgeColor.A / 2, EdgeColor.R, EdgeColor.G, EdgeColor.B) : EdgeColor;
+				var isAncestorEdge = hoverNode != null && hoverAncestors.Contains(from) &&
+					(to == hoverNode || hoverAncestors.Contains(to));
+				Color edgeColor;
+				if (isAncestorEdge)
+					edgeColor = AncestorHighlightColor;
+				else if (!from.Revealed || !to.Revealed)
+					edgeColor = Color.FromArgb(EdgeColor.A / 2, EdgeColor.R, EdgeColor.G, EdgeColor.B);
+				else
+					edgeColor = EdgeColor;
 				var start = RenderOrigin.ToFloat2() + GetEdgeStartAnchor(from, useGroupStart);
 				var end = RenderOrigin.ToFloat2() + GetEdgeEndAnchor(to, useGroupEnd);
 				var dir = end - start;
@@ -1321,7 +1369,16 @@ namespace OpenRA.Mods.Cameo.Widgets
 		void DrawNodeBorder(CommanderNode node, float2 topLeft)
 		{
 			var isHover = node == hoverNode;
-			var borderColor = node.Owned ? OwnedBorderColor : isHover ? HoverBorderColor : Color.FromArgb(0, 0, 0, 0);
+			var isAncestor = hoverNode != null && !isHover && hoverAncestors.Contains(node);
+			Color borderColor;
+			if (node.Owned)
+				borderColor = OwnedBorderColor;
+			else if (isHover)
+				borderColor = HoverBorderColor;
+			else if (isAncestor)
+				borderColor = AncestorHighlightColor;
+			else
+				borderColor = Color.FromArgb(0, 0, 0, 0);
 			if (borderColor.A == 0)
 				return;
 

--- a/OpenRA.Mods.Cameo/Widgets/DragHandleWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/DragHandleWidget.cs
@@ -1,0 +1,52 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Cameo.Widgets
+{
+	public class DragHandleWidget : ColorBlockWidget
+	{
+		public Action<MouseInput> OnMouseMove = _ => { };
+
+		[ObjectCreator.UseCtor]
+		public DragHandleWidget(ModData modData)
+			: base(modData) { }
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				TakeMouseFocus(mi);
+				OnMouseDown(mi);
+				return true;
+			}
+
+			if (mi.Event == MouseInputEvent.Move)
+			{
+				if (HasMouseFocus)
+					OnMouseMove(mi);
+				return HasMouseFocus;
+			}
+
+			if (mi.Event == MouseInputEvent.Up)
+			{
+				OnMouseUp(mi);
+				YieldMouseFocus(mi);
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Widgets/Logic/CommanderTreeWindowLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/CommanderTreeWindowLogic.cs
@@ -21,7 +21,15 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 {
 	public class CommanderTreeWindowLogic : ChromeLogic
 	{
+		const int HeaderHeight = 148;
+		const int FooterHeight = 24;
+		const int SidePadding = 16;
+		const int MinWindowWidth = 260;
+		const int MinWindowHeight = 350;
+
 		readonly World world;
+		readonly Widget overlay;
+		readonly Widget windowWidget;
 		readonly LabelWidget pointsValue;
 		readonly LabelWidget rankValue;
 		readonly LabelWidget progressValue;
@@ -29,12 +37,30 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 		readonly ColorBlockWidget dismissArea;
 		readonly LogicKeyListenerWidget hotkeys;
 		readonly CommanderTreeWidget commanderTree;
-		readonly SliderWidget horizontalScroll;
+		readonly Widget hscrollContainer;
+		readonly DragHandleWidget hscrollThumb;
+		readonly DragHandleWidget dragHandle;
+		readonly ScrollPanelWidget treeScrollPanel;
+		readonly Widget windowBgWidget;
+		readonly Widget headerStatsWidget;
+		readonly Widget treeTooltipWidget;
+
+		bool isDragging;
+		int2 dragStartMouse;
+		int2 dragStartWindowPos;
+		bool hasBeenDragged;
+		int lastContentWidth;
+		int lastContentHeight;
+
+		bool isDraggingHScroll;
+		int hscrollDragStartX;
+		float hscrollDragStartFraction;
 
 		[ObjectCreator.UseCtor]
 		public CommanderTreeWindowLogic(Widget widget, World world)
 		{
 			this.world = world;
+			overlay = widget;
 
 			var titleLabel = widget.GetOrNull<LabelWidget>("TITLE");
 			var pointsLabel = widget.GetOrNull<LabelWidget>("POINTS_LABEL");
@@ -48,7 +74,14 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			dismissArea = widget.GetOrNull<ColorBlockWidget>("DISMISS_AREA");
 			hotkeys = widget.GetOrNull<LogicKeyListenerWidget>("HOTKEYS");
 			commanderTree = widget.GetOrNull<CommanderTreeWidget>("COMMANDER_TREE");
-			horizontalScroll = widget.GetOrNull<SliderWidget>("TREE_HSCROLL");
+			hscrollContainer = widget.GetOrNull<Widget>("TREE_HSCROLL");
+			hscrollThumb = widget.GetOrNull<DragHandleWidget>("HSCROLL_THUMB");
+			dragHandle = widget.GetOrNull<DragHandleWidget>("DRAG_HANDLE");
+			treeScrollPanel = widget.GetOrNull<ScrollPanelWidget>("TREE_SCROLL");
+			windowWidget = widget.GetOrNull<Widget>("COMMANDER_TREE_WINDOW");
+			windowBgWidget = widget.GetOrNull<Widget>("WINDOW_BG");
+			headerStatsWidget = widget.GetOrNull<Widget>("HEADER_STATS");
+			treeTooltipWidget = widget.GetOrNull<Widget>("COMMANDER_TREE_TOOLTIP");
 
 			if (titleLabel != null)
 				titleLabel.GetText = () => GetLocalizedString("commander-tree.title", "Promotions");
@@ -70,11 +103,7 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 
 			if (dismissArea != null)
 			{
-				dismissArea.OnMouseDown = mi =>
-				{
-					if (mi.Button != MouseButton.None)
-						Close();
-				};
+				dismissArea.OnMouseDown = _ => { };
 				dismissArea.OnMouseUp = _ => { };
 			}
 
@@ -96,16 +125,59 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			if (progressValue != null)
 				progressValue.GetText = GetCommanderProgress;
 
-			if (horizontalScroll != null)
+			if (hscrollThumb != null && hscrollContainer != null)
 			{
-				horizontalScroll.Visible = false;
-				horizontalScroll.Disabled = true;
-				horizontalScroll.GetValue = () => commanderTree?.HorizontalScrollFraction ?? 0f;
-				horizontalScroll.OnChange += value =>
+				hscrollThumb.OnMouseDown = mi =>
 				{
-					commanderTree?.SetHorizontalScrollFraction(value);
+					isDraggingHScroll = true;
+					hscrollDragStartX = mi.Location.X;
+					hscrollDragStartFraction = commanderTree?.HorizontalScrollFraction ?? 0f;
 				};
+
+				hscrollThumb.OnMouseMove = mi =>
+				{
+					if (!isDraggingHScroll || commanderTree == null)
+						return;
+					var thumbW = GetHScrollThumbWidth();
+					var trackAvail = hscrollContainer.Bounds.Width - thumbW;
+					if (trackAvail <= 0)
+						return;
+					var delta = mi.Location.X - hscrollDragStartX;
+					commanderTree.SetHorizontalScrollFraction(Math.Clamp(hscrollDragStartFraction + delta / (float)trackAvail, 0f, 1f));
+				};
+
+				hscrollThumb.OnMouseUp = _ => isDraggingHScroll = false;
 			}
+
+			if (dragHandle != null && windowWidget != null)
+			{
+				dragHandle.OnMouseDown = mi =>
+				{
+					isDragging = true;
+					dragStartMouse = mi.Location;
+					dragStartWindowPos = new int2(windowWidget.Bounds.X, windowWidget.Bounds.Y);
+				};
+
+				dragHandle.OnMouseMove = mi =>
+				{
+					if (!isDragging)
+						return;
+
+					hasBeenDragged = true;
+					var delta = mi.Location - dragStartMouse;
+					var screenW = overlay.Bounds.Width;
+					var screenH = overlay.Bounds.Height;
+					var newX = Math.Clamp(dragStartWindowPos.X + delta.X, 0, Math.Max(0, screenW - windowWidget.Bounds.Width));
+					var newY = Math.Clamp(dragStartWindowPos.Y + delta.Y, 0, Math.Max(0, screenH - windowWidget.Bounds.Height));
+					var b = windowWidget.Bounds;
+					b.X = newX;
+					b.Y = newY;
+					windowWidget.Bounds = b;
+				};
+
+				dragHandle.OnMouseUp = _ => isDragging = false;
+			}
+
 		}
 
 		ISync GetPromotionsTrait()
@@ -192,15 +264,146 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 		{
 			base.Tick();
 
-			if (commanderTree == null || horizontalScroll == null)
+			if (commanderTree != null && windowWidget != null)
+			{
+				var cw = commanderTree.ContentWidth;
+				var ch = commanderTree.ContentHeight;
+				if (cw > 0 && ch > 0 && (cw != lastContentWidth || ch != lastContentHeight))
+				{
+					lastContentWidth = cw;
+					lastContentHeight = ch;
+					AutoSizeWindow(cw, ch);
+				}
+			}
+
+			if (commanderTree == null || hscrollContainer == null)
 				return;
 
 			var needsScroll = commanderTree.HasHorizontalOverflow;
-			horizontalScroll.Visible = needsScroll;
-			horizontalScroll.Disabled = !needsScroll;
+			hscrollContainer.Visible = needsScroll;
 
 			if (!needsScroll && commanderTree.HorizontalScrollFraction > 0f)
 				commanderTree.SetHorizontalScrollFraction(0f);
+			else if (needsScroll)
+				UpdateHScrollThumb();
+		}
+
+		void AutoSizeWindow(int treeContentWidth, int treeContentHeight)
+		{
+			if (windowWidget == null)
+				return;
+
+			var screenW = overlay.Bounds.Width;
+			var screenH = overlay.Bounds.Height;
+			var maxW = screenW * 9 / 10;
+			var maxH = screenH * 9 / 10;
+
+			var targetW = Math.Clamp(treeContentWidth + SidePadding, MinWindowWidth, maxW);
+			var targetH = Math.Clamp(treeContentHeight + HeaderHeight + FooterHeight, MinWindowHeight, maxH);
+
+			var current = windowWidget.Bounds;
+			if (current.Width == targetW && current.Height == targetH)
+				return;
+
+			int newX, newY;
+			if (hasBeenDragged)
+			{
+				newX = Math.Clamp(current.X, 0, Math.Max(0, screenW - targetW));
+				newY = Math.Clamp(current.Y, 0, Math.Max(0, screenH - targetH));
+			}
+			else
+			{
+				newX = Math.Clamp(screenW * 82 / 100 - targetW, 0, Math.Max(0, screenW - targetW));
+				newY = Math.Clamp(screenH / 5, 0, Math.Max(0, screenH - targetH));
+			}
+
+			var b = windowWidget.Bounds;
+			b.X = newX;
+			b.Y = newY;
+			b.Width = targetW;
+			b.Height = targetH;
+			windowWidget.Bounds = b;
+
+			ResizeChildren(targetW, targetH);
+		}
+
+		void ResizeChildren(int w, int h)
+		{
+			SetSize(windowBgWidget, w, h);
+
+			if (dragHandle != null)
+			{
+				var db = dragHandle.Bounds;
+				db.Width = w;
+				dragHandle.Bounds = db;
+			}
+
+			if (headerStatsWidget != null)
+			{
+				var hb = headerStatsWidget.Bounds;
+				hb.Width = w - SidePadding;
+				headerStatsWidget.Bounds = hb;
+			}
+
+			if (closeButton != null)
+			{
+				var cb = closeButton.Bounds;
+				cb.X = w - cb.Width - 4;
+				closeButton.Bounds = cb;
+			}
+
+			if (treeScrollPanel != null)
+			{
+				var sb = treeScrollPanel.Bounds;
+				sb.Width = w - SidePadding;
+				sb.Height = h - (HeaderHeight + FooterHeight);
+				treeScrollPanel.Bounds = sb;
+			}
+
+			if (hscrollContainer != null)
+			{
+				var hb = hscrollContainer.Bounds;
+				hb.Y = h - FooterHeight;
+				hb.Width = w - SidePadding;
+				hscrollContainer.Bounds = hb;
+			}
+
+			SetSize(treeTooltipWidget, w, h);
+		}
+
+		static void SetSize(Widget w, int width, int height)
+		{
+			if (w == null)
+				return;
+			var b = w.Bounds;
+			b.Width = width;
+			b.Height = height;
+			w.Bounds = b;
+		}
+
+		int GetHScrollThumbWidth()
+		{
+			var contentW = commanderTree?.ContentWidth ?? 0;
+			var barW = hscrollContainer?.Bounds.Width ?? 0;
+			if (contentW <= 0 || barW <= 0)
+				return 40;
+			var viewportW = treeScrollPanel?.Bounds.Width ?? barW;
+			var fraction = Math.Clamp((float)viewportW / contentW, 0.05f, 1f);
+			return Math.Max(24, (int)(fraction * barW));
+		}
+
+		void UpdateHScrollThumb()
+		{
+			if (hscrollThumb == null || hscrollContainer == null)
+				return;
+			var barW = hscrollContainer.Bounds.Width;
+			var thumbW = GetHScrollThumbWidth();
+			var scrollFraction = commanderTree?.HorizontalScrollFraction ?? 0f;
+			var thumbX = (int)(scrollFraction * Math.Max(0, barW - thumbW));
+			var b = hscrollThumb.Bounds;
+			b.X = thumbX;
+			b.Width = thumbW;
+			hscrollThumb.Bounds = b;
 		}
 
 		string GetLocalizedString(string key, string fallback)

--- a/mods/cameo/chrome/commander-tree-window.yaml
+++ b/mods/cameo/chrome/commander-tree-window.yaml
@@ -4,58 +4,61 @@ Container@COMMANDER_TREE_OVERLAY:
 	Logic: CommanderTreeWindowLogic
 	Children:
 		LogicKeyListener@HOTKEYS:
-		CommanderTreeDismiss@DISMISS_AREA:
-			Width: WINDOW_WIDTH
-			Height: WINDOW_HEIGHT
-			Color: 000000A0
-		Background@COMMANDER_TREE_WINDOW:
-			Width: WINDOW_WIDTH * 4 / 5
-			Height: WINDOW_HEIGHT * 4 / 5
-			X: (WINDOW_WIDTH - WIDTH) / 2
-			Y: (WINDOW_HEIGHT - HEIGHT) / 2
-			Background: dialog4
+		Container@COMMANDER_TREE_WINDOW:
+			Width: 400
+			Height: 350
+			X: -9999
+			Y: -9999
 			Children:
+				ColorBlock@WINDOW_BG:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
+					Color: 101520CC
+				DragHandle@DRAG_HANDLE:
+					Width: PARENT_WIDTH
+					Height: 148
+					Color: 00000000
 				Label@TITLE:
-					X: 24
+					X: 4
 					Y: 18
 					Font: Bold
 					Text: commander-tree.title
 				Container@HEADER_STATS:
-					X: 24
+					X: 4
 					Y: 56
-					Width: PARENT_WIDTH - 48
+					Width: PARENT_WIDTH - 8
 					Height: 72
 					Children:
 						Label@RANK_LABEL:
-							Width: 220
+							Width: 165
 							Font: Bold
 							Text: promotion-counter.rank
 						Label@RANK_VALUE:
-							X: 220
-							Width: PARENT_WIDTH - 220
+							X: 165
+							Width: PARENT_WIDTH - 165
 							Font: Bold
 						Label@POINTS_LABEL:
 							Y: 24
-							Width: 220
+							Width: 165
 							Font: Bold
 							Text: commander-tree.points-label
 						Label@POINTS_VALUE:
 							Y: 24
-							X: 220
-							Width: PARENT_WIDTH - 220
+							X: 165
+							Width: PARENT_WIDTH - 165
 							Font: Bold
 						Label@PROGRESS_LABEL:
 							Y: 48
-							Width: 220
+							Width: 165
 							Font: Bold
 							Text: promotion-counter.progress
 						Label@PROGRESS_VALUE:
 							Y: 48
-							X: 220
-							Width: PARENT_WIDTH - 220
+							X: 165
+							Width: PARENT_WIDTH - 165
 							Font: Bold
 				Button@CLOSE_BUTTON:
-					X: PARENT_WIDTH - WIDTH - 24
+					X: PARENT_WIDTH - WIDTH - 4
 					Y: 18
 					Width: 32
 					Height: 32
@@ -70,25 +73,42 @@ Container@COMMANDER_TREE_OVERLAY:
 							Font: Bold
 							Text: X
 				ScrollPanel@TREE_SCROLL:
-					X: 24
+					X: 4
 					Y: 148
-					Width: PARENT_WIDTH - 48
-					Height: PARENT_HEIGHT - 224
-					ScrollBar: Right
+					Width: PARENT_WIDTH - 16
+					Height: PARENT_HEIGHT - 172
+					ScrollBar: Hidden
+					BorderWidth: 0
 					Children:
 						CommanderTree@COMMANDER_TREE:
 							TooltipContainer: COMMANDER_TREE_TOOLTIP
 							IconWidth: 62
 							IconHeight: 46
-							HorizontalSpacing: 220
-							VerticalSpacing: 110
-							ContentPadding: 40
-				Slider@TREE_HSCROLL:
-					X: 24
-					Y: PARENT_HEIGHT - 64
-					Width: PARENT_WIDTH - 48
-					Height: 24
+							HorizontalSpacing: 62
+							VerticalSpacing: 46
+							ContentPadding: 8
+							EdgeColor: FFFFFFFF
+							ArrowWidth: 2
+							ArrowHeadLength: 5
+							ArrowHeadWidth: 3
+							ArrowNodePadding: 4
+							OwnedBorderColor: 00CC44FF
+				Container@TREE_HSCROLL:
+					X: 4
+					Y: PARENT_HEIGHT - 24
+					Width: PARENT_WIDTH - 16
+					Height: 20
 					Visible: False
+					Children:
+						CommanderTreeDismiss@HSCROLL_TRACK:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Color: 12161AFF
+						DragHandle@HSCROLL_THUMB:
+							Y: 2
+							Width: 60
+							Height: PARENT_HEIGHT - 4
+							Color: 505866FF
 				TooltipContainer@COMMANDER_TREE_TOOLTIP:
 					X: 0
 					Y: 0


### PR DESCRIPTION
- Highlight prerequisite chain (amber border + arrows) on node hover
- Change owned-node border from gold to green
- Widen header label column to fix "Progress to next rank" overflow
- Remove full-screen dismiss overlay so game interactions remain active
- Fix scrollbar always showing: set BorderWidth: 0 on scroll panel
- Fix spawn flash: init window off-screen, AutoSizeWindow places it on first tick
- Spawn near sidebar (82% screen width, 1/5 screen height)
- Increase card spacing and arrow brightness per design feedback
