### PR TITLE
Swap Consortium promotion unlocks: Stalker & White Rabbit in, Beholder & BFG 10000 out

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/buildings.yaml
@@ -630,7 +630,7 @@ bfg10k.steel:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 70
 		BuildLimit: 1
-		Prerequisites: ~up_bfg10k.steel
+		Prerequisites: qatech.steel
 		Description: actor-gun.description
 	Valued:
 		Cost: 10000

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/upgrades.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/upgrades.yaml
@@ -103,17 +103,17 @@ up_katy.steel:
 		Image: katy.steel
 	ProvidesPrerequisite:
 
-up_bfg10k.steel:
+up_white_rabbit.steel:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock BFG 10000
+		Name: Unlock White Rabbit
 	Buildable:
 		BuildPaletteOrder: 119
 		Queue: Promotions
-		Description: Enables construction of the BFG 10000.
-		Prerequisites: ~qacst.steel, up_katy.steel, !up_bfg10k.steel, rank1
+		Description: Enables construction of the White Rabbit.
+		Prerequisites: ~qacst.steel, up_katy.steel, !up_white_rabbit.steel, rank1
 	RenderSprites:
-		Image: bfg10k.steel
+		Image: white_rabbit.steel
 	ProvidesPrerequisite:
 
 ### Unisoft tree
@@ -144,17 +144,17 @@ up_defender.steel:
 		Image: defender.steel
 	ProvidesPrerequisite:
 
-up_beholder.steel:
+up_stalker.steel:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock Beholder
+		Name: Unlock Stalker
 	Buildable:
 		BuildPaletteOrder: 117
 		Queue: Promotions
-		Description: Enables construction of Beholders.
-		Prerequisites: ~qacst.steel, up_defender.steel, !up_beholder.steel, rank1
+		Description: Enables construction of Stalkers.
+		Prerequisites: ~qacst.steel, up_defender.steel, !up_stalker.steel, rank1
 	RenderSprites:
-		Image: beholder.steel
+		Image: stalker.steel
 	ProvidesPrerequisite:
 
 up_cruiser.steel:
@@ -165,7 +165,7 @@ up_cruiser.steel:
 		BuildPaletteOrder: 120
 		Queue: Promotions
 		Description: Enables construction of Cloud Breakers.
-		Prerequisites: ~qacst.steel, up_beholder.steel, !up_cruiser.steel, rank1
+		Prerequisites: ~qacst.steel, up_stalker.steel, !up_cruiser.steel, rank1
 	RenderSprites:
 		Image: cruiser.steel
 	ProvidesPrerequisite:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
@@ -219,7 +219,7 @@ stalker.steel:
 		Name: Stalker
 	Buildable:
 		BuildPaletteOrder: 75
-		Prerequisites: ~qatech.steel
+		Prerequisites: ~up_stalker.steel, ~qatech.steel
 		Queue: Vehicle, RAVehicle
 		Description: actor-steel_beholder.description
 	Mobile:
@@ -299,7 +299,7 @@ white_rabbit.steel:
 		Name: White Rabbit
 	Buildable:
 		BuildPaletteOrder: 75
-		Prerequisites: ~qatech.steel
+		Prerequisites: ~up_white_rabbit.steel, ~qatech.steel
 		Queue: Vehicle, RAVehicle
 		Description: actor-steel_beholder.description
 	Mobile:
@@ -1486,7 +1486,7 @@ beholder.steel:
 		Name: Beholder
 	Buildable:
 		BuildPaletteOrder: 75
-		Prerequisites: ~up_beholder.steel, qatech.steel
+		Prerequisites: qatech.steel
 		Queue: Vehicle, RAVehicle
 		Description: actor-steel_beholder.description
 	Mobile:

--- a/mods/cameo/ai/ai.yaml
+++ b/mods/cameo/ai/ai.yaml
@@ -5578,10 +5578,10 @@ Player:
 			up_quantumtank.steel: 1
 			up_dagger.steel: 1
 			up_katy.steel: 1
-			up_bfg10k.steel: 1
+			up_white_rabbit.steel: 1
 			up_manta_hunt.steel: 1
 			up_defender.steel: 1
-			up_beholder.steel: 1
+			up_stalker.steel: 1
 			up_cruiser.steel: 1
 			up_pulseweapons.steel: 1
 			up_naniteinfusion.steel: 1


### PR DESCRIPTION
## Summary
Reworks the Steel Consortium promotion unlocks per design feedback.

| Promotion slot | Was | Now unlocks |
|---|---|---|
| `up_stalker.steel` (ex `up_beholder.steel`, order 117) | Beholder | **Stalker** |
| `up_white_rabbit.steel` (ex `up_bfg10k.steel`, order 119) | BFG 10000 | **White Rabbit** |

- **Stalker** and **White Rabbit** are now gated behind their promotion unlock (+ Battle Lab `qatech.steel`).
- **Beholder** and **BFG 10000** are now regular Battle Lab units — no promotion required.
- Promotion actor keys renamed to match the unit they unlock; the `up_cruiser.steel` (Cloud Breaker) dependency and the bot build-weight list are re-pointed onto the renamed keys.

Whole-repo scan confirms no remaining references to the old `up_beholder.steel` / `up_bfg10k.steel` keys. YAML-only; no engine or pin change.