### PR TITLE
Add migration tooling: --faction-report, --export-cameos, map-to-CA script

### DIFF
--- a/OpenRA.Mods.Cameo/UtilityCommands/ExportCameosCommand.cs
+++ b/OpenRA.Mods.Cameo/UtilityCommands/ExportCameosCommand.cs
@@ -1,0 +1,200 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.UtilityCommands
+{
+	// Exports the production cameo (icon sequence) of every buildable actor to an
+	// individual PNG in one ModData preload, for the external tech-tree website.
+	// Each cameo is rendered with the actor's declared Buildable.IconPalette (so
+	// d2kunit/ra2/windows256/... cameos get their correct colours, not chrome).
+	// File names match the website extractor's icon_basename(): lowercased actor
+	// name with any non [a-z0-9._-] run collapsed to '_', plus ".png".
+	sealed class ExportCameosCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name => "--export-cameos";
+
+		bool IUtilityCommand.ValidateArguments(string[] args) => true;
+
+		[Desc("[OUTPUT-DIR]",
+			"Export every buildable actor's cameo icon to a PNG (default dir 'cameos').")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			var modData = Game.ModData = utility.ModData;
+			var rules = modData.DefaultRules;
+
+			var outDir = args.Length > 1 ? args[1] : "cameos";
+			Directory.CreateDirectory(outDir);
+
+			var palettes = LoadPalettes(modData, rules);
+			palettes.TryGetValue("chrome", out var chrome);
+
+			// A representative tileset for sprite resolution (cameos are tileset-independent;
+			// CameoSpriteSequence only varies by tileset for explicit TilesetFilenames).
+			var tileset = modData.DefaultTerrainInfo.Keys
+				.FirstOrDefault(t => t.Equals("TEMPERAT", StringComparison.OrdinalIgnoreCase))
+				?? modData.DefaultTerrainInfo.Keys.First();
+
+			using var sequences = new SequenceSet(modData.ModFiles, modData, tileset, null);
+			sequences.LoadSprites();
+			var haveImage = new HashSet<string>(sequences.Images, StringComparer.Ordinal);
+
+			int ok = 0, missing = 0, failed = 0;
+			foreach (var actorInfo in rules.Actors)
+			{
+				if (actorInfo.Key.StartsWith(ActorInfo.AbstractActorPrefix))
+					continue;
+
+				var buildable = actorInfo.Value.TraitInfoOrDefault<BuildableInfo>();
+				if (buildable == null)
+					continue;
+
+				var render = actorInfo.Value.TraitInfoOrDefault<RenderSpritesInfo>();
+				var image = (render != null ? render.GetImage(actorInfo.Value, null) : actorInfo.Key).ToLowerInvariant();
+				var iconSeq = string.IsNullOrEmpty(buildable.Icon) ? "icon" : buildable.Icon;
+
+				if (!haveImage.Contains(image) || !sequences.HasSequence(image, iconSeq))
+				{
+					missing++;
+					continue;
+				}
+
+				var palName = string.IsNullOrEmpty(buildable.IconPalette) ? "chrome" : buildable.IconPalette;
+				var palette = palettes.GetValueOrDefault(palName) ?? chrome;
+
+				try
+				{
+					var sprite = sequences.GetSequence(image, iconSeq).GetSprite(0);
+					var png = SpriteToPng(sprite, palette);
+					if (png == null)
+					{
+						failed++;
+						continue;
+					}
+
+					png.Save(Path.Combine(outDir, Canonical(actorInfo.Key)));
+					ok++;
+				}
+				catch (Exception)
+				{
+					failed++;
+				}
+			}
+
+			Console.Error.WriteLine($"export-cameos: wrote {ok} cameos to {outDir} ({missing} without an icon sequence, {failed} failed)");
+		}
+
+		// Resolve every named palette the cameos might reference (chrome, d2kunit, ra2,
+		// windows256, ra2cameo, ...) to a concrete palette. File palettes are read
+		// directly; player-color palettes resolve to their base palette (cameos are
+		// drawn neutral, so the un-remapped base is the right colour set).
+		static Dictionary<string, ImmutablePalette> LoadPalettes(ModData modData, Ruleset rules)
+		{
+			var worldInfo = rules.Actors[SystemActors.World];
+
+			var filePalettes = new Dictionary<string, ImmutablePalette>(StringComparer.Ordinal);
+			foreach (var ti in worldInfo.TraitInfos<TraitInfo>())
+			{
+				if (ti is not IProvidesCursorPaletteInfo provides)
+					continue;
+
+				// PaletteFromFileInfo/PaletteFromPngInfo et al. expose the palette name as a `Name` field.
+				if (ti.GetType().GetField("Name")?.GetValue(ti) is not string name || string.IsNullOrEmpty(name))
+					continue;
+				if (filePalettes.ContainsKey(name))
+					continue;
+
+				try { filePalettes[name] = provides.ReadPalette(modData.DefaultFileSystem); }
+				catch (Exception) { }
+			}
+
+			// player-color palette prefix -> base palette name
+			var playerBase = new Dictionary<string, string>(StringComparer.Ordinal);
+			foreach (var ti in worldInfo.TraitInfos<PlayerColorPaletteInfo>())
+				if (!string.IsNullOrEmpty(ti.BaseName) && !playerBase.ContainsKey(ti.BaseName))
+					playerBase[ti.BaseName] = ti.BasePalette;
+
+			var resolved = new Dictionary<string, ImmutablePalette>(filePalettes, StringComparer.Ordinal);
+			foreach (var kv in playerBase)
+			{
+				if (resolved.ContainsKey(kv.Key))
+					continue;
+				var baseName = kv.Value;
+				var depth = 0;
+				while (baseName != null && depth++ < 8 && !filePalettes.ContainsKey(baseName))
+					baseName = playerBase.GetValueOrDefault(baseName);
+				if (baseName != null && filePalettes.TryGetValue(baseName, out var pal))
+					resolved[kv.Key] = pal;
+			}
+
+			return resolved;
+		}
+
+		static string Canonical(string actorName) =>
+			Regex.Replace(actorName.ToLowerInvariant(), "[^a-z0-9._-]+", "_") + ".png";
+
+		// Sheet.cs / Util.cs pack indexed sprites' bytes at this offset within each RGBA
+		// quad for a given logical TextureChannel (Red=0, Green=1, Blue=2, Alpha=3) - the
+		// channel enum value is NOT the byte offset (see Util.ChannelMasks: "our channel
+		// order is nuts"). Using the enum value directly reads the wrong sprite's data for
+		// Red/Blue-channel sprites (Green/Alpha happen to be self-mapped).
+		static readonly int[] ChannelByteOffset = { 2, 1, 0, 3 };
+
+		// Crop a single sprite out of its (shared) sheet into a standalone PNG.
+		static Png SpriteToPng(Sprite sprite, IPalette palette)
+		{
+			var b = sprite.Bounds;
+			if (b.Width <= 0 || b.Height <= 0)
+				return null;
+
+			var sheet = sprite.Sheet;
+			var data = sheet.GetData();
+			var stride = 4 * sheet.Size.Width;
+
+			if (sheet.Type == SheetType.Indexed)
+			{
+				if (palette == null)
+					return null;
+
+				// Each sheet pixel packs four sprites' palette indices (one per channel).
+				var ch = ChannelByteOffset[(int)sprite.Channel];
+				var plane = new byte[b.Width * b.Height];
+				for (var y = 0; y < b.Height; y++)
+					for (var x = 0; x < b.Width; x++)
+						plane[y * b.Width + x] = data[(b.Top + y) * stride + 4 * (b.Left + x) + ch];
+
+				var palColors = new Color[Palette.Size];
+				for (var i = 0; i < Palette.Size; i++)
+					palColors[i] = palette.GetColor(i);
+
+				return new Png(plane, SpriteFrameType.Indexed8, b.Width, b.Height, palColors);
+			}
+
+			// BGRA sheet: copy the sub-rectangle directly.
+			var bgra = new byte[b.Width * b.Height * 4];
+			for (var y = 0; y < b.Height; y++)
+				Array.Copy(data, (b.Top + y) * stride + 4 * b.Left, bgra, y * b.Width * 4, b.Width * 4);
+
+			return new Png(bgra, SpriteFrameType.Bgra32, b.Width, b.Height);
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/UtilityCommands/FactionBuildableReportCommand.cs
+++ b/OpenRA.Mods.Cameo/UtilityCommands/FactionBuildableReportCommand.cs
@@ -1,0 +1,311 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.UtilityCommands
+{
+	// Classifies every actor by which factions can build/own it, using the engine's fully-resolved
+	// prerequisite graph (ProvidesPrerequisite incl. inherited templates) plus a tech-tree closure
+	// seeded from each faction's StartingUnits (deploy/transform chain). Output is machine-readable:
+	//   ACTORNAME<TAB>fac1,fac2     (the factions that can build/own it)
+	//   ACTORNAME<TAB>*SHARED       (all real factions)
+	//   ACTORNAME<TAB>*NONE         (no faction can build it - husk/civilian/support)
+	// Used to drive the per-faction ContentPacks migration of bare-named theme rules files.
+	sealed class FactionBuildableReportCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name => "--faction-report";
+
+		bool IUtilityCommand.ValidateArguments(string[] args) => true;
+
+		[Desc("[onlyPrefix]",
+			"Report, per actor, which factions can build/own it (engine prerequisite closure seeded from " +
+			"StartingUnits). Optional arg filters output to actor keys starting with the given prefix.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			var modData = Game.ModData = utility.ModData;
+			var rules = modData.DefaultRules;
+			var onlyPrefix = args.Length > 1 ? args[1] : null;
+
+			var byKey = new Dictionary<string, ActorInfo>(StringComparer.OrdinalIgnoreCase);
+			foreach (var ai in rules.Actors)
+				byKey[ai.Key] = ai.Value;
+
+			var world = rules.Actors[SystemActors.World];
+			var factions = world.TraitInfos<FactionInfo>()
+				.Where(f => !f.RandomFactionMembers.Any() && !string.IsNullOrEmpty(f.InternalName))
+				.Select(f => f.InternalName)
+				.ToArray();
+
+			// token (lower) -> list of (providerActor, restrictedFactions(lower) or null=all)
+			// token (lower) -> list of (providerActor, restrictedFactions(lower) or null=all). Index ALL
+			// ITechTreePrerequisite providers (ProvidesPrerequisite, ProvidesTechPrerequisite, lobby/support
+			// power grants, ...) so "no provider" genuinely means an unsatisfiable token (e.g. the bot-only
+			// 'defensebot' sentinel on ^BaseBuilding), not just a provider we failed to read.
+			var providers = new Dictionary<string, List<(string Actor, HashSet<string> Factions)>>(StringComparer.OrdinalIgnoreCase);
+			foreach (var ai in rules.Actors)
+			{
+				if (ai.Key.StartsWith(ActorInfo.AbstractActorPrefix))
+					continue;
+
+				List<ITechTreePrerequisiteInfo> pps;
+				try { pps = ai.Value.TraitInfos<ITechTreePrerequisiteInfo>().ToList(); }
+				catch { continue; }
+
+				foreach (var pp in pps)
+				{
+					var facs = pp is ProvidesPrerequisiteInfo ppi && ppi.Factions.Count > 0
+						? ppi.Factions.Select(f => f.ToLowerInvariant()).ToHashSet()
+						: null;
+					foreach (var raw in pp.Prerequisites(ai.Value))
+						providers.GetOrAdd(raw.ToLowerInvariant(), _ => new List<(string, HashSet<string>)>()).Add((ai.Key, facs));
+				}
+			}
+
+			// transforms target per actor (MCV -> conyard etc.)
+			string TransformTarget(ActorInfo ai)
+			{
+				try
+				{
+					var t = ai.TraitInfoOrDefault<TransformsInfo>();
+					return t?.IntoActor;
+				}
+				catch { return null; }
+			}
+
+			// Faction-variant suffix -> faction. A key "foo.allies" is the allies variant of foo and is
+			// faction-locked even when its generic prerequisites pass for everyone (the real lock is the
+			// faction-specific producer). Derive the tag->faction map from each faction's StartingUnits
+			// BaseActor (e.g. ramcv.japan -> modjapan), so it generalises across themes without hardcoding.
+			var startUnits = world.TraitInfos<StartingUnitsInfo>().ToList();
+			var factionBySuffix = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var su in startUnits)
+			{
+				if (string.IsNullOrEmpty(su.BaseActor) || !su.BaseActor.Contains('.'))
+					continue;
+				var suffix = su.BaseActor[(su.BaseActor.LastIndexOf('.') + 1)..];
+				foreach (var f in su.Factions)
+					if (factions.Contains(f))
+						factionBySuffix[suffix] = f;
+			}
+
+			string LockedFaction(string key)
+			{
+				var dot = key.LastIndexOf('.');
+				if (dot < 0)
+					return null;
+				return factionBySuffix.TryGetValue(key[(dot + 1)..], out var f) ? f : null;
+			}
+
+			// starting actors per faction (seed of the owned set)
+			var seedByFaction = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+			foreach (var f in factions)
+			{
+				var seed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+				void SeedAdd(string a)
+				{
+					if (string.IsNullOrEmpty(a))
+						return;
+					var lk = LockedFaction(a);
+					if (lk == null || lk == f)
+						seed.Add(a);
+				}
+
+				foreach (var su in startUnits)
+				{
+					if (su.Factions.Count > 0 && !su.Factions.Contains(f))
+						continue;
+					SeedAdd(su.BaseActor);
+					foreach (var a in su.SupportActors) SeedAdd(a);
+					foreach (var a in su.SupportBuildings) SeedAdd(a);
+					foreach (var a in su.SupportProxyActors) SeedAdd(a);
+				}
+				seedByFaction[f] = seed;
+			}
+
+			// global tokens: anything granted by the Player/World actors (lobby options, tech-level, default
+			// player prereqs) is treated as always available, so units gated only by such tokens still classify.
+			var globalTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var sa in new[] { SystemActors.Player, SystemActors.World })
+			{
+				try
+				{
+					var actor = rules.Actors[sa];
+					foreach (var pp in actor.TraitInfos<ITechTreePrerequisiteInfo>())
+						foreach (var token in pp.Prerequisites(actor))
+							globalTokens.Add(token.ToLowerInvariant());
+				}
+				catch { }
+			}
+
+			// closure per faction
+			var ownedByFaction = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+			foreach (var f in factions)
+				ownedByFaction[f] = ComputeOwned(f, rules, byKey, providers, seedByFaction[f], globalTokens, TransformTarget, LockedFaction);
+
+			// water locomotors (move on Water but not on land) -> used to classify naval units
+			var waterLocos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var li in world.TraitInfos<LocomotorInfo>())
+				if (li.TerrainSpeeds != null && li.TerrainSpeeds.ContainsKey("Water") && !li.TerrainSpeeds.ContainsKey("Clear"))
+					waterLocos.Add(li.Name);
+
+			string TypeOf(ActorInfo ai)
+			{
+				try
+				{
+					if (ai.HasTraitInfo<BuildingInfo>()) return "buildings";
+					if (ai.HasTraitInfo<AircraftInfo>()) return "aircraft";
+					var mob = ai.TraitInfoOrDefault<MobileInfo>();
+					if (mob != null)
+					{
+						if (!string.IsNullOrEmpty(mob.Locomotor) && waterLocos.Contains(mob.Locomotor)) return "naval";
+						if (ai.HasTraitInfo<WithInfantryBodyInfo>()) return "infantry";
+						return "vehicles";
+					}
+				}
+				catch { }
+				return "upgrades";
+			}
+
+			// classify and emit:  ACTOR<TAB>factions<TAB>type
+			Console.Error.WriteLine($"# factions: {string.Join(", ", factions)}");
+			foreach (var ai in rules.Actors.OrderBy(a => a.Key, StringComparer.OrdinalIgnoreCase))
+			{
+				if (ai.Key.StartsWith(ActorInfo.AbstractActorPrefix) || ai.Key == "World" || ai.Key == "Player")
+					continue;
+				if (onlyPrefix != null && !ai.Key.StartsWith(onlyPrefix, StringComparison.OrdinalIgnoreCase))
+					continue;
+
+				var owners = factions.Where(f => ownedByFaction[f].Contains(ai.Key)).ToArray();
+				string val;
+				if (owners.Length == 0) val = "*NONE";
+				else if (owners.Length == factions.Length) val = "*SHARED";
+				else val = string.Join(",", owners);
+				Console.WriteLine($"{ai.Key}\t{val}\t{TypeOf(ai.Value)}");
+			}
+		}
+
+		static HashSet<string> ComputeOwned(string faction, Ruleset rules, Dictionary<string, ActorInfo> byKey,
+			Dictionary<string, List<(string Actor, HashSet<string> Factions)>> providers,
+			HashSet<string> seed, HashSet<string> globalTokens, Func<ActorInfo, string> transformTarget,
+			Func<string, string> lockedFaction)
+		{
+			var owned = new HashSet<string>(seed, StringComparer.OrdinalIgnoreCase);
+
+			bool TryOwn(string key)
+			{
+				var lk = lockedFaction(key);
+				if (lk != null && lk != faction)
+					return false;
+				return owned.Add(key);
+			}
+
+			// expand transform chains of the seed (MCV -> conyard)
+			ExpandTransforms(owned, byKey, transformTarget, TryOwn);
+
+			bool TokenAvailable(string token)
+			{
+				token = token.ToLowerInvariant();
+				if (globalTokens.Contains(token))
+					return true;
+				if (!providers.TryGetValue(token, out var list))
+					return false;  // no provider anywhere => unsatisfiable (e.g. bot-only 'defensebot' sentinel)
+				foreach (var (actor, facs) in list)
+					if (owned.Contains(actor) && (facs == null || facs.Contains(faction)))
+						return true;
+				return false;
+			}
+
+			var changed = true;
+			var guard = 0;
+			while (changed && guard++ < 100)
+			{
+				changed = false;
+				foreach (var ai in rules.Actors)
+				{
+					if (ai.Key.StartsWith(ActorInfo.AbstractActorPrefix) || owned.Contains(ai.Key))
+						continue;
+
+					BuildableInfo b;
+					try { b = ai.Value.TraitInfoOrDefault<BuildableInfo>(); }
+					catch { continue; }
+					if (b == null)
+						continue;
+
+					// Faction variants are locked to their faction regardless of generic prerequisites.
+					var lk = lockedFaction(ai.Key);
+					if (lk != null && lk != faction)
+						continue;
+
+					var ok = true;
+					foreach (var raw in b.Prerequisites)
+					{
+						var p = raw.ToLowerInvariant();
+						var negative = false;
+						while (p.Length > 0 && (p[0] == '~' || p[0] == '!'))
+						{
+							if (p[0] == '!') negative = true;
+							p = p[1..];
+						}
+
+						// Ignore negative prerequisites: they encode mutually-exclusive upgrade/doctrine
+						// choices, not faction membership (a unit and its upgraded form share a faction).
+						if (negative || p.Length == 0)
+							continue;
+
+						if (!TokenAvailable(p))
+						{
+							ok = false;
+							break;
+						}
+					}
+
+					if (ok)
+					{
+						// Owning a buildable actor also grants its deploy target (e.g. a building's "making"
+						// form -> finished building). This is safe now that unprovided tokens are unsatisfiable:
+						// a faction's MCV is no longer buildable-by-all, so its conyard can't leak cross-faction.
+						owned.Add(ai.Key);
+						var tgt = transformTarget(ai.Value);
+						if (!string.IsNullOrEmpty(tgt))
+							TryOwn(tgt);
+						changed = true;
+					}
+				}
+			}
+
+			return owned;
+		}
+
+		static void ExpandTransforms(HashSet<string> owned, Dictionary<string, ActorInfo> byKey,
+			Func<ActorInfo, string> transformTarget, Func<string, bool> tryOwn)
+		{
+			var changed = true;
+			while (changed)
+			{
+				changed = false;
+				foreach (var key in owned.ToArray())
+				{
+					if (!byKey.TryGetValue(key, out var ai))
+						continue;
+					var tgt = transformTarget(ai);
+					if (!string.IsNullOrEmpty(tgt) && tryOwn(tgt))
+						changed = true;
+				}
+			}
+		}
+	}
+}

