### PR TITLE
More feature updates

### DIFF
--- a/OpenRA.Mods.Cameo/CameoStatistics.cs
+++ b/OpenRA.Mods.Cameo/CameoStatistics.cs
@@ -1,0 +1,114 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenRA.Mods.Cameo
+{
+	// Cumulative results for a single faction, accumulated across every completed game and
+	// persisted between sessions. Public fields so FieldLoader/FieldSaver can round-trip it.
+	public class FactionStatistics
+	{
+		public int GamesPlayed;
+		public int GamesWon;
+		public int GamesLost;
+		public int UnitsKilled;
+		public int BuildingsKilled;
+		public int UnitsLost;
+		public int BuildingsLost;
+		public long ResourcesEarned;
+		public long ResourcesSpent;
+	}
+
+	// Reads and writes the local, cross-session statistics file. The data is keyed by
+	// faction internal name and lives next to the other per-user data under the support
+	// directory, so it survives reinstalls of the mod itself.
+	public static class CameoStatistics
+	{
+		const string FileName = "cameo-statistics.yaml";
+
+		static string FilePath => Path.Combine(Platform.SupportDir, FileName);
+
+		// Never throws: a missing or malformed file simply yields an empty set, so a corrupt
+		// file can never crash the menu (the next Save overwrites it cleanly).
+		public static Dictionary<string, FactionStatistics> Load()
+		{
+			var result = new Dictionary<string, FactionStatistics>();
+			var path = FilePath;
+			if (!File.Exists(path))
+				return result;
+
+			try
+			{
+				foreach (var node in MiniYaml.FromFile(path, false))
+				{
+					if (string.IsNullOrEmpty(node.Key))
+						continue;
+
+					result[node.Key] = FieldLoader.Load<FactionStatistics>(node.Value);
+				}
+			}
+			catch (Exception)
+			{
+				return new Dictionary<string, FactionStatistics>();
+			}
+
+			return result;
+		}
+
+		public static void Save(Dictionary<string, FactionStatistics> stats)
+		{
+			try
+			{
+				stats
+					.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+					.Select(kv => new MiniYamlNode(kv.Key, FieldSaver.Save(kv.Value)))
+					.ToList()
+					.WriteToFile(FilePath);
+			}
+			catch (Exception)
+			{
+				// Best-effort: failing to persist statistics must never interrupt the game.
+			}
+		}
+
+		// Folds one completed game's results into the running total for a faction.
+		public static void Record(string faction, bool won,
+			int unitsKilled, int buildingsKilled, int unitsLost, int buildingsLost,
+			long resourcesEarned, long resourcesSpent)
+		{
+			if (string.IsNullOrEmpty(faction))
+				return;
+
+			var stats = Load();
+			if (!stats.TryGetValue(faction, out var s))
+				stats[faction] = s = new FactionStatistics();
+
+			s.GamesPlayed++;
+			if (won)
+				s.GamesWon++;
+			else
+				s.GamesLost++;
+
+			s.UnitsKilled += unitsKilled;
+			s.BuildingsKilled += buildingsKilled;
+			s.UnitsLost += unitsLost;
+			s.BuildingsLost += buildingsLost;
+			s.ResourcesEarned += resourcesEarned;
+			s.ResourcesSpent += resourcesSpent;
+
+			Save(stats);
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Traits/StatisticsRecorder.cs
+++ b/OpenRA.Mods.Cameo/Traits/StatisticsRecorder.cs
@@ -1,0 +1,65 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits
+{
+	[TraitLocation(SystemActors.World)]
+	[Desc("Folds the local player's end-of-game statistics into the persistent, per-faction",
+		"statistics file shown in the main-menu Statistics window. Place on the world actor.")]
+	public class StatisticsRecorderInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new StatisticsRecorder(); }
+	}
+
+	public class StatisticsRecorder : IGameOver
+	{
+		bool recorded;
+
+		void IGameOver.GameOver(World world)
+		{
+			// GameOver can only fire once per world, but guard anyway.
+			if (recorded)
+				return;
+
+			recorded = true;
+
+			// Only completed games with a real local player are counted. Replays are watched,
+			// not played; a dedicated server has no local player. In multiplayer each client
+			// records its own player, which is exactly what we want for local statistics.
+			if (world.IsReplay)
+				return;
+
+			var player = world.LocalPlayer;
+			if (player == null || player.Spectating || player.NonCombatant || player.IsBot)
+				return;
+
+			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
+			if (stats == null)
+				return;
+
+			var resources = player.PlayerActor.TraitOrDefault<PlayerResources>();
+			var won = player.WinState == WinState.Won;
+
+			CameoStatistics.Record(
+				player.Faction.InternalName,
+				won,
+				stats.UnitsKilled,
+				stats.BuildingsKilled,
+				stats.UnitsDead,
+				stats.BuildingsDead,
+				resources?.Earned ?? 0,
+				resources?.Spent ?? 0);
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Widgets/ClickMaskWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/ClickMaskWidget.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Cameo.Widgets
+{
+	// A full-screen colour fill that also swallows every mouse event, so widgets sitting
+	// behind it (e.g. the main menu) cannot be clicked while a modal window is open. The
+	// main menu is loaded directly into the UI root rather than the modal window stack, so
+	// OpenWindow alone does not hide it; this mask provides the missing modal backstop.
+	public class ClickMaskWidget : ColorBlockWidget
+	{
+		[ObjectCreator.UseCtor]
+		public ClickMaskWidget(ModData modData)
+			: base(modData)
+		{
+		}
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				TakeMouseFocus(mi);
+				OnMouseDown(mi);
+				return true;
+			}
+
+			if (mi.Event == MouseInputEvent.Up)
+			{
+				OnMouseUp(mi);
+				YieldMouseFocus(mi);
+				return true;
+			}
+
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Widgets/Logic/CameoMainMenuLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/CameoMainMenuLogic.cs
@@ -1,0 +1,34 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Cameo.Widgets.Logic
+{
+	// Wires up the Cameo-specific main-menu buttons that the shared MainMenuLogic does not know
+	// about. Attached as a second Logic on the main-menu container so the engine's MainMenuLogic
+	// stays untouched. The Statistics window is a self-contained modal overlay (it dims and
+	// blocks the menu behind it), so there is no need to drive the menu's private show/hide state.
+	public class CameoMainMenuLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public CameoMainMenuLogic(Widget widget, World world)
+		{
+			var statisticsButton = widget.GetOrNull<ButtonWidget>("STATISTICS_BUTTON");
+			if (statisticsButton != null)
+				statisticsButton.OnClick = () => Ui.OpenWindow("STATISTICS_PANEL", new WidgetArgs
+				{
+					{ "world", world }
+				});
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
@@ -1,0 +1,112 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Globalization;
+using System.Linq;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Cameo.Widgets.Logic
+{
+	public class StatisticsWindowLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public StatisticsWindowLogic(Widget widget, World world)
+		{
+			var stats = CameoStatistics.Load();
+
+			// Selectable, non-random factions, with their localized display names. These define
+			// the per-faction rows (unplayed factions appear with zeroed totals so the player can
+			// see which factions they have yet to play).
+			var factions = world.WorldActor.Info.TraitInfos<FactionInfo>()
+				.Where(f => f.Selectable && !IsRandom(f))
+				.OrderBy(ResolveName, StringComparer.CurrentCultureIgnoreCase)
+				.ToList();
+
+			// Global totals, summed across every recorded faction.
+			var gamesPlayed = stats.Values.Sum(s => s.GamesPlayed);
+			var gamesWon = stats.Values.Sum(s => s.GamesWon);
+			var gamesLost = stats.Values.Sum(s => s.GamesLost);
+			var enemiesKilled = stats.Values.Sum(s => (long)s.UnitsKilled);
+			var buildingsDestroyed = stats.Values.Sum(s => (long)s.BuildingsKilled);
+			var resourcesEarned = stats.Values.Sum(s => s.ResourcesEarned);
+			var resourcesSpent = stats.Values.Sum(s => s.ResourcesSpent);
+			var factionsPlayed = stats.Count(kv => kv.Value.GamesPlayed > 0);
+
+			SetText(widget, "GAMES_PLAYED_VALUE", Number(gamesPlayed));
+			SetText(widget, "GAMES_WON_VALUE", Number(gamesWon));
+			SetText(widget, "GAMES_LOST_VALUE", Number(gamesLost));
+			SetText(widget, "FACTIONS_PLAYED_VALUE", $"{Number(factionsPlayed)} / {Number(factions.Count)}");
+			SetText(widget, "ENEMIES_KILLED_VALUE", Number(enemiesKilled));
+			SetText(widget, "BUILDINGS_DESTROYED_VALUE", Number(buildingsDestroyed));
+			SetText(widget, "RESOURCES_COLLECTED_VALUE", Number(resourcesEarned));
+			SetText(widget, "RESOURCES_SPENT_VALUE", Number(resourcesSpent));
+
+			var list = widget.GetOrNull<ScrollPanelWidget>("FACTION_LIST");
+			var template = list?.GetOrNull<ScrollItemWidget>("ROW_TEMPLATE");
+			if (list != null && template != null)
+			{
+				list.RemoveChildren();
+				foreach (var faction in factions)
+				{
+					stats.TryGetValue(faction.InternalName, out var s);
+
+					var name = ResolveName(faction);
+					var games = Number(s?.GamesPlayed ?? 0);
+					var wins = Number(s?.GamesWon ?? 0);
+					var kills = Number(s?.UnitsKilled ?? 0);
+					var destroyed = Number(s?.BuildingsKilled ?? 0);
+
+					var item = ScrollItemWidget.Setup(template, () => false, () => { });
+					SetText(item, "NAME", name);
+					SetText(item, "GAMES", games);
+					SetText(item, "WINS", wins);
+					SetText(item, "KILLS", kills);
+					SetText(item, "DESTROYED", destroyed);
+					list.AddChild(item);
+				}
+			}
+
+			var closeButton = widget.GetOrNull<ButtonWidget>("CLOSE_BUTTON");
+			if (closeButton != null)
+				closeButton.OnClick = Ui.CloseWindow;
+		}
+
+		static string Number(long value)
+		{
+			return value.ToString("N0", CultureInfo.CurrentCulture);
+		}
+
+		static bool IsRandom(FactionInfo f)
+		{
+			return string.Equals(f.InternalName, "Random", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(f.Side, "Random", StringComparison.OrdinalIgnoreCase);
+		}
+
+		static string ResolveName(FactionInfo f)
+		{
+			var name = f.Name;
+			if (!string.IsNullOrEmpty(name) && FluentProvider.TryGetMessage(name, out var localized))
+				return localized;
+
+			return string.IsNullOrEmpty(name) ? f.InternalName : name;
+		}
+
+		static void SetText(Widget parent, string id, string value)
+		{
+			var label = parent.GetOrNull<LabelWidget>(id);
+			if (label != null)
+				label.GetText = () => value;
+		}
+	}
+}

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="ba08626"
+ENGINE_VERSION="bfa31df"
 
 ##############################################################################
 # Packaging

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="b2ebb08"
+ENGINE_VERSION="ba08626"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/audio/notifications.yaml
+++ b/mods/cameo/audio/notifications.yaml
@@ -195,6 +195,7 @@ Speech:
 		BuildingLost: strclst1
 		BuildingInfiltrated: bldginf1
 		Cancelled: cancld1
+			Priority: true
 		CivilianBuildingCaptured: strucap1
 		CivilianKilled: civdead1
 		ConstructionComplete: conscmp1, conscmp2
@@ -225,6 +226,7 @@ Speech:
 		NuclearWeaponLaunched: alaunch1
 			Priority: true
 		OnHold: onhold1
+			Priority: true
 		PrimaryBuildingSelected: pribldg1
 		Reinforce: reinfor1
 		Repairing: repair1

--- a/mods/cameo/chrome/mainmenu.yaml
+++ b/mods/cameo/chrome/mainmenu.yaml
@@ -1,5 +1,5 @@
 Container@MAINMENU:
-	Logic: MainMenuLogic
+	Logic: MainMenuLogic, CameoMainMenuLogic
 	Children:
 		LogicKeyListener@GLOBAL_KEYHANDLER:
 			Logic: MusicHotkeyLogic, ScreenshotHotkeyLogic, MuteHotkeyLogic
@@ -277,3 +277,13 @@ Container@MAINMENU:
 			Logic: LoadLocalPlayerProfileLogic
 			X: 25
 			Y: 25
+		# Detached top-right shortcut, mirroring the top-left player-profile card. Statistics
+		# are player-career data, so they get a persistent shell button rather than being buried
+		# in Extras. Sits clear of the centred news bar and above the right-hand logo.
+		Button@STATISTICS_BUTTON:
+			X: WINDOW_WIDTH - WIDTH - 25
+			Y: 25
+			Width: 150
+			Height: 28
+			Text: Statistics (WIP)
+			Font: Bold

--- a/mods/cameo/chrome/mainmenu.yaml
+++ b/mods/cameo/chrome/mainmenu.yaml
@@ -253,7 +253,7 @@ Container@MAINMENU:
 					Y: 15
 					Width: 400
 					Height: 25
-					Text: Battlefield News
+					Text: Cameo News
 					Font: Bold
 		Container@UPDATE_NOTICE:
 			X: (WINDOW_WIDTH - WIDTH) / 2

--- a/mods/cameo/chrome/statistics-window.yaml
+++ b/mods/cameo/chrome/statistics-window.yaml
@@ -1,0 +1,229 @@
+Container@STATISTICS_PANEL:
+	Width: WINDOW_WIDTH
+	Height: WINDOW_HEIGHT
+	Logic: StatisticsWindowLogic
+	Children:
+		ClickMask@MASK:
+			Width: WINDOW_WIDTH
+			Height: WINDOW_HEIGHT
+			Color: 00000099
+		Container@WINDOW:
+			X: (WINDOW_WIDTH - WIDTH) / 2
+			Y: (WINDOW_HEIGHT - HEIGHT) / 2
+			Width: 600
+			Height: 520
+			Children:
+				ColorBlock@WINDOW_BG:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
+					Color: 101520F2
+				Label@TITLE:
+					Y: 14
+					Width: PARENT_WIDTH
+					Height: 26
+					Align: Center
+					Font: Bold
+					Text: statistics.title
+				Button@CLOSE_BUTTON:
+					X: PARENT_WIDTH - 38
+					Y: 12
+					Width: 28
+					Height: 28
+					Key: escape
+					Background: button
+					Children:
+						Label@TEXT:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Align: Center
+							VAlign: Middle
+							Font: Bold
+							Text: X
+				# Left summary column
+				Label@GAMES_PLAYED:
+					X: 24
+					Y: 50
+					Width: 150
+					Height: 22
+					Text: statistics.games-played
+				Label@GAMES_PLAYED_VALUE:
+					X: 178
+					Y: 50
+					Width: 110
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@GAMES_WON:
+					X: 24
+					Y: 76
+					Width: 150
+					Height: 22
+					Text: statistics.games-won
+				Label@GAMES_WON_VALUE:
+					X: 178
+					Y: 76
+					Width: 110
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@GAMES_LOST:
+					X: 24
+					Y: 102
+					Width: 150
+					Height: 22
+					Text: statistics.games-lost
+				Label@GAMES_LOST_VALUE:
+					X: 178
+					Y: 102
+					Width: 110
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@FACTIONS_PLAYED:
+					X: 24
+					Y: 128
+					Width: 150
+					Height: 22
+					Text: statistics.factions-played
+				Label@FACTIONS_PLAYED_VALUE:
+					X: 178
+					Y: 128
+					Width: 110
+					Height: 22
+					Align: Right
+					Font: Bold
+				# Right summary column
+				Label@ENEMIES_KILLED:
+					X: 312
+					Y: 50
+					Width: 160
+					Height: 22
+					Text: statistics.enemies-killed
+				Label@ENEMIES_KILLED_VALUE:
+					X: 476
+					Y: 50
+					Width: 100
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@BUILDINGS_DESTROYED:
+					X: 312
+					Y: 76
+					Width: 160
+					Height: 22
+					Text: statistics.buildings-destroyed
+				Label@BUILDINGS_DESTROYED_VALUE:
+					X: 476
+					Y: 76
+					Width: 100
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@RESOURCES_COLLECTED:
+					X: 312
+					Y: 102
+					Width: 160
+					Height: 22
+					Text: statistics.resources-collected
+				Label@RESOURCES_COLLECTED_VALUE:
+					X: 476
+					Y: 102
+					Width: 100
+					Height: 22
+					Align: Right
+					Font: Bold
+				Label@RESOURCES_SPENT:
+					X: 312
+					Y: 128
+					Width: 160
+					Height: 22
+					Text: statistics.resources-spent
+				Label@RESOURCES_SPENT_VALUE:
+					X: 476
+					Y: 128
+					Width: 100
+					Height: 22
+					Align: Right
+					Font: Bold
+				# Per-faction list column headers
+				Label@COL_FACTION:
+					X: 26
+					Y: 170
+					Width: 170
+					Height: 20
+					Font: Bold
+					Text: statistics.col-faction
+				Label@COL_GAMES:
+					X: 208
+					Y: 170
+					Width: 70
+					Height: 20
+					Align: Center
+					Font: Bold
+					Text: statistics.col-games
+				Label@COL_WINS:
+					X: 278
+					Y: 170
+					Width: 70
+					Height: 20
+					Align: Center
+					Font: Bold
+					Text: statistics.col-wins
+				Label@COL_KILLS:
+					X: 348
+					Y: 170
+					Width: 100
+					Height: 20
+					Align: Center
+					Font: Bold
+					Text: statistics.col-kills
+				Label@COL_DESTROYED:
+					X: 448
+					Y: 170
+					Width: 110
+					Height: 20
+					Align: Center
+					Font: Bold
+					Text: statistics.col-destroyed
+				ScrollPanel@FACTION_LIST:
+					X: 16
+					Y: 192
+					Width: PARENT_WIDTH - 32
+					Height: 312
+					Children:
+						ScrollItem@ROW_TEMPLATE:
+							Width: PARENT_WIDTH - 27
+							Height: 24
+							X: 2
+							Visible: false
+							EnableChildMouseOver: True
+							Children:
+								Label@NAME:
+									X: 8
+									Width: 170
+									Height: 24
+									VAlign: Middle
+								Label@GAMES:
+									X: 190
+									Width: 70
+									Height: 24
+									Align: Center
+									VAlign: Middle
+								Label@WINS:
+									X: 260
+									Width: 70
+									Height: 24
+									Align: Center
+									VAlign: Middle
+								Label@KILLS:
+									X: 330
+									Width: 100
+									Height: 24
+									Align: Center
+									VAlign: Middle
+								Label@DESTROYED:
+									X: 430
+									Width: 110
+									Height: 24
+									Align: Center
+									VAlign: Middle

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -64,6 +64,22 @@ commander-tree =
     .points-label = Available Points
     .close = Close
 
+statistics =
+    .title = Statistics
+    .games-played = Games played:
+    .games-won = Games won:
+    .games-lost = Games lost:
+    .factions-played = Factions played:
+    .enemies-killed = Enemies killed:
+    .buildings-destroyed = Buildings destroyed:
+    .resources-collected = Resources collected:
+    .resources-spent = Resources spent:
+    .col-faction = Faction
+    .col-games = Games
+    .col-wins = Wins
+    .col-kills = Kills
+    .col-destroyed = Destroyed
+
 actor-stats-label-prefix =
     .armor = Armor:
     .sight = Sight:

--- a/mods/cameo/mod.yaml
+++ b/mods/cameo/mod.yaml
@@ -310,6 +310,7 @@ ChromeLayout:
 	cameo|chrome/ingame-player.yaml
 	cameo|chrome/ingame-transients.yaml
 	cameo|chrome/commander-tree-window.yaml
+	cameo|chrome/statistics-window.yaml
 	cameo|chrome/lobby.yaml
 	common|chrome/lobby-kickdialogs.yaml
 	common|chrome/lobby-mappreview.yaml

--- a/mods/cameo/mod.yaml
+++ b/mods/cameo/mod.yaml
@@ -406,6 +406,10 @@ LoadScreen: FitImageLoadScreen
 	SplashImage: cameo|uibits/splash-screen.png
 	Image: cameo|uibits/loadscreen2.png,cameo|uibits/loadscreen3.png,cameo|uibits/loadscreen4.png,cameo|uibits/loadscreen5.png,cameo|uibits/loadscreen6.png,cameo|uibits/loadscreen7.png,cameo|uibits/loadscreen8.png,cameo|uibits/loadscreen9.png,cameo|uibits/loadscreen10.png,cameo|uibits/loadscreen11.png,cameo|uibits/loadscreen12.png,cameo|uibits/loadscreen13.png,cameo|uibits/loadscreen14.png,cameo|uibits/loadscreen15.png,cameo|uibits/loadscreen16.png,cameo|uibits/loadscreen17.png,cameo|uibits/loadscreen18.png,cameo|uibits/loadscreen19.png,cameo|uibits/loadscreen20.png,cameo|uibits/loadscreen21.png,cameo|uibits/loadscreen22.png,cameo|uibits/loadscreen23.png,cameo|uibits/loadscreen24.png,cameo|uibits/loadscreen25.png,cameo|uibits/loadscreen26.png,cameo|uibits/loadscreen27.png
 
+WebServices:
+	GameNews: https://api.github.com/repos/cameo-mod/Cameo-mod/releases
+	GameNewsFromGitHubReleases: true
+
 ServerTraits:
 	LobbyCommands
 	SkirmishLogic

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -4934,7 +4934,7 @@
 		LowerValue: -20000
 	WithPhysicalStateColoredOverlay@CryoFreeze:
 		PhysicalStateName: Temperature
-		MinColor: 88BBFF78
+		MinColor: 88BBFF64
 		MaxColor: 4488FF08
 		UpperValue: -200
 		LowerValue: -20000
@@ -4948,7 +4948,7 @@
 	WithPhysicalStateColoredOverlay@Overheating:
 		PhysicalStateName: Temperature
 		MinColor: FF884408
-		MaxColor: FF402096
+		MaxColor: FF40207B
 		UpperValue: 20000
 		LowerValue: 200
 	WithIdleOverlay@overheat:

--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -916,6 +916,7 @@ World:
 	Inherits@MapGenerators: ^MapGenerators
 	CryoFogLimiter:
 		Max: 24
+	StatisticsRecorder:
 	ChatCommands:
 	DevCommands:
 	DebugVisualizationCommands:


### PR DESCRIPTION
[Make On Hold and Cancelled speech notifications priority](https://github.com/cameo-mod/Cameo-mod/commit/83b513733b3c17a15f4777d078fb976aad6971ce) 

[Add player Statistics window with cross-session stats](https://github.com/cameo-mod/Cameo-mod/commit/0669763801d71733d7ebe1c8669c35a1f840954d) 

"Battlefield News" is remade into "Cameo News" but it's only tracking Github releases on cameo-mod repo:

[Bump engine pin for GitHub Releases news support](https://github.com/cameo-mod/Cameo-mod/commit/71de6107b4ba332814cbb3abf1bec6e493e4fd8d) 

[Point the news panel at Cameo-mod GitHub Releases](https://github.com/cameo-mod/Cameo-mod/commit/f07fb868271e9e8a4305629307cc734e3f876c97) 

Other minor adjustment

[Reduce physical states effect alpha](https://github.com/cameo-mod/Cameo-mod/pull/128/commits/7e8b20b616c78c3528ca81fe063e4576db5dc442)