### PR TITLE
Revert RA2 and RA2-mod infantry scale to original (with per-unit exceptions)

### DIFF
--- a/mods/cameo/sequences/redalert2.yaml
+++ b/mods/cameo/sequences/redalert2.yaml
@@ -5508,7 +5508,6 @@ ra2e1:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.76
 		Filename: ra2_gi.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5559,7 +5558,6 @@ ra2e1dep:
 yrggi:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.73
 		Filename: yr_ggi.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5624,7 +5622,6 @@ yrggidep:
 ra2snipe:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.81
 		Filename: ra2_snipe.shp
 	paradrop:
 		Start: 292
@@ -5635,7 +5632,6 @@ ra2e2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_cons.shp
 	run:
 		Tick: 120
@@ -5647,7 +5643,6 @@ ra2e2.black:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_bcons.shp
 	run:
 		Tick: 120
@@ -5659,7 +5654,6 @@ ra2e2.black:
 ra2terror:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_trst.shp
 	run:
 		Tick: 120
@@ -5699,7 +5693,6 @@ ra2terror:
 ra2flakt:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.52
 		Filename: ra2_flakt.shp
 	run:
 		Tick: 120
@@ -5727,7 +5720,6 @@ ra2flakt:
 ra2sidewind:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.61
 		Filename: ra2_sidewinder.shp
 	run:
 		Tick: 120
@@ -5745,7 +5737,6 @@ ra2sidewind:
 ra2deso:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.65
 		Filename: ra2_deso.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -5770,7 +5761,6 @@ ra2deso:
 ra2ivan:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.85
 		Filename: ra2_ivan.shp
 	run:
 		Tick: 120
@@ -5791,7 +5781,6 @@ ra2ivan:
 ra2shk:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.76
 		Filename: ra2_shk.shp
 	idle:
 	run:
@@ -5812,7 +5801,6 @@ ra2shk.bot:
 ra2tany:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_tany.shp
 	run:
 		Tick: 120
@@ -5869,7 +5857,6 @@ ra2tany:
 yrinit:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.67
 		Filename: yr_init.shp
 	run:
 		Tick: 120
@@ -5900,7 +5887,6 @@ yrinit:
 yrslav:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
-		Scale: 0.8
 		Filename: yr_slav.shp
 	idle:
 		Filename: invisibleitem.shp
@@ -5963,7 +5949,6 @@ yrbrute:
 yrvirus:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: yr_virus.shp
 	run:
 		Tick: 120
@@ -5985,7 +5970,6 @@ yrvirus:
 ra2yuri:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_yuri.shp
 	deploy:
 		Start: 292
@@ -6009,7 +5993,6 @@ ra2yuri:
 ra2engineer:
 	Inherits: ^RA2Infantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_engineer.shp
 	paradrop:
 		Start: 244
@@ -6049,7 +6032,6 @@ ra2dog:
 yryurix:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.8
 		Filename: yr_yurix.shp
 	idle1:
 		Start: 56
@@ -6079,7 +6061,6 @@ yryurix:
 ra2spy:
 	Inherits: ^RA2Infantry
 	Defaults:
-		Scale: 0.88
 		Filename: ra2_spy.shp
 	liedown:
 		Start: 164
@@ -6093,7 +6074,6 @@ ra2spy:
 ra2seal: # TODO: seala on SNOW
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_seal.shp
 	run:
 		Tick: 120
@@ -6144,7 +6124,6 @@ ra2seal: # TODO: seala on SNOW
 ra2cleg:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
-		Scale: 0.76
 		Filename: ra2_cleg.shp
 	run:
 		Start: 117
@@ -6170,7 +6149,6 @@ ra2cleg:
 yrboris:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.73
 		Filename: yr_boris.shp
 	run:
 		Tick: 120
@@ -6208,7 +6186,6 @@ yrboris:
 yrbiot:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.63
 		Filename: ra2_biotroop.shp
 	paradrop:
 		Start: 292
@@ -7621,7 +7598,6 @@ yrarnd:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.76
 		Filename: arnd.shp
 	run:
 		Tick: 120
@@ -7635,7 +7611,6 @@ yrarnd:
 yrstln:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 1.47
 		Filename: yrstln.shp
 	run:
 		Tick: 120

--- a/mods/cameo/sequences/redalert2mod.yaml
+++ b/mods/cameo/sequences/redalert2mod.yaml
@@ -912,7 +912,6 @@ aa_awall:
 aa_gren:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: aa_gren.shp
 	run:
 		Tick: 120
