### PR TITLE
Fix Robot Tank duplicate in FutureTech's build palette

### DIFF
--- a/mods/cameo/rules/redalert2.yaml
+++ b/mods/cameo/rules/redalert2.yaml
@@ -15883,6 +15883,8 @@ ra2_tractor_driveby:
 # 		PlayerPalette: raplayer
 
 # Robot Tank copy for the redalert2 theme (spawned by a SpawnActorWarhead in weapons/redalert2.yaml).
+# Not Buildable: the FutureTech content pack has the real buildable copy (yrrobo.futu); this one
+# previously carried a stray Buildable block that duplicated it in FutureTech's build palette.
 yrrobo:
 	Inherits: ^Tank
 	Inherits@anim: ^RA2Vehicle
@@ -15898,11 +15900,6 @@ yrrobo:
 		Cost: 1200
 	Tooltip:
 		Name: Robot Tank
-	Buildable:
-		BuildPaletteOrder: 70
-		Prerequisites: ~egtech.futu
-		Queue: Vehicle, RAVehicle
-		Description: actor-robo.description
 	Mobile:
 		Locomotor: hover
 		Speed: 130


### PR DESCRIPTION
## Summary
- PR #170 restored a `yrrobo` actor in `mods/cameo/rules/redalert2.yaml`, copied verbatim from FutureTech, to fix a crash: `RA2ChronoAI`'s `SpawnActor` warhead (`weapons/redalert2.yaml`) referenced `yrrobo` by id, but the RA2Mod migration had renamed the real actor to `yrrobo.futu` and dropped the monolithic rules file that used to define the unsuffixed `yrrobo`.
- That restored copy kept its `Buildable` trait with the same `~egtech.futu` prerequisite as `yrrobo.futu` - so any FutureTech player satisfies both, and two identical "Robot Tank" icons show up in the Vehicle build queue.
- `RA2ChronoAI` spawns `yrrobo` directly by actor id via `SpawnActor` - it never goes through the production queue, so `Buildable` was never needed on this copy. Stripped it, leaving `yrrobo.futu` as the only buildable Robot Tank.

## Test plan
- [ ] In-game boot as FutureTech: confirm only one Robot Tank appears in the Vehicle queue
- [ ] Trigger `RA2ChronoAI`'s spawn effect (or confirm ruleset loads without the prior crash) to confirm `yrrobo` still resolves for the warhead