### PR TITLE
Adaptive game-speed: multiplayer host path + lobby option

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/AdaptiveGameSpeed.cs
+++ b/OpenRA.Mods.Cameo/Traits/AdaptiveGameSpeed.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using OpenRA.Network;
@@ -16,9 +17,9 @@ namespace OpenRA.Mods.Cameo.Traits
 		"time, instead of dropping render frames (the late-game teleport-stutter). Feeds the existing",
 		"server-authoritative TickScale pacing path — it never touches World.Timestep / the simulated dt,",
 		"so it is deterministic by construction and a hard no-op in replays, while loading saves, and in",
-		"networked (more than one human) games. Toggle via the Cameo 'AdaptiveGameSpeedEnabled' setting",
-		"(default off). Attach to the world actor.")]
-	public class AdaptiveGameSpeedInfo : TraitInfo
+		"networked (more than one human) games. Enabled by the default-on 'Adaptive Game Speed' lobby",
+		"option (shared with the multiplayer host driver AdaptiveGameSpeedHost). Attach to the world actor.")]
+	public class AdaptiveGameSpeedInfo : TraitInfo, ILobbyOptions
 	{
 		[Desc("Slowest the game may run, as a percentage of normal speed. 25 = quarter speed (timestep x4).",
 			"Must be deep enough that the stretched timestep can exceed peak late-game tick compute, or the",
@@ -66,6 +67,25 @@ namespace OpenRA.Mods.Cameo.Traits
 			"feature is active. The log file completes when you quit the game. Useful for re-tuning.")]
 		public readonly bool EnableDiagnosticLog = false;
 
+		[Desc("Default state of the Adaptive Game Speed lobby option (governs both this single-player path",
+			"and the multiplayer host driver).")]
+		public readonly bool CheckboxEnabled = true;
+
+		[Desc("Prevent the Adaptive Game Speed lobby option from being changed in the lobby.")]
+		public readonly bool CheckboxLocked = false;
+
+		[Desc("Display order for the Adaptive Game Speed lobby option.")]
+		public readonly int CheckboxDisplayOrder = 0;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
+		{
+			yield return new LobbyBooleanOption(map, "adaptivegamespeed",
+				"Adaptive Game Speed",
+				"Smoothly slow game-time under heavy late-game load instead of dropping frames (teleport-stutter), "
+					+ "then speed back up as it clears.",
+				true, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+		}
+
 		public override object Create(ActorInitializer init) => new AdaptiveGameSpeed(this);
 	}
 
@@ -108,17 +128,17 @@ namespace OpenRA.Mods.Cameo.Traits
 			if (world == null || world.Type != WorldType.Regular)
 				return false;
 
-			// Determinism guard (SC-04/SC-05): never engage for replays or save-load catch-up — those
+			// Determinism guard: never engage for replays or save-load catch-up — those
 			// paths bypass tickScale in SuggestedTimestep, and we must not re-introduce it there.
 			if (world.IsReplay || world.IsLoadingGameSave)
 				return false;
 
 			// Single-player / skirmish only. Any game with more than one human keeps stock pacing — a
-			// locally-derived scale must never leak into networked wall-clock flow control (SC-04).
+			// locally-derived scale must never leak into networked wall-clock flow control.
 			if (world.LobbyInfo.NonBotClients.Count() > 1)
 				return false;
 
-			return world.GetSettings<CameoSettings>().AdaptiveGameSpeedEnabled;
+			return world.LobbyInfo.GlobalSettings.OptionOrDefault("adaptivegamespeed", info.CheckboxEnabled);
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Cameo/Traits/AdaptiveGameSpeedHost.cs
+++ b/OpenRA.Mods.Cameo/Traits/AdaptiveGameSpeedHost.cs
@@ -10,15 +10,15 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cameo.Traits
 {
-	[Desc("Multiplayer host-side driver for adaptive game-speed (Stage C Prong C). On the game host ONLY,",
+	[Desc("Multiplayer host-side driver for adaptive game-speed. On the game host ONLY,",
 		"measures the host's per-tick simulation compute and submits an absolute pacing scale to the server",
 		"(an immediate 'AdaptivePacingScale' order). The server validates admin + sanitizes it and folds it",
 		"into the authoritative TickScale broadcast (max with the per-player relative scale), so every client",
 		"slows UNIFORMLY to the host's sustainable pace. Pacing-only — it never touches World.Timestep / the",
 		"simulated dt and the host applies the value the SERVER rebroadcasts (like every client), not its local",
 		"one — so it is deterministic by construction. Inert unless this client is the host, more than one human",
-		"is connected (single-human games use the local AdaptiveGameSpeed path), and the Cameo",
-		"'AdaptiveGameSpeedEnabled' setting is on. Attach to the world actor.")]
+		"is connected (single-human games use the local AdaptiveGameSpeed path), and the default-on",
+		"'Adaptive Game Speed' lobby option is enabled. Attach to the world actor.")]
 	public class AdaptiveGameSpeedHostInfo : TraitInfo
 	{
 		[Desc("Slowest the game may run, as a percentage of normal speed. 25 = quarter speed (timestep x4).",
@@ -52,6 +52,12 @@ namespace OpenRA.Mods.Cameo.Traits
 			"comfortably below the server's expiry window.")]
 		public readonly int HeartbeatMs = 1000;
 
+		[Desc("Opt-in diagnostic (default off): on the host, write a once-per-second line to",
+			"Logs/adaptivespeed-host.log with the measured sim-compute, the computed scale, and the scale last",
+			"sent to the server. Only logs while the host driver is active. Useful for confirming the driver",
+			"engages and for re-tuning.")]
+		public readonly bool EnableDiagnosticLog = false;
+
 		public override object Create(ActorInitializer init) => new AdaptiveGameSpeedHost(this);
 	}
 
@@ -69,9 +75,16 @@ namespace OpenRA.Mods.Cameo.Traits
 		long lastSendTime;
 		bool wasActive;
 
+		// Diagnostic accumulators (opt-in — see EnableDiagnosticLog). Per ~1s window.
+		readonly bool diag;
+		long lastLogTime = -1;
+		int winTicks, winSends;
+		float winSumC, winMinC, winMaxC, winSumScale, winMaxScale;
+
 		public AdaptiveGameSpeedHost(AdaptiveGameSpeedHostInfo info)
 		{
 			this.info = info;
+			diag = info.EnableDiagnosticLog;
 			controller = new AdaptiveSpeedController(info.MinimumSpeedPercent, info.OverloadMargin,
 				info.Smoothing, info.RecoveryStep, info.RecoveryRate, info.OverloadHoldTicks);
 		}
@@ -79,6 +92,8 @@ namespace OpenRA.Mods.Cameo.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			world = self.World;
+			if (diag)
+				Log.AddChannel("adaptivespeed-host", "adaptivespeed-host.log");   // idempotent
 		}
 
 		bool Active()
@@ -96,7 +111,7 @@ namespace OpenRA.Mods.Cameo.Traits
 			if (!OpenRA.Game.IsHost || world.LobbyInfo.NonBotClients.Count() <= 1)
 				return false;
 
-			return world.GetSettings<CameoSettings>().AdaptiveGameSpeedEnabled;
+			return world.LobbyInfo.GlobalSettings.OptionOrDefault("adaptivegamespeed", true);
 		}
 
 		void ITick.Tick(Actor self)