@@ -962,7 +961,7 @@ aa_japrif:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_japrif.shp
-		Scale: 0.52
+		Scale: 0.75
 		Offset: 0,-16
 	stand:
 		ShadowStart: 253
@@ -1031,7 +1030,7 @@ aa_samurai:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_samurai.shp
-		Scale: 0.8
+		Scale: 0.9
 	stand:
 		ShadowStart: 429
 	run:
@@ -1163,7 +1162,7 @@ aa_shinobi:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: aa_shinobi.shp
-		Scale: 0.79
+		Scale: 0.9
 	stand:
 		ShadowStart: 829
 	run:
@@ -1228,7 +1227,6 @@ aa_shinobi:
 aa_asdf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
-		Scale: 0.79
 		Filename: aa_asdf.shp
 	stand:
 		ShadowStart: 188
@@ -1270,7 +1268,6 @@ aa_asdf:
 aa_commando:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.81
 		Filename: ra2_snipe.shp
 	paradrop:
 		Start: 292
@@ -1296,7 +1293,7 @@ aa_banzai2:
 aa_tkiller:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
-		Scale: 0.69
+		Scale: 0.9
 		Filename: aa_tkiller.shp
 	run:
 		Tick: 120
@@ -1315,7 +1312,6 @@ aa_tkiller:
 aa_plast:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
-		Scale: 0.73
 		Filename: aa_plast.shp
 	run:
 		Tick: 120
@@ -1340,7 +1336,6 @@ aa_plast:
 aa_flam:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
-		Scale: 0.73
 		Filename: aa_flam.shp
 	idle:
 	shoot:
@@ -3060,7 +3055,6 @@ latin_mili:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.79
 		Filename: latin_mili.shp
 	run:
 		Tick: 120
@@ -3092,7 +3086,6 @@ latin_fftr:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.88
 		Filename: latin_fftr.shp
 	run:
 		Tick: 120
@@ -3140,7 +3133,6 @@ latin_narco:
 	Inherits: ^RA2ArmedCivilian
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.76
 		Filename: latin_narco.shp
 	idle2:
 		Start: 56
@@ -3175,7 +3167,6 @@ latin_fthrow:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.76
 		Filename: latin_fthrow.shp
 	run:
 		Tick: 120
@@ -3226,7 +3217,7 @@ latin_witch:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.59
+		Scale: 0.8
 		Filename: latin_witch.shp
 	run:
 		Tick: 120
@@ -4008,7 +3999,7 @@ steel_fedinf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: steel_fedinf.shp
-		Scale: 0.67
+		Scale: 0.8
 		Offset: 0,-4
 	stand:
 		ShadowStart: 281
@@ -4081,7 +4072,7 @@ steel_qinf:
 	Inherits: ^RA2ArmedInfantryNoProneAnimation
 	Defaults:
 		Filename: steel_qinf.shp
-		Scale: 0.76
+		Scale: 0.8
 		Offset: 0,-4
 	stand:
 		ShadowStart: 332
@@ -4172,7 +4163,7 @@ steel_fedeng:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: steel_fedeng.shp
-		Scale: 1.1
+		Scale: 1.0
 		Offset: 0,-4
 	stand:
 		ShadowStart: 338
@@ -4211,7 +4202,7 @@ steel_board_inf:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: steel_board_inf.shp
-		Scale: 0.6
+		Scale: 0.7
 		Offset: 0,-4
 	stand:
 		ShadowStart: 303
@@ -5699,7 +5690,7 @@ nax_rifle:
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
 		Filename: nax_rifle.shp
-		Scale: 0.65
+		Scale: 0.7
 	run:
 		Tick: 120
 	paradrop:
@@ -5711,7 +5702,6 @@ nax_mp40:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.61
 		Filename: nax_mp40.shp
 	run:
 		Tick: 120
@@ -5724,7 +5714,7 @@ nax_shrek:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.6
+		Scale: 0.7
 		Filename: nax_shrek.shp
 	run:
 		Tick: 120
@@ -5820,7 +5810,6 @@ nax2_parv:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.7
 		Filename: nax2_parzi.shp
 	run:
 		Tick: 100
@@ -6373,7 +6362,6 @@ nax_slavemaster:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.76
 		Filename: nax_litt.shp
 	run:
 		Tick: 120