--- a/tools/migrate_map_to_ca.py
+++ b/tools/migrate_map_to_ca.py
@@ -1,0 +1,134 @@
+"""Migrate a Cameo-generated .oramap so it loads in Combined Arms (CA).
+
+Cameo and CA share the JUNGLE/BARREN tile ART but renumber template Ids
+differently. A generated map stores raw (templateId, index) cells in map.bin, so
+to play a Cameo map in CA we: (1) remap each cell's templateId to CA's equivalent
+(matched by shared art stem), and (2) flip RequiresMod to ca. frameIndex is kept
+(matched templates have identical cell layout).
+
+Usage:
+    python tools/migrate_map_to_ca.py <map.oramap> [out.oramap]
+    # options: --ca <path-to-combined-arms> --cameo <path-to-Cameo-mod>
+
+The Cameo->CA Id remap is DERIVED at runtime from both mods' tileset YAML (by
+shared image stem), so it is never a stale hand table. Tiles with no CA match are
+left unchanged and reported (a coverage gap to inspect).
+"""
+import sys, os, re, io, zipfile, struct, argparse
+from collections import defaultdict
+
+def parse_templates(path):
+    """Id -> image stem (lowercase, no ext)."""
+    txt = open(path, encoding="utf-8", errors="replace").read()
+    out = {}
+    for b in re.split(r"\n(?=\tTemplate@)", txt):
+        mid = re.search(r"^\s*Id:\s*(\d+)", b, re.M)
+        if not mid:
+            continue
+        mim = re.search(r"^\s*Images?:\s*([^\n,]+)", b, re.M)
+        img = os.path.splitext(mim.group(1).strip().lower())[0] if mim else None
+        out[int(mid.group(1))] = img
+    return out
+
+def norm_stem(stem):
+    """Cameo's upscaled SHPs map back to the shared original stems."""
+    m = re.match(r"jungle_sh(\d+)$", stem or "")
+    if m:
+        return ["sh" + m.group(1), "sh%02d" % int(m.group(1))]
+    m = re.match(r"jungle_bridge(\w+)$", stem or "")
+    if m:
+        return ["bridge" + m.group(1)]
+    return [stem]
+
+def derive_remap(cameo_yaml, ca_yaml):
+    cam = parse_templates(cameo_yaml)
+    ca = parse_templates(ca_yaml)
+    ca_by_img = defaultdict(list)
+    for i, img in ca.items():
+        if img:
+            ca_by_img[img].append(i)
+    remap = {}
+    for cid, img in cam.items():
+        for c in norm_stem(img):
+            if c in ca_by_img:
+                remap[cid] = ca_by_img[c][0]
+                break
+    return remap
+
+def tileset_of(map_yaml_text):
+    m = re.search(r"^Tileset:\s*(\S+)", map_yaml_text, re.M)
+    return m.group(1).upper() if m else None
+
+def set_requires_mod(map_yaml_text, mod):
+    if re.search(r"^RequiresMod:", map_yaml_text, re.M):
+        return re.sub(r"^RequiresMod:.*$", f"RequiresMod: {mod}", map_yaml_text, count=1, flags=re.M)
+    # insert after MapFormat line (always present near top)
+    return re.sub(r"(^MapFormat:.*$)", r"\1\nRequiresMod: " + mod, map_yaml_text, count=1, flags=re.M)
+
+def remap_bin(data, remap):
+    """Rewrite tile-layer template Ids in a map.bin byte array. Returns (new_bytes, stats)."""
+    fmt = data[0]
+    width, height = struct.unpack_from("<HH", data, 1)
+    tiles_off, heights_off, res_off = struct.unpack_from("<III", data, 5)
+    buf = bytearray(data)
+    changed = 0
+    unmatched = defaultdict(int)
+    pos = tiles_off
+    for _ in range(width * height):
+        t = struct.unpack_from("<H", buf, pos)[0]
+        if t in remap:
+            if remap[t] != t:
+                struct.pack_into("<H", buf, pos, remap[t])
+                changed += 1
+        elif t not in (0,):
+            unmatched[t] += 1
+        pos += 3  # u16 type + u8 index
+    return bytes(buf), {"format": fmt, "size": (width, height), "changed": changed,
+                        "unmatched": dict(unmatched)}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("map")
+    ap.add_argument("out", nargs="?")
+    ap.add_argument("--cameo", default=r"C:\Users\Blackrobe\repo\Cameo-mod")
+    ap.add_argument("--ca", default=r"C:\Users\Blackrobe\repo\combined-arms")
+    a = ap.parse_args()
+
+    with zipfile.ZipFile(a.map) as z:
+        names = z.namelist()
+        map_yaml = z.read("map.yaml").decode("utf-8")
+        map_bin = z.read("map.bin")
+        others = {n: z.read(n) for n in names if n not in ("map.yaml", "map.bin")}
+
+    ts = tileset_of(map_yaml)
+    if ts not in ("JUNGLE", "BARREN"):
+        print(f"Tileset is {ts}; this tool only supports JUNGLE/BARREN. Aborting.")
+        sys.exit(2)
+
+    cam_yaml = os.path.join(a.cameo, "mods", "cameo", "tilesets", ts.lower() + ".yaml")
+    ca_yaml = os.path.join(a.ca, "mods", "ca", "tilesets", ts.lower() + ".yaml")
+    remap = derive_remap(cam_yaml, ca_yaml)
+
+    new_bin, stats = remap_bin(map_bin, remap)
+    new_yaml = set_requires_mod(map_yaml, "ca")
+
+    out = a.out or re.sub(r"\.oramap$", "", a.map) + ".ca.oramap"
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("map.yaml", new_yaml)
+        z.writestr("map.bin", new_bin)
+        for n, b in others.items():
+            z.writestr(n, b)
+
+    print(f"tileset={ts}  map.bin {stats['size'][0]}x{stats['size'][1]} (format {stats['format']})")
+    print(f"remapped {stats['changed']} tile cells via {len(remap)}-entry stem table; RequiresMod -> ca")
+    if stats["unmatched"]:
+        tot = sum(stats["unmatched"].values())
+        print(f"WARNING: {tot} cells use {len(stats['unmatched'])} tile Id(s) with NO CA match "
+              f"(left unchanged): {dict(list(stats['unmatched'].items())[:20])}")
+    else:
+        print("all tile cells covered (no unmatched Ids).")
+    print(f"wrote -> {out}")
+    print("Next: drop this into CA's maps folder and load it in Combined Arms.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Read-only tooling with no gameplay/runtime effect, used to drive the ContentPacks migration and the external tech-tree website.

**`--faction-report`** classifies every actor by which factions can build/own it. It runs the engine's resolved prerequisite/tech-tree closure seeded from each faction's StartingUnits MCV (deploy/transform chain), and reports a trait-based type (buildings/infantry/vehicles/aircraft/naval/upgrades). Output is machine-readable (`ACTOR<TAB>factions<TAB>type`).

Used to drive the per-faction ContentPacks migration of bare-named theme rules files (no in-game/runtime effect; tooling only). Validated: Red Alert 1 22/22 spot-checks; ra2mod cross-checked 461/461 vs its prefix-based split.

**`--export-cameos`** renders every buildable actor's production cameo (icon sequence, frame 0) to a standalone PNG using the actor's declared `Buildable.IconPalette`, so per-actor palettes (d2kunit/ra2/windows256/ra2cameo/...) render correctly instead of everything flattening to chrome. Output filenames are a canonicalised actor name for lookup by external tooling. Used to give the external tech-tree website full icon coverage.

**`tools/migrate_map_to_ca.py`** migrates a Cameo-generated `.oramap` so it loads in Combined Arms: remaps each cell's tile template Id to CA's equivalent (matched by shared art stem, derived at runtime from both mods' tileset YAML) and flips `RequiresMod` to `ca`.

Cameo project change — no engine sync.