### PR TITLE
Normalize humanoid infantry sprite scale to the RA1 rifleman baseline

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="922913a"
+ENGINE_VERSION="7ea6ac6"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/sequences/d2k.yaml
+++ b/mods/cameo/sequences/d2k.yaml
@@ -6583,6 +6583,7 @@ d2k_hijacker:
 facedancer:
 	Inherits: ^InfantryOverlays
 	Defaults:
+		Scale: 1.47
 		Filename: facedancer.shp
 	invisible:
 		Filename: DATA.R16
@@ -6702,6 +6703,7 @@ ordos_aatrooper:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: ordos_aatrooper.png
 	run:
 		Tick: 100
@@ -6740,6 +6742,7 @@ ordos_mortar:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.71
 		Filename: ordos_mortar.png
 	run:
 		Tick: 100

--- a/mods/cameo/sequences/redalert.yaml
+++ b/mods/cameo/sequences/redalert.yaml
@@ -6,7 +6,7 @@ redguard:
 	Inherits: ^InfantryOverlays
 	Defaults:
 		Filename: redguard.shp
-		Scale: 1.6
+		Scale: 1.38
 	stand:
 		Facings: 8
 	stand2:
@@ -103,7 +103,7 @@ japanesesoldier:
 	Inherits: ^InfantryOverlays
 	Defaults:
 		Filename: redguard.shp
-		Scale: 1.6
+		Scale: 1.38
 	stand:
 		Facings: 8
 	stand2:
@@ -516,7 +516,7 @@ raje3:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: scybgm.shp
-		Scale: 1
+		Scale: 0.69
 	stand:
 		Start: 160
 		Facings: 8
@@ -870,6 +870,7 @@ e7:
 
 gnrl:
 	Defaults:
+		Scale: 0.96
 		Filename: gnrl.shp
 	Inherits: ^InfantryOverlays
 	stand:
@@ -936,7 +937,7 @@ gnrl:
 volkov:
 	Inherits: gnrl
 	Defaults:
-		Scale: 1.5
+		Scale: 1.2
 	icon:
 		Filename: volkovicon.png
 
@@ -1026,6 +1027,7 @@ ra_conscript_ak:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.59
 		Filename: ra_cons_ak.png
 		#Scale: 0.75
 	run:
@@ -1065,6 +1067,7 @@ ra_cons_molo:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.59
 		Filename: ra_cons_molo.png
 		#Scale: 0.75
 	run:
@@ -1104,6 +1107,7 @@ ra_dragunov:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.51
 		Filename: ra_dragunov.png
 		#Scale: 0.75
 	run:
@@ -1143,6 +1147,7 @@ ra_commissar:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.61
 		Filename: ra_commissar.png
 	run:
 		Tick: 48
@@ -1181,6 +1186,7 @@ ra_zapper:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.59
 		Filename: ra_zapper.png
 	run:
 		Tick: 96
@@ -1289,6 +1295,7 @@ raspy:
 
 einstein:
 	Defaults:
+		Scale: 0.65
 		Filename: einstein.shp
 	Inherits: ^InfantryOverlays
 	stand:
@@ -1422,7 +1429,7 @@ rachan:
 rasamurai:
 	Defaults:
 		Filename: rasamurai.shp
-		Scale: 0.8
+		Scale: 0.5
 	Inherits: ^InfantryOverlays
 	stand:
 		Facings: 8
@@ -1533,7 +1540,7 @@ rasamurai:
 ramaid:
 	Defaults:
 		Filename: ramaid.shp
-		Scale: 0.8
+		Scale: 0.58
 	Inherits: ^InfantryOverlays
 	stand:
 		Facings: 8
@@ -5058,7 +5065,7 @@ rapierjumpjet:
 hakurei:
 	Defaults:
 		Filename: hakurei.shp
-		Scale: 1.333
+		Scale: 0.96
 	Inherits: ^InfantryOverlays
 	stand:
 		Start: 1

--- a/mods/cameo/sequences/redalert2.yaml
+++ b/mods/cameo/sequences/redalert2.yaml
@@ -5508,6 +5508,7 @@ ra2e1:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: ra2_gi.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5558,6 +5559,7 @@ ra2e1dep:
 yrggi:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.73
 		Filename: yr_ggi.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5622,6 +5624,7 @@ yrggidep:
 ra2snipe:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.81
 		Filename: ra2_snipe.shp
 	paradrop:
 		Start: 292
