### PR TITLE
Fix lobby faction-selector order after content-pack migration

### DIFF
--- a/mods/cameo/ContentPacks/Outpost2/content.yaml
+++ b/mods/cameo/ContentPacks/Outpost2/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated Outpost 2 ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/outpost2.yaml

--- a/mods/cameo/ContentPacks/RedAlert/content.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated Red Alert ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/redalert.yaml

--- a/mods/cameo/ContentPacks/RedAlert2/content.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated Red Alert 2 ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/redalert2.yaml

--- a/mods/cameo/ContentPacks/StarCraft/content.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated StarCraft ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/starcraft.yaml

--- a/mods/cameo/ContentPacks/TKM/content.yaml
+++ b/mods/cameo/ContentPacks/TKM/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated TKM ruleset as-is so its
+# faction is ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/tkm.yaml

--- a/mods/cameo/ContentPacks/TiberianSun/content.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated Tiberian Sun ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/tiberiansun.yaml

--- a/mods/cameo/ContentPacks/Warcraft2/content.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/content.yaml
@@ -1,0 +1,5 @@
+# Include-only content pack: loads the unmigrated Warcraft 2 ruleset as-is so its
+# factions are ordered alongside the migrated packs via mod.yaml's Include order.
+# No rules are split here; this only controls faction load order in the lobby.
+Rules:
+	cameo|rules/warcraft2.yaml

--- a/mods/cameo/mod.yaml
+++ b/mods/cameo/mod.yaml
@@ -97,23 +97,40 @@ MapFolders:
 	cameo|maps: System
 	~^SupportDir|maps/cameo/{DEV_VERSION}: User
 
+# Faction content packs — the Include order below defines the lobby faction
+# selector order (the lobby groups factions by Side and lists them in load
+# order). Unmigrated themes are loaded via include-only wrapper packs so every
+# faction is ordered from this one place; see ContentPacks/<Theme>/content.yaml.
 Include: ContentPacks/TiberianDawn/Shared/content.yaml
 Include: ContentPacks/TiberianDawn/GDI/content.yaml
 Include: ContentPacks/TiberianDawn/Nod/content.yaml
 
-Include: ContentPacks/D2k/Shared/content.yaml
-Include: ContentPacks/D2k/Ixian/content.yaml
-Include: ContentPacks/D2k/Ordos/content.yaml
-Include: ContentPacks/D2k/Atreides/content.yaml
-Include: ContentPacks/D2k/Harkonnen/content.yaml
+Include: ContentPacks/RedAlert/content.yaml
+
+Include: ContentPacks/TiberianSun/content.yaml
+
+Include: ContentPacks/RedAlert2/content.yaml
 
 Include: ContentPacks/RedAlert2Mod/Shared/content.yaml
 Include: ContentPacks/RedAlert2Mod/AsianAlliance/content.yaml
-Include: ContentPacks/RedAlert2Mod/Syndicate/content.yaml
 Include: ContentPacks/RedAlert2Mod/Consortium/content.yaml
+Include: ContentPacks/RedAlert2Mod/Syndicate/content.yaml
 Include: ContentPacks/RedAlert2Mod/Naxis/content.yaml
 Include: ContentPacks/RedAlert2Mod/SchwarzerMond/content.yaml
 Include: ContentPacks/RedAlert2Mod/FutureTech/content.yaml
+Include: ContentPacks/TKM/content.yaml
+
+Include: ContentPacks/D2k/Shared/content.yaml
+Include: ContentPacks/D2k/Ordos/content.yaml
+Include: ContentPacks/D2k/Ixian/content.yaml
+Include: ContentPacks/D2k/Atreides/content.yaml
+Include: ContentPacks/D2k/Harkonnen/content.yaml
+
+Include: ContentPacks/StarCraft/content.yaml
+
+Include: ContentPacks/Warcraft2/content.yaml
+
+Include: ContentPacks/Outpost2/content.yaml
 
 Rules:
 	cameo|rules/misc.yaml
