### PR TITLE
Fix Latin Syndicate Bunker Tower sprite centering

### DIFF
--- a/mods/cameo/sequences/redalert2mod.yaml
+++ b/mods/cameo/sequences/redalert2mod.yaml
@@ -2420,8 +2420,6 @@ latin_cgair:
 		Offset: 0,0
 
 latin_ngbunk2:
-	Defaults:
-		Offset: 0, 24
 	idle:
 		Filename: latin_nagaurd.shp
 		ShadowStart: 4


### PR DESCRIPTION
## Problem

The Latin Syndicate **Bunker Tower** (`latin_ngbunk2`) renders too low — the bottom of the sprite bleeds into the tile to the south.

## Cause

The `latin_ngbunk2` sequence block carried `Defaults: Offset: 0, 24`. Its art (`latin_nagaurd.shp`, plus the `_a` overlay and `mk` make animation) are full-size 640×480 RA2/TS canvases, so OpenRA's ShpTS loader already derives the correct on-screen offset from each frame's placement within the canvas (frame 0 intrinsic ≈ −1, −24). The explicit `Offset: 0, 24` exactly cancelled that intrinsic −24, shifting the whole building 24px down so its base overran the cell below.

## Fix

Remove the `Offset: 0, 24` so all three sub-sprites render at their authored full-canvas alignment (they share the same coordinate system, so they stay mutually aligned).

YAML-only change — no rebuild required, just a game restart.