@@ -5632,6 +5635,7 @@ ra2e2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_cons.shp
 	run:
 		Tick: 120
@@ -5643,6 +5647,7 @@ ra2e2.black:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_bcons.shp
 	run:
 		Tick: 120
@@ -5654,6 +5659,7 @@ ra2e2.black:
 ra2terror:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_trst.shp
 	run:
 		Tick: 120
@@ -5693,6 +5699,7 @@ ra2terror:
 ra2flakt:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.52
 		Filename: ra2_flakt.shp
 	run:
 		Tick: 120
@@ -5720,6 +5727,7 @@ ra2flakt:
 ra2sidewind:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.61
 		Filename: ra2_sidewinder.shp
 	run:
 		Tick: 120
@@ -5737,6 +5745,7 @@ ra2sidewind:
 ra2deso:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.65
 		Filename: ra2_deso.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5761,6 +5770,7 @@ ra2deso:
 ra2ivan:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.85
 		Filename: ra2_ivan.shp
 	run:
 		Tick: 120
@@ -5781,6 +5791,7 @@ ra2ivan:
 ra2shk:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.76
 		Filename: ra2_shk.shp
 	idle:
 	run:
@@ -5801,6 +5812,7 @@ ra2shk.bot:
 ra2tany:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_tany.shp
 	run:
 		Tick: 120
@@ -5857,6 +5869,7 @@ ra2tany:
 yrinit:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.67
 		Filename: yr_init.shp
 	run:
 		Tick: 120
@@ -5887,6 +5900,7 @@ yrinit:
 yrslav:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
+		Scale: 0.8
 		Filename: yr_slav.shp
 	idle:
 		Filename: invisibleitem.shp
@@ -5949,6 +5963,7 @@ yrbrute:
 yrvirus:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: yr_virus.shp
 	run:
 		Tick: 120
@@ -5970,6 +5985,7 @@ yrvirus:
 ra2yuri:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_yuri.shp
 	deploy:
 		Start: 292
@@ -5993,6 +6009,7 @@ ra2yuri:
 ra2engineer:
 	Inherits: ^RA2Infantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_engineer.shp
 	paradrop:
 		Start: 244
@@ -6032,6 +6049,7 @@ ra2dog:
 yryurix:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.8
 		Filename: yr_yurix.shp
 	idle1:
 		Start: 56
@@ -6061,6 +6079,7 @@ yryurix:
 ra2spy:
 	Inherits: ^RA2Infantry
 	Defaults:
+		Scale: 0.88
 		Filename: ra2_spy.shp
 	liedown:
 		Start: 164
@@ -6074,6 +6093,7 @@ ra2spy:
 ra2seal: # TODO: seala on SNOW
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_seal.shp
 	run:
 		Tick: 120
@@ -6124,6 +6144,7 @@ ra2seal: # TODO: seala on SNOW
 ra2cleg:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
+		Scale: 0.76
 		Filename: ra2_cleg.shp
 	run:
 		Start: 117
@@ -6149,6 +6170,7 @@ ra2cleg:
 yrboris:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.73
 		Filename: yr_boris.shp
 	run:
 		Tick: 120
@@ -6186,6 +6208,7 @@ yrboris:
 yrbiot:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.63
 		Filename: ra2_biotroop.shp
 	paradrop:
 		Start: 292
@@ -7598,6 +7621,7 @@ yrarnd:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: arnd.shp
 	run:
 		Tick: 120
@@ -7611,6 +7635,7 @@ yrarnd:
 yrstln:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 1.47
 		Filename: yrstln.shp
 	run:
 		Tick: 120

--- a/mods/cameo/sequences/redalert2mod.yaml
+++ b/mods/cameo/sequences/redalert2mod.yaml
@@ -912,6 +912,7 @@ aa_awall:
 aa_gren:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: aa_gren.shp
 	run:
 		Tick: 120
@@ -961,7 +962,7 @@ aa_japrif:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_japrif.shp
-		Scale: 0.75
+		Scale: 0.52
 		Offset: 0,-16
 	stand:
 		ShadowStart: 253
@@ -1030,7 +1031,7 @@ aa_samurai:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_samurai.shp
-		Scale: 0.9
+		Scale: 0.8
 	stand:
 		ShadowStart: 429
 	run:
@@ -1162,7 +1163,7 @@ aa_shinobi:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_shinobi.shp
-		Scale: 0.9
+		Scale: 0.79
 	stand:
 		ShadowStart: 829
 	run:
@@ -1227,6 +1228,7 @@ aa_shinobi:
 aa_asdf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
+		Scale: 0.79
 		Filename: aa_asdf.shp
 	stand:
 		ShadowStart: 188
@@ -1268,6 +1270,7 @@ aa_asdf:
 aa_commando:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.81
 		Filename: ra2_snipe.shp
 	paradrop:
 		Start: 292
@@ -1293,6 +1296,7 @@ aa_banzai2:
 aa_tkiller:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
+		Scale: 0.69
 		Filename: aa_tkiller.shp
 	run:
 		Tick: 120
@@ -1311,6 +1315,7 @@ aa_tkiller:
 aa_plast:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
+		Scale: 0.73
 		Filename: aa_plast.shp
 	run:
 		Tick: 120
@@ -1335,6 +1340,7 @@ aa_plast:
 aa_flam:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
+		Scale: 0.73
 		Filename: aa_flam.shp
 	idle:
 	shoot:
@@ -3054,6 +3060,7 @@ latin_mili:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.79
 		Filename: latin_mili.shp
 	run:
 		Tick: 120
@@ -3085,6 +3092,7 @@ latin_fftr:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.88
 		Filename: latin_fftr.shp
 	run:
 		Tick: 120
@@ -3132,6 +3140,7 @@ latin_narco:
 	Inherits: ^RA2ArmedCivilian
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: latin_narco.shp
 	idle2:
 		Start: 56
@@ -3166,6 +3175,7 @@ latin_fthrow:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: latin_fthrow.shp
 	run:
 		Tick: 120
@@ -3216,6 +3226,7 @@ latin_witch:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.59
 		Filename: latin_witch.shp
 	run:
 		Tick: 120
@@ -3997,7 +4008,7 @@ steel_fedinf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: steel_fedinf.shp
-		Scale: 1.0
+		Scale: 0.67
 		Offset: 0,-4
 	stand:
 		ShadowStart: 281
@@ -4070,7 +4081,7 @@ steel_qinf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: steel_qinf.shp
-		Scale: 1.0
+		Scale: 0.76
 		Offset: 0,-4
 	stand:
 		ShadowStart: 332
@@ -4161,7 +4172,7 @@ steel_fedeng:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: steel_fedeng.shp
-		Scale: 1.0
+		Scale: 1.1
 		Offset: 0,-4
 	stand:
 		ShadowStart: 338
@@ -4200,7 +4211,7 @@ steel_board_inf:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: steel_board_inf.shp
-		Scale: 1.0
+		Scale: 0.6
 		Offset: 0,-4
 	stand:
 		ShadowStart: 303
@@ -5688,7 +5699,7 @@ nax_rifle:
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
 		Filename: nax_rifle.shp
-		Scale: 0.9
+		Scale: 0.65
 	run:
 		Tick: 120
 	paradrop:
@@ -5700,6 +5711,7 @@ nax_mp40:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.61
 		Filename: nax_mp40.shp
 	run:
 		Tick: 120
@@ -5712,6 +5724,7 @@ nax_shrek:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.6
 		Filename: nax_shrek.shp
 	run:
 		Tick: 120
@@ -5807,6 +5820,7 @@ nax2_parv:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.7
 		Filename: nax2_parzi.shp
 	run:
 		Tick: 100
@@ -6359,6 +6373,7 @@ nax_slavemaster:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.76
 		Filename: nax_litt.shp
 	run:
 		Tick: 120
@@ -6370,6 +6385,7 @@ nax_slavemaster:
 nax_slav:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
+		Scale: 0.8
 		Filename: yr_slav.shp
 	idle:
 		Filename: invisibleitem.shp
@@ -6762,6 +6778,7 @@ nax_tuboat:
 nax_frank:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
+		Scale: 0.76
 		Filename: nax_frank.shp
 	stand:
 		#ShadowStart: 164
@@ -6797,7 +6814,7 @@ nax_merc:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_merc.shp
-		Scale: 0.75
+		Scale: 0.52
 		Offset: 0,0
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6816,7 +6833,7 @@ nax_cons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_cons.shp
-		Scale: 0.75
+		Scale: 0.54
 		Offset: 0,0
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6835,7 +6852,7 @@ nax_tcons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_tcons.shp
-		Scale: 0.75
+		Scale: 0.52
 		Offset: 0,-16
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6854,7 +6871,7 @@ nax_fcons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_fcons.shp
-		Scale: 0.75
+		Scale: 0.51
 		Offset: 0,-16
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6873,7 +6890,7 @@ nax_hmg:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: nax_hmg.shp
-		Scale: 0.75
+		Scale: 0.5
 		Offset: 0,-4
 	stand:
 		ShadowStart: 271