@@ -6385,7 +6373,6 @@ nax_slavemaster:
 nax_slav:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
-		Scale: 0.8
 		Filename: yr_slav.shp
 	idle:
 		Filename: invisibleitem.shp
@@ -6778,7 +6765,6 @@ nax_tuboat:
 nax_frank:
 	Inherits: ^RA2BasicInfantry
 	Defaults:
-		Scale: 0.76
 		Filename: nax_frank.shp
 	stand:
 		#ShadowStart: 164
@@ -6814,7 +6800,7 @@ nax_merc:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_merc.shp
-		Scale: 0.52
+		Scale: 0.75
 		Offset: 0,0
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6833,7 +6819,7 @@ nax_cons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_cons.shp
-		Scale: 0.54
+		Scale: 0.75
 		Offset: 0,0
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6852,7 +6838,7 @@ nax_tcons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_tcons.shp
-		Scale: 0.52
+		Scale: 0.7
 		Offset: 0,-16
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6871,7 +6857,7 @@ nax_fcons:
 	Inherits: ^RA2ModDafoolWW2Infantry
 	Defaults:
 		Filename: nax_fcons.shp
-		Scale: 0.51
+		Scale: 0.75
 		Offset: 0,-16
 	garrison-muzzle:
 		Filename: minigun.shp
@@ -6890,7 +6876,7 @@ nax_hmg:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
 		Filename: nax_hmg.shp
-		Scale: 0.5
+		Scale: 0.6
 		Offset: 0,-4
 	stand:
 		ShadowStart: 271
@@ -7083,7 +7069,7 @@ nax_alien:
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
 		Filename: nax_alien.shp
-		Scale: 0.79
+		Scale: 0.75
 		Offset: 0,-16
 	stand:
 	run:
@@ -7272,7 +7258,6 @@ nax_lunar:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.8
 		Filename: nax_lunar.shp
 	run:
 		Tick: 100
@@ -7311,7 +7296,6 @@ nax_lunar2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.8
 		Filename: nax_lunar2.shp
 	run:
 		Tick: 100
@@ -7350,7 +7334,6 @@ nax2_uber:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.7
 		Filename: nax2_uber.shp
 	run:
 		Tick: 100
@@ -7389,7 +7372,6 @@ nax_undead:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.69
 		Filename: nax_undead.shp
 	run:
 		Tick: 100
@@ -7476,7 +7458,7 @@ nax_conehead:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.56
+		Scale: 0.7
 		Filename: nax_conehead.png
 	run:
 		Tick: 100
@@ -7514,7 +7496,7 @@ nax_conehead2:
 	Inherits: ^RA2ArmedInfantry
 	Inherits@2: ^RA2MachineGunMuzzle
 	Defaults:
-		Scale: 0.56
+		Scale: 0.7
 		Filename: nax_conehead2.png
 	run:
 		Tick: 100
@@ -8110,7 +8092,6 @@ futu_ggmlt:
 futu_enforcer:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: futu_enforcer.shp
 	dot:
 		Filename: invisibleitem.shp
@@ -8799,7 +8780,6 @@ yrrobo:
 futu_spy:
 	Inherits: ^RA2Infantry
 	Defaults:
-		Scale: 0.88
 		Filename: ra2_spy.shp
 	liedown:
 		Start: 164
@@ -8813,7 +8793,6 @@ futu_spy:
 futu_blackwidow:
 	Inherits: ^RA2ArmedInfantry
 	Defaults:
-		Scale: 0.79
 		Filename: ra2_tany_black.shp
 	run:
 		Tick: 120


### PR DESCRIPTION
Follow-up to the infantry scale normalization (#146). The normalized sizes didn't suit the Red Alert 2 / RA2-based mod factions, so this restores their original sprite scale per-unit.

## What changed
- **RA2 (`redalert2`)** — all infantry reverted to original scale.
- **RA2-mod (`redalert2mod`)** — reverted to original, except these units keep a manual scale:
  - `aa_tkiller` 0.9
  - `latin_witch`, `steel_fedinf`, `steel_qinf` 0.8
  - `futu_javelinsoldier`, `nax_conehead`, `nax_conehead2`, `nax_shrek`, `nax_tcons`, `steel_board_inf`, `nax_rifle` 0.7
  - `nax_hmg`, `nax_quadflak` 0.6

Other factions (TD, RA1, D2k, tkm) keep the normalized scale from #146. YAML-only, no engine change.