### PR TITLE
Fix crash on map load: replace phantom SpawnsActorPeriodically trait

### DIFF
--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -1490,12 +1490,27 @@
 	GrantConditionOnDamageState@EpicBurning:
 		Condition: epic-wounded
 		ValidDamageStates: Heavy, Critical
-	SpawnsActorPeriodically@GroundFire:
+	# Fire sticks to the body (attached overlay), reusing the ground fire sprite; shows continuously
+	# while below half health.
+	WithIdleOverlay@EpicFire:
 		RequiresCondition: epic-wounded
-		Actor: groundfire
-		Range: 1
-		Interval: 16, 32
-		Chance: 100
+		Image: fire
+		Sequence: 1
+		Palette: effect
+		IsDecoration: True
+	# Smoke does not stick: it is emitted at the unit's current position each tick and then rises and
+	# drifts away on its own, leaving a trail as the unit moves. Same smoke the ground fire uses.
+	SmokeParticleEmitter@EpicSmoke:
+		RequiresCondition: epic-wounded
+		Image: smoke_fire_glow
+		Sequences: idle
+		Palette: effect
+		SpawnFrequency: 6, 12
+		Duration: 64
+		Speed: 6, 16
+		Gravity: 30, 70
+		TurnRate: 2
+		Offset: 0,0,128
 
 ^FighterTemplate:
 	Inherits@EXPERIENCE: ^GainsExperienceAircraft
@@ -1647,12 +1662,27 @@
 	GrantConditionOnDamageState@EpicBurning:
 		Condition: epic-wounded
 		ValidDamageStates: Heavy, Critical
-	SpawnsActorPeriodically@GroundFire:
+	# Fire sticks to the body (attached overlay), reusing the ground fire sprite; shows continuously
+	# while below half health.
+	WithIdleOverlay@EpicFire:
 		RequiresCondition: epic-wounded
-		Actor: groundfire
-		Range: 1
-		Interval: 16, 32
-		Chance: 100
+		Image: fire
+		Sequence: 1
+		Palette: effect
+		IsDecoration: True
+	# Smoke does not stick: it is emitted at the unit's current position each tick and then rises and
+	# drifts away on its own, leaving a trail as the unit moves. Same smoke the ground fire uses.
+	SmokeParticleEmitter@EpicSmoke:
+		RequiresCondition: epic-wounded
+		Image: smoke_fire_glow
+		Sequences: idle
+		Palette: effect
+		SpawnFrequency: 6, 12
+		Duration: 64
+		Speed: 6, 16
+		Gravity: 30, 70
+		TurnRate: 2
+		Offset: 0,0,128
 
 ^FlyingInfantryTemplate:
 	Inherits@EXPERIENCE: ^GainsExperienceAircraft


### PR DESCRIPTION
## Problem
`mods/cameo/rules/defaults.yaml` on `master` references `SpawnsActorPeriodically@GroundFire:` on the two epic templates (`^EpicVehicleTemplate`, `^EpicAirUnitTemplate`). **No such trait exists in the pinned engine.** OpenRA parses the full mod ruleset during map load, so *every* map fails:

```
System.AggregateException: ... Cannot locate type: SpawnsActorPeriodicallyInfo
Failed to load map: <any>.oramap
```

This was introduced via #166, which carried a half-finished version of the epic burning effect (the custom `SpawnsActorPeriodically` C# trait was prototyped then dropped in favour of stock traits, but the YAML reference shipped). master is currently crash-on-load for all maps.

## Fix
Replace it on both epic templates with stock engine traits:
- `WithIdleOverlay@EpicFire` (Mods.Common) — sticking ground-fire overlay
- `SmokeParticleEmitter@EpicSmoke` (Mods.AS) — non-sticking rising smoke

Pure YAML. No engine change, no pin bump, no rebuild — game restart only.

## Verification
- Confirmed `SpawnsActorPeriodically` exists in no engine repo (`OpenRA/`).
- Confirmed both replacement traits exist in the bundled engine.
- The epic burning effect itself was previously in-game verified (Ixian Farasha).