### PR TITLE
Muzzle glow: Tank muzzle flashes setting + brightness tune

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
+++ b/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Cameo.Traits.Render
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || !Game.Settings.Graphics.LaserGlow)
+			if (IsTraitDisabled || !Game.Settings.Graphics.TankMuzzleFlashes)
 				return;
 
 			if (barrel == null || (Info.Armaments.Count > 0 && !Info.Armaments.Contains(a.Info.Name)))

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="7b69697"
+ENGINE_VERSION="ae0a187"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/chrome/settings-display.yaml
+++ b/mods/cameo/chrome/settings-display.yaml
@@ -402,6 +402,19 @@ Container@DISPLAY_PANEL:
 					Width: PARENT_WIDTH - 24
 					Height: 25
 					Children:
+						Container@TANK_MUZZLE_FLASHES_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Children:
+								Checkbox@TANK_MUZZLE_FLASHES_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-tank-muzzle-flashes
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 25
+					Children:
 						Container@HEAT_DISTORTION_CHECKBOX_CONTAINER:
 							X: 10
 							Width: PARENT_WIDTH - 20

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -301,6 +301,7 @@ support-power-timer = { $player }'s { $support-power }: { $time }
 
 ## settings-display.yaml
 checkbox-laser-glow = Weapon Glow Effects
+checkbox-tank-muzzle-flashes = Tank muzzle flashes
 checkbox-heat-distortion = Heat Distortion Effects
 checkbox-shockwave = Shockwave Distortion Effects
 checkbox-screen-shake = Screen Shake Effects

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2216,9 +2216,9 @@
 # tune the muzzle-flash brightness here in one place.
 ^MuzzleGlowCannon:
 	WithMuzzleGlow:
-		Intensity: 1.6
-		CoreIntensity: 2.2
-		FlashBrightness: 1.1
+		Intensity: 1.0
+		CoreIntensity: 1.5
+		FlashBrightness: 0.8
 
 ^Walker:
 	Inherits: ^Vehicle


### PR DESCRIPTION
Follow-up to #172 (which merged before these landed). Three commits:

1. **Tune brightness** to `Intensity 1.0 / CoreIntensity 1.5 / FlashBrightness 0.8` (in-game approved) — `^MuzzleGlowCannon`. Master currently ships the brighter 1.6/2.2/1.1.
2. **Dedicated "Tank muzzle flashes" setting** — `WithMuzzleGlow` now reads `Game.Settings.Graphics.TankMuzzleFlashes` instead of `LaserGlow`, so muzzle flashes toggle independently of "Weapon Glow Effects". Adds the Display-tab checkbox (`TANK_MUZZLE_FLASHES_CHECKBOX`) and fluent label (`checkbox-tank-muzzle-flashes = Tank muzzle flashes`).
3. **Engine pin bump** `7b69697 -> ae0a187` to pull in the `TankMuzzleFlashes` engine setting (cameo-mod/OpenRA#74, merged).

Engine side (#74) is already merged into `cameo-engine`, so this builds from a clean engine fetch. In-game verified: the checkbox toggles the glow on/off and 1.0/1.5/0.8 looks right.