@@ -111,10 +126,16 @@ namespace OpenRA.Mods.Cameo.Traits
 						Send(1f, OpenRA.Game.RunTime);
 
 					wasActive = false;
+					ResetDiagWindow();
+					lastLogTime = -1;
 				}
 
 				return;
 			}
+
+			if (diag && !wasActive)
+				Log.Write("adaptivespeed-host", FormattableString.Invariant(
+					$"activated: host={OpenRA.Game.IsHost} nonBotClients={world.LobbyInfo.NonBotClients.Count()}"));
 
 			wasActive = true;
 
@@ -137,8 +158,12 @@ namespace OpenRA.Mods.Cameo.Traits
 			var changed = Math.Abs(scale - lastSentScale) >= info.SendThreshold;
 			var settled = scale == 1f && lastSentScale != 1f;
 			var heartbeat = scale > 1f && now - lastSendTime >= info.HeartbeatMs;
-			if (changed || settled || heartbeat)
+			var sent = changed || settled || heartbeat;
+			if (sent)
 				Send(scale, now);
+
+			if (diag)
+				LogDiag(now, compute, scale, sent);
 		}
 
 		void Send(float scale, long now)
@@ -149,6 +174,57 @@ namespace OpenRA.Mods.Cameo.Traits
 			OpenRA.Network.HostPacing.SendScale(scale);
 			lastSentScale = scale;
 			lastSendTime = now;