@@ -6955,7 +6972,7 @@ nax_quadflak:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: nax_quadflak.shp
-		Scale: 0.75
+		Scale: 0.6
 		Offset: 0,-4
 		FlipX: True
 	stand:
@@ -7066,7 +7083,7 @@ nax_alien:
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
 		Filename: nax_alien.shp
-		Scale: 0.75
+		Scale: 0.79
 		Offset: 0,-16
 	stand:
 	run:
@@ -7255,6 +7272,7 @@ nax_lunar:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.8
 		Filename: nax_lunar.shp
 	run:
 		Tick: 100
@@ -7293,6 +7311,7 @@ nax_lunar2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.8
 		Filename: nax_lunar2.shp
 	run:
 		Tick: 100
@@ -7331,6 +7350,7 @@ nax2_uber:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.7
 		Filename: nax2_uber.shp
 	run:
 		Tick: 100
@@ -7369,6 +7389,7 @@ nax_undead:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.69
 		Filename: nax_undead.shp
 	run:
 		Tick: 100
@@ -7455,6 +7476,7 @@ nax_conehead:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.56
 		Filename: nax_conehead.png
 	run:
 		Tick: 100
@@ -7492,6 +7514,7 @@ nax_conehead2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
+		Scale: 0.56
 		Filename: nax_conehead2.png
 	run:
 		Tick: 100
@@ -8087,6 +8110,7 @@ futu_ggmlt:
 futu_enforcer:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: futu_enforcer.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -8125,6 +8149,7 @@ futu_enforcer:
 futu_javelinsoldier:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.7
 		Filename: futu_javelinsoldier.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -8774,6 +8799,7 @@ yrrobo:
 futu_spy:
 	Inherits: ^RA2Infantry
 	Defaults:
+		Scale: 0.88
 		Filename: ra2_spy.shp
 	liedown:
 		Start: 164
@@ -8787,6 +8813,7 @@ futu_spy:
 futu_blackwidow:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.79
 		Filename: ra2_tany_black.shp
 	run:
 		Tick: 120

--- a/mods/cameo/sequences/tiberiandawn.yaml
+++ b/mods/cameo/sequences/tiberiandawn.yaml
@@ -2279,6 +2279,7 @@ tsblackhandlaser2:
 	Inherits: ^BasicInfantryTibsun
 	Inherits@attack: ^BasicInfantryAttackTibsun
 	Defaults:
+		Scale: 1.16
 		Filename: tsblackhandlaser.shp
 	icon:
 		Filename: tsblackhandlasericon.shp
@@ -2288,13 +2289,14 @@ tsblackhandflamer:
 	Inherits@attack: ^BasicInfantryAttackTibsun
 	Defaults:
 		Filename: tsblackhandflamer.shp
-		Scale: 1.333
+		Scale: 1.1
 	icon:
 		Filename: tsblackhandflamericon.shp
 tsstealthsoldier2:
 	Inherits: ^BasicInfantryTibsun
 	Inherits@attack: ^BasicInfantryAttackTibsun
 	Defaults:
+		Scale: 1.05
 		Filename: tsstealthsoldier.shp
 	icon:
 		Filename: tsstealthsoldiericon.shp
@@ -2306,7 +2308,7 @@ stealthtech:
 tsstealthsoldier:
 	Defaults:
 		Filename: nodstealthsoldier.shp
-		Scale: 1.333
+		Scale: 0.96
 	Inherits: ^InfantryOverlays
 	stand:
 		Start: 1
@@ -2421,7 +2423,7 @@ tsstealthsoldier:
 tsblackhandlaser:
 	Defaults:
 		Filename: tdlasertroop.shp
-		Scale: 1.4
+		Scale: 0.92
 	Inherits: ^InfantryOverlays
 	stand:
 		Start: 1
@@ -2682,7 +2684,7 @@ zombie:
 	Inherits: ^InfantryOverlays
 	Defaults:
 		Filename: zombie.shp
