### PR TITLE
Add muzzle-flash glow for cannon units

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
+++ b/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
@@ -1,0 +1,155 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits.Render
+{
+	[Desc("Registers a short-lived GlowRenderer muzzle flash when a weapon fires: a warm plume cone that is",
+		"brightest at the barrel and narrows forward, plus an optional hot core, giving tank cannons a",
+		"directional muzzle-flash glow. Respects the \"Weapon Glow Effects\" setting.")]
+	public class WithMuzzleGlowInfo : ConditionalTraitInfo
+	{
+		[Desc("Only flash for these armament names. Leave empty to flash for every armament on the actor.")]
+		public readonly HashSet<string> Armaments = new();
+
+		[Desc("Color of the warm plume cone.")]
+		public readonly Color Color = Color.FromArgb(230, 255, 138, 60);
+
+		[Desc("Length of the plume cone from the muzzle along the firing direction.")]
+		public readonly WDist Length = new(768);
+
+		[Desc("Plume glow radius scale at the muzzle (bright wide end).")]
+		public readonly float StartScale = 0.9f;
+
+		[Desc("Plume glow radius scale at the cone tip (narrow dissipating end).")]
+		public readonly float EndScale = 0.3f;
+
+		[Desc("Plume brightness multiplier, independent of glow radius.")]
+		public readonly float Intensity = 1.6f;
+
+		[Desc("Extra brightness ramped toward the cone tip. Keep at 0 for a muzzle flash (a far light",
+			"pool reads as a searchlight, not a flash).")]
+		public readonly float EndpointBoost = 0f;
+
+		[Desc("Render frames the plume takes to fade out.")]
+		public readonly int FadeFrames = 5;
+
+		[Desc("Render frames the plume takes to fade in (0 = instant pop).")]
+		public readonly int FadeInFrames = 0;
+
+		[Desc("Emit a small hot core point-glow at the muzzle for a white-hot center. One extra fading glow per shot.")]
+		public readonly bool EnableCore = true;
+
+		[Desc("Color of the hot core.")]
+		public readonly Color CoreColor = Color.FromArgb(255, 255, 246, 210);
+
+		[Desc("Radius scale of the hot core point-glow.")]
+		public readonly float CoreScale = 0.45f;
+
+		[Desc("Brightness multiplier of the hot core.")]
+		public readonly float CoreIntensity = 2.2f;
+
+		[Desc("Render frames the hot core takes to fade out (shorter than the plume fakes an exponential decay).")]
+		public readonly int CoreFadeFrames = 3;
+
+		[Desc("Brighten the tank sprite (and ground) under a soft circle at the muzzle, like a flash of light",
+			"hitting it. Strongest at the center, falling off to the edge; lifts shadows without washing to white.")]
+		public readonly bool EnableFlashLight = true;
+
+		[Desc("Strength of the sprite-brightening flash (radial gamma lift). 0 disables.")]
+		public readonly float FlashBrightness = 1.1f;
+
+		[Desc("Radius scale of the sprite-brightening circle at the muzzle.")]
+		public readonly float FlashRadiusScale = 0.8f;
+
+		[Desc("Render frames the sprite-brightening flash takes to fade out.")]
+		public readonly int FlashFadeFrames = 4;
+
+		[Desc("Per-shot random variation of plume length and overall brightness, as a percentage (0 = identical every shot).")]
+		public readonly int JitterPercent = 15;
+
+		[Desc("Minimum ticks between flashes from this trait (0 = flash on every shot). Use to tame very rapid-fire weapons.")]
+		public readonly int MinInterval = 0;
+
+		public override object Create(ActorInitializer init) { return new WithMuzzleGlow(this); }
+	}
+
+	public class WithMuzzleGlow : ConditionalTrait<WithMuzzleGlowInfo>, INotifyAttack
+	{
+		int lastFlashTick = int.MinValue;
+
+		public WithMuzzleGlow(WithMuzzleGlowInfo info)
+			: base(info) { }
+
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
+		{
+			if (IsTraitDisabled || !Game.Settings.Graphics.LaserGlow)
+				return;
+
+			if (barrel == null || (Info.Armaments.Count > 0 && !Info.Armaments.Contains(a.Info.Name)))
+				return;
+
+			// Only flash for armaments that define a muzzle sequence — the same convention WithMuzzleOverlay
+			// uses to decide a gun has a muzzle effect. This skips target painters / designator lasers and
+			// other non-gun armaments (which set no MuzzleSequence) without any per-actor configuration.
+			if (string.IsNullOrEmpty(a.Info.MuzzleSequence))
+				return;
+
+			if (Info.MinInterval > 0 && self.World.WorldTick - lastFlashTick < Info.MinInterval)
+				return;
+
+			lastFlashTick = self.World.WorldTick;
+
+			var glowRenderer = self.World.WorldActor.TraitOrDefault<GlowRenderer>();
+			if (glowRenderer == null)
+				return;
+
+			// Cosmetic-only jitter — the glow is render-only and never synced, so Game.CosmeticRandom is safe.
+			var lengthJitter = 1f;
+			var brightnessJitter = 1f;
+			if (Info.JitterPercent > 0)
+			{
+				var j = Info.JitterPercent;
+				lengthJitter = 1f + Game.CosmeticRandom.Next(-j, j + 1) / 100f;
+				brightnessJitter = 1f + Game.CosmeticRandom.Next(-j, j + 1) / 100f;
+			}
+
+			var source = self.CenterPosition + a.MuzzleOffset(self, barrel);
+			var yaw = a.MuzzleOrientation(self, barrel).Yaw;
+
+			// Yaw 0 faces north (-Y); project the plume forward out of the barrel.
+			var length = (int)(Info.Length.Length * lengthJitter);
+			var coneTip = source + new WVec(0, -length, 0).Rotate(WRot.FromYaw(yaw));
+
+			// Plume: bright/wide at the muzzle (StartScale), narrowing forward (EndScale), no far pool.
+			glowRenderer.RegisterGlow(source, coneTip, Info.Color, Info.StartScale,
+				fadeFrames: Info.FadeFrames, fadeInFrames: Info.FadeInFrames,
+				intensity: Info.Intensity * brightnessJitter, scaleEnd: Info.EndScale, endpointBoost: Info.EndpointBoost);
+
+			// Hot core: a radial point-glow at the muzzle (source == target) for a white-hot center.
+			if (Info.EnableCore)
+				glowRenderer.RegisterGlow(source, source, Info.CoreColor, Info.CoreScale,
+					fadeFrames: Info.CoreFadeFrames, intensity: Info.CoreIntensity * brightnessJitter);
+
+			// Flash light: brighten the sprite/ground under a soft circle at the muzzle. No added color
+			// (transparent), only the radial gamma lift via selfBrighten.
+			if (Info.EnableFlashLight && Info.FlashBrightness > 0f)
+				glowRenderer.RegisterGlow(source, source, Color.Transparent, Info.FlashRadiusScale,
+					fadeFrames: Info.FlashFadeFrames, selfBrighten: Info.FlashBrightness * brightnessJitter);
+		}
+
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
+	}
+}

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="cbeefdd"
+ENGINE_VERSION="7b69697"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/ContentPacks/D2k/Ixian/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/rules/buildings.yaml
@@ -525,6 +525,7 @@ machine_gun_turret.ixian:
 	Inherits: ^D2KDefense
 	Inherits@exp: ^GainsExperienceRABuilding
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@AUTOTARGET: ^AutoTargetAll
 	Inherits@EMP: ^TurretEMP
 	Inherits@D2KSprite: ^D2KPaletteRender