+		}
+
+		// Diagnostic. Accumulate this tick into the current ~1s window and flush a summary line once a second.
+		// Key signals: the host sim compute (the bottleneck), the scale the controller asks for, and the scale
+		// actually sent to the server. A rising scale + nonzero sends while compute exceeds budget = the host is
+		// driving the global slowdown.
+		void LogDiag(long now, long compute, float scale, bool sent)
+		{
+			if (lastLogTime < 0)
+				lastLogTime = now;
+
+			if (winTicks == 0)
+			{
+				winMinC = compute;
+				winMaxC = compute;
+			}
+			else
+			{
+				winMinC = Math.Min(winMinC, compute);
+				winMaxC = Math.Max(winMaxC, compute);
+			}
+
+			winTicks++;
+			winSumC += compute;
+			winSumScale += scale;
+			winMaxScale = Math.Max(winMaxScale, scale);
+			if (sent)
+				winSends++;
+
+			if (now - lastLogTime < 1000)
+				return;
+
+			var avgC = winSumC / winTicks;
+			var avgScale = winSumScale / winTicks;
+			var speedPct = (int)Math.Round(100f / avgScale);
+			var line = FormattableString.Invariant(
+					$"t={now / 1000}s ticks={winTicks} compute_ms[min={winMinC:F0} avg={avgC:F0} max={winMaxC:F0}] ")
+				+ FormattableString.Invariant(
+					$"scale[avg={avgScale:F2} max={winMaxScale:F2}] sent={lastSentScale:F2} sends={winSends} ")
+				+ FormattableString.Invariant(
+					$"speed={speedPct}% budget={world.Timestep}");
+			Log.Write("adaptivespeed-host", line);
+
+			lastLogTime = now;
+			ResetDiagWindow();
+		}
+
+		void ResetDiagWindow()
+		{
+			winTicks = 0; winSends = 0;
+			winSumC = 0; winMinC = 0; winMaxC = 0; winSumScale = 0; winMaxScale = 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Cameo/Traits/AdaptiveSpeedController.cs
+++ b/OpenRA.Mods.Cameo/Traits/AdaptiveSpeedController.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace OpenRA.Mods.Cameo.Traits
 {
-	// Pure, source- and sink-agnostic core of Stage C adaptive game-speed.
+	// Pure, source- and sink-agnostic core of the adaptive game-speed controller.
 	//
 	// Feed it the measured wall-clock period between sim ticks — which the game loop makes equal to
 	// max(pacedTimestep, actual compute) — plus the unscaled base timestep; it returns the pacing

--- a/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
@@ -14,9 +14,5 @@ namespace OpenRA.Mods.Cameo.Traits
 	{
 		[Desc("Enables Quota Mode: production buildings auto-requeue units to maintain alive count targets.")]
 		public bool QuotaModeEnabled = false;
-
-		[Desc("Single-player only: gracefully slow the game when the simulation can't keep up (instead of",
-			"render-frame-drop / teleport-stutter). No effect in multiplayer or replays.")]
-		public bool AdaptiveGameSpeedEnabled = false;
 	}
 }

--- a/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
@@ -69,16 +69,6 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 				quotaManager?.SetEnabled(cameoSettings.QuotaModeEnabled);
 			};
 
-			var adaptiveGameSpeedCheckbox = panel.Get<CheckboxWidget>("ADAPTIVE_GAMESPEED_CHECKBOX");
-			adaptiveGameSpeedCheckbox.IsChecked = () => cameoSettings.AdaptiveGameSpeedEnabled;
-			adaptiveGameSpeedCheckbox.OnClick = () =>
-			{
-				// The AdaptiveGameSpeed world trait reads this setting live each tick, so toggling here
-				// takes effect immediately mid-game (no manager poke needed, unlike Quota Mode).
-				cameoSettings.AdaptiveGameSpeedEnabled ^= true;
-				cameoSettings.Save();
-			};
-
 			return () => false;
 		}
 