@@ -131,15 +148,15 @@ Rules:
 	cameo|rules/husks.yaml
 	cameo|rules/promotions.yaml
 	cameo|ai/ai.yaml
-	cameo|rules/redalert.yaml
-	cameo|rules/tiberiansun.yaml
-	cameo|rules/redalert2.yaml
+	# redalert.yaml, tiberiansun.yaml, redalert2.yaml are now loaded via include-only
+	# wrapper packs (ContentPacks/{RedAlert,TiberianSun,RedAlert2}/) so their factions
+	# can be ordered in the lobby; not loaded here to avoid duplicate keys.
 	# redalert2mod.yaml migrated to ContentPacks/RedAlert2Mod/* (Included above).
 	# File kept on disk as dormant reference; not loaded here to avoid duplicate keys.
 	# d2k.yaml migrated to ContentPacks/D2k/* (Included above). File kept on disk
 	# for the commented planned factions (Atreides/Harkonnen/Corrino) reference.
-	cameo|rules/starcraft.yaml
-	cameo|rules/warcraft2.yaml
+	# starcraft.yaml, warcraft2.yaml are now loaded via include-only wrapper packs
+	# (ContentPacks/{StarCraft,Warcraft2}/) so their factions can be ordered in the lobby.
 	# cameo|rules/xcom.yaml
 	# cameo|rules/advancewars.yaml
 	# cameo|rules/camea.yaml
@@ -176,9 +193,9 @@ Rules:
 	# cameo|rules/xmas.yaml
 	# cameo|rules/valentine.yaml
 	# cameo|rules/halloween.yaml
-	cameo|rules/outpost2.yaml
+	# outpost2.yaml, tkm.yaml are now loaded via include-only wrapper packs
+	# (ContentPacks/{Outpost2,TKM}/) so their factions can be ordered in the lobby.
 	# cameo|rules/z.yaml
-	cameo|rules/tkm.yaml
 
 Sequences:
 	cameo|sequences/misc.yaml


### PR DESCRIPTION
## Problem
After the content-pack migration, the lobby faction selector order is scrambled. The lobby orders factions purely by **load order** (grouped by `Side`) — `FactionCA` has no sort field (LobbyUtils.cs `GroupBy(f => f.Side)`). Migrated themes load via content-pack `Include`s, which come **before** the still-monolithic themes in the inline `Rules:` list. That:
- hoisted the migrated Side groups (Dune, RA2 Mod) ahead of the classic monolith themes (Red Alert, Tiberian Sun, Red Alert 2), and
- left the within-Side order wrong (e.g. Syndicate before Consortium).

## Approach (no rules migrated)
Put every faction on the same Include path so a single ordered include block governs the lobby order:
- Each unmigrated theme (Red Alert, Tiberian Sun, Red Alert 2, TKM, StarCraft, Warcraft 2, Outpost 2) gets an **include-only wrapper pack** (`ContentPacks/<Theme>/content.yaml`) that loads its existing monolith ruleset as-is — nothing is split.
- Those monoliths are dropped from the inline `Rules:` list (now loaded once via the wrappers).
- The include block is reordered to the intended order.

## Resulting lobby order
Random, Tiberian Dawn (gdi, nod), Red Alert (allies, soviet, modjapan), Tiberian Sun (tsgdi, tsnod, forgotten, cabal), Red Alert 2 (ra2america, ra2russia, yuri), **RA2 Mod (asianalliance, consortium, syndicate, naxis, lnaxis, futuretech, tkm)**, Dune (ordos, ixian), StarCraft (terran, protoss, zerg), Warcraft 2 (human2, orc2), Outpost 2 (plymouthl, edenl).

Fixes Consortium-before-Syndicate, Ordos-before-Ixian, and places TKM last in the RA2 Mod group.

## Safety
- Verified each monolith still loads **exactly once** (no duplicate-key loads).
- Verified **no theme redefines any of the 507 core actor keys** (themes are additive), so moving their load position relative to the core rules has no override effect; `defaults.yaml` is templates-only.

## Testing
Needs an in-game check: confirm the lobby selector order matches the table above and that a skirmish from each Side still launches cleanly.