@@ -596,6 +597,7 @@ medium_gun_turret.ixian:
 	Inherits: ^D2KDefense
 	Inherits@exp: ^GainsExperienceRABuilding
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Inherits@EMP: ^TurretEMP
 	Inherits@D2KSprite: ^D2KPaletteRender

--- a/mods/cameo/ContentPacks/D2k/Ordos/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/rules/buildings.yaml
@@ -458,6 +458,7 @@ artillery_platform.ordos:
 	Inherits: ^D2KDefense
 	Inherits@exp: ^GainsExperienceRABuilding
 	Inherits@Template: ^AdvancedDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@detect: ^GenericGroundDetector
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Inherits@EMP: ^TurretEMP
@@ -528,6 +529,7 @@ autogun_turret.ordos:
 	Inherits: ^D2KDefense
 	Inherits@exp: ^GainsExperienceRABuilding
 	Inherits@Template: ^AdvancedDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@detect: ^GenericAllDetector
 	Inherits@AUTOTARGET: ^AutoTargetAll
 	Inherits@EMP: ^TurretEMP

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/rules/buildings.yaml
@@ -244,6 +244,7 @@ twr.nax2:
 sturmcann.nax2:
 	Inherits: ^RA2Defense
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@EXPERIENCE: ^GainsExperienceRA2
 	Inherits@AUTOTARGET: ^AutoTargetAll
 	Inherits@sell: ^NaxisSpawnActorsOnSell

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/buildings.yaml
@@ -210,6 +210,7 @@ FIX.GDI:
 GTWR:
 	Inherits: ^TDDefense
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Inherits@EMP: ^TurretEMP

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/buildings.yaml
@@ -485,6 +485,7 @@ td_nod_templeprime:
 GUN:
 	Inherits: ^TDDefense
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@exp: ^GainsExperienceTDBuilding
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Inherits@AntiTank: ^PrioritizeVehicle

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2209,6 +2209,16 @@
 		Payload: 300
 		Type: GrinderCash
 		Sounds: bgrinda.wav