--- a/mods/cameo/chrome/settings-gameplay.yaml
+++ b/mods/cameo/chrome/settings-gameplay.yaml
@@ -70,18 +70,3 @@ Container@GAMEPLAY_PANEL:
 									Text: checkbox-quota-mode.label
 									TooltipText: checkbox-quota-mode.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
-				Container@ADAPTIVE_GAMESPEED_ROW:
-					Width: PARENT_WIDTH - 24
-					Height: 25
-					Children:
-						Container@ADAPTIVE_GAMESPEED_CHECKBOX_CONTAINER:
-							X: 10
-							Width: PARENT_WIDTH - 20
-							Children:
-								Checkbox@ADAPTIVE_GAMESPEED_CHECKBOX:
-									Width: PARENT_WIDTH
-									Height: 20
-									Font: Regular
-									Text: checkbox-adaptive-gamespeed.label
-									TooltipText: checkbox-adaptive-gamespeed.tooltip
-									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -329,11 +329,6 @@ checkbox-quota-mode =
     .tooltip = Production buildings automatically re-queue units to maintain target alive counts per type.
         Left-click a unit in the production panel to set its target; right-click to lower it.
         Due to its instability, this feature is currently single-player only, and disabled in multiplayer.
-checkbox-adaptive-gamespeed =
-    .label = Adaptive Game Speed
-    .tooltip = When the simulation can't keep up in big late-game battles, smoothly slow game-time instead of dropping frames (teleport-stutter), then speed back up as the battle clears.
-        Single-player and skirmish only; has no effect in multiplayer or replays.
-
 
 ## Map Generator (from OpenRA RA)
 ## map-generators.yaml

--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -5,6 +5,10 @@
 	Selection:
 	AutoControlGroupsManager:
 	AdaptiveGameSpeed:
+	# Multiplayer host-driven counterpart to AdaptiveGameSpeed; inert unless this client is the host
+	# of a game with more than one human (single-human games use AdaptiveGameSpeed instead).
+	AdaptiveGameSpeedHost:
+		EnableDiagnosticLog: true
 	BackstabGameMode:
 		BackstabCheckboxDisplayOrder: 22
 	VoxelCache:


### PR DESCRIPTION
## What

Enables the multiplayer side of adaptive game-speed (graceful slowdown under simulation overload) and converts its on/off control to a lobby option.

- **Host-authoritative multiplayer slowdown.** On the host of a multiplayer game, `AdaptiveGameSpeedHost` measures the host's per-tick simulation compute and submits an absolute pacing scale to the server. The server validates the admin, sanitises/clamps the value, and folds it (max with the existing per-player relative scale) into the authoritative `TickScale` broadcast, so all clients slow uniformly and stay in lockstep. Pacing-only — it never touches the simulated timestep — so it is deterministic by construction and inert in replays and saves.
- **Lobby option.** Replaces the per-client `AdaptiveGameSpeedEnabled` setting with a synced, default-on **"Adaptive Game Speed"** lobby option, read by both the single-player and host drivers (mutually exclusive on the human count, so only one ever drives). The Settings → Gameplay checkbox and its strings are removed.
- **Diagnostics.** The host driver writes a once-per-second line to `adaptivespeed-host.log` (host only) to aid bug reports.

The engine support for this path is already in the pinned engine, so this is a mod-only change — **no engine version bump**.

## Testing

Local two-client multiplayer match versus several AI opponents, played into a heavy late game:

- The host drove the slowdown to ~32% speed at peak (216 ms ticks against a 40 ms budget), broadcasting ~1,400 pacing updates over the match, and recovered to full speed as the battle cleared.
- **No desync** (no `syncreport`, no out-of-sync notification) and no exceptions on either client.

Decoupled rendering was off for this run to isolate the pacing path; the combined case is a follow-up.
