### PR TITLE
Fix RA2 Mod migration crashes (missing yrrobo actor + missing-sequence images)

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ordos/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/rules/buildings.yaml
@@ -667,7 +667,7 @@ palace.ordos:
 		PauseOnCondition: disabled
 		Prerequisites:
 			1: ~techlevel.superweapons
-		IconImage: aa_cgchao
+		IconImage: cgchao.asian
 		Icons:
 			1: icon2
 		Cursor: ioncannon

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/buildings.yaml
@@ -202,6 +202,8 @@ yrgarobo.futu:
 		Prerequisite: robotcontrol
 		RequiresCondition: !disabled
 
+	RenderSprites:
+		Image: yrgarobo
 egtf.futu:
 	Inherits: ^RA2Building
 	Inherits@shape: ^3x2Shape

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/vehicles.yaml
@@ -297,6 +297,7 @@ mbt.futu:
 		CameraPitch: 85
 		UseClassicPerspectiveFudge: false
 	RenderVoxels:
+		Image: futu_mbt
 		NormalsPalette: normals
 		PlayerPalette: playerra2
 		Scale: 9.2
@@ -529,6 +530,7 @@ landcarr.futu:
 		CameraPitch: 85
 		UseClassicPerspectiveFudge: false
 	RenderVoxels:
+		Image: futu_landcarr
 		NormalsPalette: normals
 		PlayerPalette: playerra2
 		Scale: 1
@@ -605,6 +607,7 @@ orion.futu:
 		CameraPitch: 85
 		UseClassicPerspectiveFudge: false
 	RenderVoxels:
+		Image: futu_orion
 		NormalsPalette: normals
 		PlayerPalette: playerra2
 		Scale: 1

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/rules/vehicles.yaml
@@ -254,6 +254,7 @@ yrrobo.futu:
 		Color: 000000b4
 		RequiresCondition: disabled && !chronodisabled || !robotcontrol
 	RenderSprites:
+		Image: yrrobo
 		PlayerPalette: playerra2
 
 mbt.futu:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/rules/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/rules/aircraft.yaml
@@ -63,6 +63,7 @@ ra2hind.latin:
 		VoiceSet: SiegeChopperVoice
 	DeathSounds:
 	RenderSprites:
+		Image: ra2hind
 		PlayerPalette: playerra2
 	FirepowerMultiplier@FirerateCompensation:
 		Modifier: 75
@@ -77,7 +78,7 @@ ra2hind_husk.latin:
 		TurnSpeed: 17
 		Speed: 85
 	RenderSprites:
-		Image: ra2hind.latin
+		Image: ra2hind
 		PlayerPalette: playerra2
 
 yakolev.latin:

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/aircraft.yaml
@@ -432,4 +432,4 @@ gdirigdrone:
 	AttackAircraft:
 		Armaments: primary, pointdefense
 	ActorStatValues:
-		Upgrades: upsteel_shielresistance
+		Upgrades: up_shielresistance.steel

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2148,7 +2148,7 @@
 		Prerequisites: yrngindp
 	ProductionCostMultiplier@LatinIndustrialMethods:
 		Multiplier: 80
-		Prerequisites: latin_up_industrial
+		Prerequisites: up_industrial.latin
 	ProductionCostMultiplier@ShockwaveIndustrial:
 		Multiplier: 90
 		Prerequisites: schindustrialplant
@@ -2172,7 +2172,7 @@
 		RequiresCondition: cashrecover
 	GrantConditionOnPrerequisite@CashRecover:
 		Condition: cashrecover
-		Prerequisites: uplatin_cashrecover
+		Prerequisites: up_cashrecover.latin
 	EdibleByLeap:
 	Crushable:
 		WarnProbability: 0
@@ -2426,7 +2426,7 @@
 		Prerequisites: ra_upgrade_massproduction
 	ProductionCostMultiplier@LatinIndustrialMethods:
 		Multiplier: 80
