### PR TITLE
Construction yards redeploy after an Alt-move

### DIFF
--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -7310,6 +7310,7 @@ CPQDEBUGDUMMY:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle

--- a/mods/cameo/rules/tiberiansun.yaml
+++ b/mods/cameo/rules/tiberiansun.yaml
@@ -373,6 +373,7 @@ TSGTCNST:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle
@@ -438,6 +439,7 @@ TSGTCNSTGDI:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle
@@ -511,6 +513,7 @@ TSGTCNSTNOD:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle
@@ -588,6 +591,7 @@ TSGTCNSTCABAL:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle
@@ -2460,6 +2464,7 @@ TSGTCNSTMUTANT:
 		RequiresCondition: factundeploy
 		Locomotor: heavywheeled
 		RequiresForceMove: true
+		RedeployAfterMove: true
 	TransformsIntoPassenger:
 		RequiresCondition: factundeploy
 		CargoType: Vehicle


### PR DESCRIPTION
Enables `RedeployAfterMove` on the construction-yard `TransformsIntoMobile`, so a force-move (Alt) order on a Construction Yard undeploys it, relocates the MCV, and redeploys it at the destination in one action instead of leaving it as an MCV.

Applied to `^Conyard` (covers all yards that inherit it) and the `TSGTCNST` conyard family in `tiberiansun.yaml` (which define their own `TransformsIntoMobile`). The inactive `tiberiansunold`/`n64`/`lostunits` packs are intentionally not touched.

Depends on the engine option added in cameo-mod/OpenRA#66 — needs that merged and the engine pin bumped before this YAML is valid (the `RedeployAfterMove` field does not exist in the currently pinned engine).

Verified working in-game.