### PR TITLE
Lower ground/building fire smoke density (SpawnFrequency 4,8 -> 6,12)

### DIFF
--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -3438,7 +3438,7 @@
 		Sequences: idle
 		Palette: effect
 		# Interval (ticks) between smoke puffs, lower = more smoke.
-		SpawnFrequency: 4, 8
+		SpawnFrequency: 6, 12
 		# Must equal the animation length (32 frames * 80ms Tick = 64 sim ticks); a longer Duration
 		# loops the one-shot sprite and pops a fresh puff back in. See groundfire in misc.yaml.
 		Duration: 64

--- a/mods/cameo/rules/misc.yaml
+++ b/mods/cameo/rules/misc.yaml
@@ -435,8 +435,8 @@ groundfire:
 		Image: smoke_fire_glow
 		Sequences: idle
 		Palette: effect
-		# Interval (ticks) between smoke puffs, lower = more smoke. Optimal is 6, 10.
-		SpawnFrequency: 4, 8
+		# Interval (ticks) between smoke puffs, lower = more smoke.
+		SpawnFrequency: 6, 12
 		# Must equal the animation length (32 frames * 80ms Tick = 64 sim ticks). The engine plays
 		# the sprite with PlayRepeating; a longer Duration loops it and pops a fresh puff back in.
 		Duration: 64


### PR DESCRIPTION
Widens the puff interval on the two fire-smoke emitters that commit b95c7ad2 raised together, thinning out the smoke columns:

- `@GroundFireSmoke` (ground fire, `misc.yaml`)
- `@CriticalFire` (burning buildings, `defaults.yaml`)

`SpawnFrequency: 4, 8 -> 6, 12`. Pure YAML, no engine dependency. The unrelated husk/other smoke emitters (10,16 / 12,20) are untouched.