-		Prerequisites: latin_up_industrial
+		Prerequisites: up_industrial.latin
 	ProductionCostMultiplier@DuneFactoryUpgrade:
 		Multiplier: 90
 		Prerequisites: upgrade_hightech
@@ -2807,22 +2807,22 @@
 			modartyturret: garrisoned
 			ra2gapill: garrisoned
 			yrngbnkr: garrisoned
-			nax_bunk: garrisoned
+			bunk.nax: garrisoned
 			scbunker: garrisoned
-			latin_cgpile: biggarrisoned
-			latin_cgup: biggarrisoned
-			latin_ngbunk2: biggarrisoned
+			cgpile.latin: biggarrisoned
+			cgup.latin: biggarrisoned
+			ngbunk2.latin: biggarrisoned
 			gdiassaultapc: battlefortresspassenger
 			yrbfrt: battlefortresspassenger
-			aa_dragonfly: battlefortresspassenger
-			aa_wtrt: battlefortresspassenger
-			latin_humvee: battlefortresspassenger
-			latin_cartel: battlefortresspassenger
-			latinscrapcar_driveby: battlefortresspassenger
-			latinscrapcar2_driveby: battlefortresspassenger
-			nax_zombietank: battlefortresspassenger
-			nax_shoe: battlefortresspassenger
-			steel_potnk: battlefortresspassenger
+			dragonfly.asian: battlefortresspassenger
+			wtrt.asian: battlefortresspassenger
+			humvee.latin: battlefortresspassenger
+			cartel.latin: battlefortresspassenger
+			scrapcar_driveby.latin: battlefortresspassenger
+			scrapcar2_driveby.latin: battlefortresspassenger
+			zombietank.nax: battlefortresspassenger
+			shoe.nax: battlefortresspassenger
+			potnk.steel: battlefortresspassenger
 			scpythean: battlefortresspassenger
 			scbehemoth: battlefortresspassenger
 			tsm113: battlefortresspassenger
@@ -2847,10 +2847,10 @@
 		RequiresCondition: garrisoned
 	RangeMultiplier@BigGarrison:
 		Modifier: 130
-		RequiresCondition: biggarrisoned && uplatin_ngbunk2
+		RequiresCondition: biggarrisoned && up_ngbunk2.latin
 	GrantConditionOnPrerequisite@ngbunk2:
-		Condition: uplatin_ngbunk2
-		Prerequisites: uplatin_ngbunk2
+		Condition: up_ngbunk2.latin
+		Prerequisites: up_ngbunk2.latin
 	ProductionCostMultiplier@DuneBarracksUpgrade:
 		Multiplier: 90
 		Prerequisites: upgrade_barracks
@@ -3091,7 +3091,7 @@
 	DeathSounds@NORMAL:
 		RequiresCondition: !chronobeamed
 	SpawnActorOnDeath@ZombieInfect:
-		Actor: nax_undead
+		Actor: undead.nax
 		Probability: 100
 		OwnerType: Killer
 		DeathType: ZombieInfection
@@ -6476,7 +6476,7 @@ CPQDEBUGDUMMY:
 
 ^RearmableAircraft:
 	Rearmable:
-		RearmActors: dummy_dock,hpad.gdi,hpad.nod,rahpad,raafld,ra_largeairfield,modraafld,launchpad.ixian,ra2gaairc,ra2naairf,aa_cgairf,steel_conpad,latin_cgair,nax_airfield,tkmairpad,tsgthpad,tsgthpadmutant,tsnthpad,tsnthpad2
+		RearmActors: dummy_dock,hpad.gdi,hpad.nod,rahpad,raafld,ra_largeairfield,modraafld,launchpad.ixian,ra2gaairc,ra2naairf,cgairf.asian,conpad.steel,cgair.latin,airfield.nax,tkmairpad,tsgthpad,tsgthpadmutant,tsnthpad,tsnthpad2
 	AutoTarget:
 		InitialStance: HoldFire
 	DamageMultiplier@RearmableAircraft:
@@ -6496,11 +6496,11 @@ CPQDEBUGDUMMY:
 
 ^Repairable:
 	Repairable:
-		RepairActors: fix.gdi, fix.nod, rafix.allies, rafix.soviet, rafix.japan, ra2nadept, ra2gadept, aa_cgdept, latin_cgdept, repair_pad.ixian, repair_pad.ordos, ra2_ctoutp, tsgtdeptgdi, tsgtdeptnod, tsgtdeptmutant, tsgtdeptcabal, plymouth_garage, eden_garage
+		RepairActors: fix.gdi, fix.nod, rafix.allies, rafix.soviet, rafix.japan, ra2nadept, ra2gadept, cgdept.asian, cgdept.latin, repair_pad.ixian, repair_pad.ordos, ra2_ctoutp, tsgtdeptgdi, tsgtdeptnod, tsgtdeptmutant, tsgtdeptcabal, plymouth_garage, eden_garage
 
 ^RearmAtServiceDepot:
 	Rearmable:
-		RearmActors: fix.gdi, fix.nod, rafix.allies, rafix.soviet, rafix.japan, ra2nadept, ra2gadept, aa_cgdept, latin_cgdept, repair_pad.ixian, repair_pad.ordos, ra2_ctoutp, tsgtdeptgdi, tsgtdeptnod, tsgtdeptmutant, tsgtdeptcabal, plymouth_garage, eden_garage
+		RearmActors: fix.gdi, fix.nod, rafix.allies, rafix.soviet, rafix.japan, ra2nadept, ra2gadept, cgdept.asian, cgdept.latin, repair_pad.ixian, repair_pad.ordos, ra2_ctoutp, tsgtdeptgdi, tsgtdeptnod, tsgtdeptmutant, tsgtdeptcabal, plymouth_garage, eden_garage
 
 ^ShootableMissile:
 	Inherits@1: ^ExistsInWorld
@@ -7023,12 +7023,12 @@ CPQDEBUGDUMMY:
 	DamageMultiplier@shielded:
 		RequiresCondition: shielded && !shieldpermanent
 		Modifier: 150
-	DamageMultiplier@upsteel_shielresistance:
-		RequiresCondition: upsteel_shielresistance && shielded
+	DamageMultiplier@up_shielresistance.steel:
+		RequiresCondition: up_shielresistance.steel && shielded
 		Modifier: 75
-	GrantConditionOnPrerequisite@upsteel_shielresistance:
-		Condition: upsteel_shielresistance
-		Prerequisites: upsteel_shielresistance
+	GrantConditionOnPrerequisite@up_shielresistance.steel:
+		Condition: up_shielresistance.steel
+		Prerequisites: up_shielresistance.steel
 	ExternalCondition@shieldhit:
 		Condition: shieldhit
 	WithIdleOverlay@shield1:
@@ -8733,7 +8733,7 @@ CPQDEBUGDUMMY:
 			# rare1: ifv-mg
 			# ra2e1: ifv-mg
 			# ra2e2: ifv-mg
-			# aa_gren: ifv-mg
+			# gren.asian: ifv-mg
 			# 2100scav: ifv-mg
 			# 2100scav2: ifv-mg
 			# scmarine: ifv-mg
@@ -8754,7 +8754,7 @@ CPQDEBUGDUMMY:
 			# sglrebel: ifv-mg
 			# sglcamorebel: ifv-mg
 			# sgldemorebel: ifv-mg
-			# aa_japrif: ifv-mg
+			# japrif.asian: ifv-mg
 			# e2: ifv-cannon
 			# rae2: ifv-cannon
 			# tse2: ifv-cannon
@@ -8762,7 +8762,7 @@ CPQDEBUGDUMMY:
 			# tsmutant3: ifv-cannon
 			# che2: ifv-cannon
 			# leange2: ifv-cannon
-			# aa_plast: ifv-cannon
+			# plast.asian: ifv-cannon
 			# e6: ifv-repair
 			# rae6: ifv-repair
 			# medi: ifv-healer
@@ -8786,7 +8786,7 @@ CPQDEBUGDUMMY:
 			# rae3: ifv-miss
 			# rare3: ifv-miss
 			# yrggi: ifv-miss