+	Inherits@muzzleglow: ^MuzzleGlowCannon
+
+# Shared muzzle-glow tuning for cannon/gun units — inherited by ^Tank and by cannon defence
+# turrets so both use identical values. Geometry/fades fall back to the trait defaults;
+# tune the muzzle-flash brightness here in one place.
+^MuzzleGlowCannon:
+	WithMuzzleGlow:
+		Intensity: 1.6
+		CoreIntensity: 2.2
+		FlashBrightness: 1.1
 
 ^Walker:
 	Inherits: ^Vehicle
@@ -5674,7 +5684,8 @@
 		Condition: CommandoDebuff
 	WithColoredOverlay@COMMANDODEBUFF:
 		RequiresCondition: CommandoDebuff
-		Color: 0088FF88
+		Color: 0088FF40
+		Multiply: true
 	DamageMultiplier@COMMANDODEBUFF:
 		Modifier: 150
 		RequiresCondition: CommandoDebuff

--- a/mods/cameo/rules/redalert.yaml
+++ b/mods/cameo/rules/redalert.yaml
@@ -9368,6 +9368,7 @@ RAGUN:
 	Inherits: ^Defense
 	Inherits@exp: ^GainsExperienceRABuilding
 	Inherits@Template: ^BasicDefenseTemplate
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Inherits@EMP: ^TurretEMP
 	Inherits@AntiTank: ^PrioritizeVehicle


### PR DESCRIPTION
Adds a **`WithMuzzleGlow`** trait (OpenRA.Mods.Cameo) that fires a short-lived directional glow at the barrel when a unit attacks:

- a warm **plume** cone, bright at the muzzle and narrowing forward;
- a hot white **core**;
- a radial **sprite-brighten** that lights the firing unit itself (uses the engine `selfBrighten` gamma-lift).

Per-shot jitter + a punchy fade keep it from looking stamped. Only armaments that define a `MuzzleSequence` flash, so **target painters / designator lasers are skipped automatically** (same convention `WithMuzzleOverlay` uses). Gated behind the existing **"Weapon Glow Effects"** setting (default off), so no visual change until enabled.

**Wiring** — a single shared `^MuzzleGlowCannon` template (one tuning point) on:
- `^Tank` (all tank-class units)
- cannon/gun defences: `GUN` (Nod Gun Turret), `GTWR` (GDI Guard Tower), `RAGUN` (Allied Gun Turret), Ordos Autogun + Artillery Platform, Ixian MG + Gun Turret, `sturmcann.nax2` (Sturm Cannon)

Tanks and defences share identical values (Intensity 1.6 / CoreIntensity 2.2 / FlashBrightness 1.1). *(Allied pillboxes are garrison-only with no own armament, so they aren't wired.)*

Also makes the commando **target-painter tint subtle + multiplicative** — `^CommandoDebuff` `WithColoredOverlay`: `Color 0088FF88 -> 0088FF40`, `Multiply: true`.

### Depends on cameo-mod/OpenRA#73
The trait calls `GlowRenderer.RegisterGlow(..., selfBrighten:)`. **Merge #73 and bump the engine pin before merging this**, or a clean `./make all` won't compile.