-		Scale: 2
+		Scale: 1.47
 	stand:
 		Facings: 8
 	stand2:
@@ -3075,6 +3077,7 @@ chemtibatomic:
 gdiofficer:
 	Inherits: ^InfantryOverlays
 	Defaults:
+		Scale: 0.71
 		Filename: modofficer.shp
 	stand:
 		Facings: 8
@@ -3199,6 +3202,7 @@ deadsixrmbo:
 moddeadeye:
 	Inherits: rmbo
 	Defaults: moddeadeye
+		Scale: 2
 		Filename: moddeadeye.shp
 	icon:
 		Filename: deadsixicon.shp
@@ -3209,6 +3213,7 @@ moddeadeye:
 modgunner:
 	Inherits: rmbo
 	Defaults: modgunner
+		Scale: 2
 		Filename: modgunner.shp
 	icon:
 		Filename: deadsixicon.shp
@@ -3219,6 +3224,7 @@ modgunner:
 modhotwire:
 	Inherits: rmbo
 	Defaults: modhotwire
+		Scale: 2
 		Filename: modhotwire.shp
 	icon:
 		Filename: deadsixicon.shp
@@ -3229,6 +3235,7 @@ modhotwire:
 modrpatch:
 	Inherits: rmbo
 	Defaults: modrpatch
+		Scale: 2
 		Filename: modrpatch.shp
 	icon:
 		Filename: deadsixicon.shp
@@ -3239,6 +3246,7 @@ modrpatch:
 modsakura:
 	Inherits: rmbo
 	Defaults: modsakura
+		Scale: 2
 		Filename: modsakura.shp
 	icon:
 		Filename: deadsixicon.shp
@@ -3468,7 +3476,7 @@ gdiempgrenadier:
 	Inherits: ^InfantryOverlays
 	Defaults:
 		Filename: tdempgrenadier.shp
-		Scale: 1.4
+		Scale: 0.96
 	stand:
 		Start: 1
 		Facings: 8
@@ -3581,6 +3589,7 @@ gdiempgrenadier:
 gdishotgunner:
 	Inherits: ^InfantryOverlays
 	Defaults:
+		Scale: 0.92
 		Filename: tdshotgunner.shp
 	stand:
 		Facings: 8
@@ -3693,7 +3702,7 @@ gdishotgunner:
 gdisniper:
 	Defaults:
 		Filename: gdisniper.shp
-		Scale: 1.4
+		Scale: 0.96
 	Inherits: ^InfantryOverlays
 	stand:
 		Start: 1
@@ -3866,7 +3875,7 @@ gdihavoc:
 	Inherits@2: ^RA2InfantryDeaths
 	Defaults:
 		Filename: havoc.shp
-		Scale: 1.333
+		Scale: 0.8
 	stand:
 		Facings: 8
 	stand2:
@@ -3980,7 +3989,7 @@ nodlasercommando:
 	Inherits@2: ^RA2InfantryDeaths
 	Defaults:
 		Filename: nodlasercommando.shp
-		Scale: 1.333
+		Scale: 0.79
 	stand:
 		Facings: 8
 	stand2:

--- a/mods/cameo/sequences/tkm.yaml
+++ b/mods/cameo/sequences/tkm.yaml
@@ -107,7 +107,7 @@ tkmworker:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
 		Filename: modwor.shp
-		Scale: 0.6
+		Scale: 0.51
 	idle:
 		Filename: invisibleitem.shp
 	run:
@@ -867,6 +867,7 @@ tkmengineer:
 tkmvon:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
+		Scale: 0.81
 		Filename: ra2_snipe.shp
 	paradrop:
 		Start: 292


### PR DESCRIPTION
Normalizes the on-screen size of humanoid infantry so every faction's infantry reads at the same height as the RA1 rifle infantry (`e1`), used as the reference.

## What changed
Per-image `Scale:` set in the sequence definitions for humanoid infantry across:
`tiberiandawn`, `redalert`, `redalert2`, `redalert2mod`, `d2k`, `tkm`.

Scales are derived from each sprite's measured opaque stand-frame height (reference height ÷ sprite height), with manual adjustments for a handful of units (heroes/oversized-by-design kept larger).

## Scope
- **Excluded:** animals and non-humanoid creatures (dogs, ants, crab, visceroids, brute, etc.).
- **Untouched:** Tiberian Sun, Warcraft and StarCraft factions.

YAML-only — no engine change, no rebuild required.