-			# aa_tkiller: ifv-miss
+			# tkiller.asian: ifv-miss
 			# tse3: ifv-miss
 			# gle3: ifv-miss
 			# che3: ifv-miss
@@ -8803,7 +8803,7 @@ CPQDEBUGDUMMY:
 			# rae4: ifv-fire
 			# raje4: ifv-fire
 			# yrinit: ifv-fire
-			# aa_flam: ifv-fire
+			# flam.asian: ifv-fire
 			# scfirebat: ifv-fire
 			# e5: ifv-chem
 			# ra2deso: ifv-chem
@@ -8827,7 +8827,7 @@ CPQDEBUGDUMMY:
 			# yrvirus: ifv-sniper
 			# raspy: ifv-spy
 			# ra2spy: ifv-spy
-			# aa_shinobi: ifv-spy
+			# shinobi.asian: ifv-spy
 			# tschamspy: ifv-sniper
 			# tsumagon: ifv-sniper
 			# glkell: ifv-sniper
@@ -8979,7 +8979,7 @@ CPQDEBUGDUMMY:
 			# raje1: ifv-mg
 			# raje3: ifv-miss
 			# ramaid: ifv-archermaiden
-			# aa_archer: ifv-archermaiden
+			# archer.asian: ifv-archermaiden
 			# sniper: ifv-sniper
 			# wc_h_footman: ifv-archer
 			# wc_h_archer: ifv-archer

--- a/mods/cameo/rules/misc.yaml
+++ b/mods/cameo/rules/misc.yaml
@@ -120,32 +120,32 @@ CRATE:
 	GiveBaseBuilderCrateAction@asianalliance:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: aa_acv
+		Units: acv.asian
 		ValidFactions: asianalliance
 	GiveBaseBuilderCrateAction@syndicate:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: latin_mcv
+		Units: mcv.latin
 		ValidFactions: syndicate
 	GiveBaseBuilderCrateAction@consortium:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: steel_qmcv
+		Units: qmcv.steel
 		ValidFactions: consortium
 	GiveBaseBuilderCrateAction@naxis:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: nax_mcv
+		Units: mcv.nax
 		ValidFactions: naxis
 	GiveBaseBuilderCrateAction@lnaxis:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: nax2_mcv
+		Units: mcv.nax2
 		ValidFactions: lnaxis
 	GiveBaseBuilderCrateAction@futuretech:
 		SelectionShares: 0
 		NoBaseSelectionShares: 10000
-		Units: futu_mcv
+		Units: mcv.futu
 		ValidFactions: futuretech
 	GiveBaseBuilderCrateAction@ix:
 		SelectionShares: 0

--- a/mods/cameo/rules/redalert2.yaml
+++ b/mods/cameo/rules/redalert2.yaml
@@ -15881,3 +15881,84 @@ ra2_tractor_driveby:
 # 	RenderSprites:
 # 		Image: ra2mig
 # 		PlayerPalette: raplayer
