### PR TITLE
Fix Beholder & BFG 10000 appearing in all factions' build palettes

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/buildings.yaml
@@ -630,7 +630,7 @@ bfg10k.steel:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 70
 		BuildLimit: 1
-		Prerequisites: qatech.steel
+		Prerequisites: ~qacst.steel, qatech.steel
 		Description: actor-gun.description
 	Valued:
 		Cost: 10000

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
@@ -1486,7 +1486,7 @@ beholder.steel:
 		Name: Beholder
 	Buildable:
 		BuildPaletteOrder: 75
-		Prerequisites: qatech.steel
+		Prerequisites: ~qaweap.steel, qatech.steel
 		Queue: Vehicle, RAVehicle
 		Description: actor-steel_beholder.description
 	Mobile:


### PR DESCRIPTION
Follow-up to #173.

When the Beholder and BFG 10000 were converted to regular units in #173, the promotion gate was removed leaving each with a bare `qatech.steel` prerequisite. A non-structural prerequisite renders the item (greyed) in **every** faction's production queue, so both showed up for all factions.

Every other Consortium unit uses a `~`-prefixed *structural* prerequisite to stay faction-hidden. Restored that here:

- **Beholder** (vehicle): `~qaweap.steel, qatech.steel` — matches the Consortium vehicle convention.
- **BFG 10000** (defense): `~qacst.steel, qatech.steel` — matches the Consortium defense convention.

Both remain Battle-Lab-tier and are now correctly restricted to the Steel Consortium.