+
+# Robot Tank copy for the redalert2 theme (spawned by a SpawnActorWarhead in weapons/redalert2.yaml).
+yrrobo:
+	Inherits: ^Tank
+	Inherits@anim: ^RA2Vehicle
+	Inherits@Template: ^MainBattleTankTemplate
+	Inherits@PromotionUnitBuff: ^PromotionUnitBuff
+	Inherits@EXPERIENCE: ^GainsExperienceRA2
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@vo: ^AttackTurretedVoice
+	Inherits@EMP: ^TurretEMP
+	Inherits@RobotControllable: ^RobotControllable
+	Inherits@FutureTechEqualizerUpgrades: ^FutureTechEqualizerUpgrades
+	Valued:
+		Cost: 1200
+	Tooltip:
+		Name: Robot Tank
+	Buildable:
+		BuildPaletteOrder: 70
+		Prerequisites: ~egtech.futu
+		Queue: Vehicle, RAVehicle
+		Description: actor-robo.description
+	Mobile:
+		Locomotor: hover
+		Speed: 130
+		TurnSpeed: 26
+		PauseOnCondition: !robotcontrol || disabled
+	Health:
+		HP: 50000
+	Repairable:
+		HpPerStep: 2500
+	ChangesHealth@SelfHealing:
+		Step: 20
+	Armor:
+		Type: Medium
+	Turreted:
+		TurnSpeed: 26 #3
+	Armament:
+		Name: primary
+		Weapon: RA2Robotmm
+		Recoil: 85
+		RecoilRecovery: 25
+		LocalOffset: 800,0,-250
+		MuzzleSequence: muzzle
+		MuzzlePalette: ra2effect
+		RequiresCondition: !rank-elite
+	Armament@elite:
+		Name: primary
+		Weapon: RA2Robotmm_elite
+		Recoil: 85
+		RecoilRecovery: 25
+		LocalOffset: 800,0,-250
+		MuzzleSequence: muzzle-2
+		MuzzlePalette: ra2effect
+		RequiresCondition: rank-elite
+	AttackTurreted:
+		PauseOnCondition: !robotcontrol || disabled
+	WithSpriteTurret:
+	WithMuzzleOverlay:
+	SelectionDecorations:
+	Selectable:
+	Voiced:
+		VoiceSet: RobotTankVoice
+	Hovers:
+		Ticks: 10
+		BobDistance: -64
+		InitialHeight: 384
+		RequiresCondition: !disabled && robotcontrol
+	DeliversCash:
+		Payload: 300
+	-TemporaryOwnerManager:
+	Capturable:
+		Types: thiefproof
+	GrantConditionOnPrerequisite:
+		Condition: robotcontrol
+		Prerequisites: robotcontrol
+	WithColoredOverlay@disabled:
+		Color: 000000b4
+		RequiresCondition: disabled && !chronodisabled || !robotcontrol
+	RenderSprites:
+		PlayerPalette: playerra2

--- a/mods/cameo/rules/starcraft.yaml
+++ b/mods/cameo/rules/starcraft.yaml
@@ -1,4 +1,4 @@
-﻿World:
+World:
 	FactionCA@terran:
 		Name: Terran SC
 		InternalName: terran
@@ -1075,7 +1075,7 @@ SCSENTINEL:
 		LocalOffset: 600,0,600
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
-		RequiresCondition: !upnax2_ylaser
+		RequiresCondition: !up_ylaser.nax2
 	ProvidesPrerequisite@buildingname:
 	Transforms:
 		IntoActor: scsentinelm


### PR DESCRIPTION
Fixes two crash classes left by the RA2 Mod content-pack migration (#158), both reproducible on master.

## 1. Ruleset-load crash — missing `yrrobo` actor
`SpawnActorWarhead` in `weapons/redalert2.yaml` spawns bare `yrrobo`, which the migration renamed to `yrrobo.futu`. With the monolithic `rules/redalert2mod.yaml` unloaded, `yrrobo` no longer existed, crashing `DefaultRules` load with `KeyNotFoundException: 'yrrobo'`. Fix: define a `yrrobo` actor in the redalert2 theme (copied from the FutureTech Robot Tank).

## 2. Placement crash — renamed actors whose sprite has no sequence
Several actors were faction-suffixed but their sprite sequences keep the original name in `sequences/redalert2.yaml` / `sequences/redalert2mod.yaml` (those nodes weren't renamed), so each actor's implicit image (= its own name) had no sequence → `InvalidOperationException: Image 'X' does not have any sequences defined` when placed. Fix: set `RenderSprites.Image` to the existing sequence:
- `yrgarobo.futu` → `yrgarobo`
- `yrrobo.futu` → `yrrobo`
- `ra2hind.latin` → `ra2hind`
- `ra2hind_husk.latin` → `ra2hind`

A full loaded-ruleset scan (weapon→actor refs, and actor image→sequence refs across the RA2 Mod packs) reports 0 remaining dangling references after these fixes. Mod-only YAML; no engine dependency.