### PR TITLE
[Experimental/Unstable] Low-VRAM mode settings UI + tileset TileSize halving

### DIFF
--- a/mods/cameo/chrome/settings-display.yaml
+++ b/mods/cameo/chrome/settings-display.yaml
@@ -355,6 +355,19 @@ Container@DISPLAY_PANEL:
 									Text: checkbox-cross-map-sprite-cache-container
 				Container@ROW:
 					Width: PARENT_WIDTH - 24
+					Height: 30
+					Children:
+						Container@LOW_VRAM_SPRITE_SCALE_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Children:
+								Checkbox@LOW_VRAM_SPRITE_SCALE_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-low-vram-sprite-scale
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
 						Container@GL_PROFILE_DROPDOWN_CONTAINER:

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -308,6 +308,7 @@ checkbox-screen-shake = Screen Shake Effects
 checkbox-ground-fire-smoke = Ground Fire Smoke Effects
 checkbox-decoupled-rendering = Decoupled Render Thread (Experimental)
 checkbox-cross-map-sprite-cache-container = Reuse sprite atlases between maps (faster map loads)
+checkbox-low-vram-sprite-scale = Low VRAM mode (halve sprite resolution)
 
 ## settings-gameplay.yaml
 label-game-play-section-header = Gameplay

--- a/mods/cameo/tilesets/arrakis.yaml
+++ b/mods/cameo/tilesets/arrakis.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Arrakis (Dune 2000)
 	Id: ARRAKIS
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Basic, Dune, Sand-Detail, Rock-Detail, Ice-Detail, Rock-Sand-Smooth, Sand-Sand-Cliff, Sand-Rock-Cliff, Sand-Ice-Cliff, Rock-Rock-Cliff, Rock-Sand-Cliff, Cliff-Type-Changer, Cliff-Ends, Sand-Platform, Bridge, Rotten-Base, Dead-Worm, Unidentified
 	IgnoreTileSpriteOffsets: True

--- a/mods/cameo/tilesets/arrakis2.yaml
+++ b/mods/cameo/tilesets/arrakis2.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: D2 Arrakis
 	Id: ARRAKIS2
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Basic, Rock, Sand, Rough
 	IgnoreTileSpriteOffsets: True

--- a/mods/cameo/tilesets/barren.yaml
+++ b/mods/cameo/tilesets/barren.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Barren (wasteland)
 	Id: BARREN
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/cameo.yaml
+++ b/mods/cameo/tilesets/cameo.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Cameo (experimental, blank only)
 	Id: CAMEO
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 4096
 	EditorTemplateOrder: Terrain, Act Terrain, Act Water, Har Terrain, Har Cliffs, Har Buildings, Ze3 Terrain, Ze3 Cliffs, Ze3 Kakariko, Ze3 Decoration, Ze3 Water & Bridge, Terrain, T&W Debris, T&W Road, T&W Cliffs, T&W Beach, T&W River, T&W Bridge, T&W RA Debris, T&W RA Water Cliffs, T&W RA Bridge, J&S&D Debris, J&S&D Road, J&S&D Cliffs, J&S&D Beach, J&S&D River, J&S&D Bridge, J&S&D RA Debris, J&S&D RA Water Cliffs, J&S&D RA Bridge, Int Floor, Int Wall, Zeruel87 Urban
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/caribic.yaml
+++ b/mods/cameo/tilesets/caribic.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Caribic
 	Id: CARIBIC
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, RA Debris, RA Water Cliffs, RA Bridge, Zeruel87 Urban
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/desert.yaml
+++ b/mods/cameo/tilesets/desert.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Desert (Tiberian Dawn, blank only)
 	Id: DESERT
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, RA Debris, RA Water Cliffs, RA Bridge, Zeruel87 Urban
 	HeightDebugColors: 880000

--- a/mods/cameo/tilesets/jungle.yaml
+++ b/mods/cameo/tilesets/jungle.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Jungle (tropical)
 	Id: JUNGLE
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge, Zeruel87 Urban
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/outpost2.yaml
+++ b/mods/cameo/tilesets/outpost2.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: OUTPOST2
 	Id: OUTPOST2
-	TileSize: 48,48
+	TileSize: 24,24
 	EditorTemplateOrder: Terrain
 	SheetSize: 1024
 

--- a/mods/cameo/tilesets/ra2_temperat.yaml
+++ b/mods/cameo/tilesets/ra2_temperat.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: ra2_Temperate
 	Id: RA2_TEMPERAT
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Terrain
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/ra_desert.yaml
+++ b/mods/cameo/tilesets/ra_desert.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Desert (Red Alert)
 	Id: RA_DESERT
-	TileSize: 48,48
+	TileSize: 24,24
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/cameo/tilesets/ra_interior.yaml
+++ b/mods/cameo/tilesets/ra_interior.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Interior (Red Alert, blank only)
 	Id: RA_INTERIOR
-	TileSize: 48,48
+	TileSize: 24,24
 	EditorTemplateOrder: Floor, Wall
 	HeightDebugColors: 880000
 

--- a/mods/cameo/tilesets/ra_snow.yaml
+++ b/mods/cameo/tilesets/ra_snow.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Snow (Red Alert)
 	Id: RA_SNOW
-	TileSize: 48,48
+	TileSize: 24,24
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 	SheetSize: 4096

--- a/mods/cameo/tilesets/ra_temperat.yaml
+++ b/mods/cameo/tilesets/ra_temperat.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Temperate (Red Alert)
 	Id: RA_TEMPERAT
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/snow.yaml
+++ b/mods/cameo/tilesets/snow.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Snow (Tiberian Dawn, blank only)
 	Id: SNOW
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 4096
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, RA Debris, RA Water Cliffs, RA Bridge, Zeruel87 Urban
 	HeightDebugColors: 880000

--- a/mods/cameo/tilesets/temperat.yaml
+++ b/mods/cameo/tilesets/temperat.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Temperate (Tiberian Dawn, blank only)
 	Id: TEMPERAT
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, RA Debris, RA Water Cliffs, RA Bridge, Zeruel87 Urban
 	HeightDebugColors: AA0000

--- a/mods/cameo/tilesets/tibfields.yaml
+++ b/mods/cameo/tilesets/tibfields.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Tiberian Fields
 	Id: TIBFIELD
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, RA Debris, RA Water Cliffs, RA Bridge, Zeruel87 Urban
 	HeightDebugColors: 880000

--- a/mods/cameo/tilesets/wc2_summer.yaml
+++ b/mods/cameo/tilesets/wc2_summer.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: WC2_Summer
 	Id: WC2SUMMER
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Basic, Forest, Rocks, Sand, Rough
 	IgnoreTileSpriteOffsets: True

--- a/mods/cameo/tilesets/wc2_sunset.yaml
+++ b/mods/cameo/tilesets/wc2_sunset.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: WC2_Sunset
 	Id: WC2SUNSET
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Basic, Forest, Rocks, Sand, Rough
 	IgnoreTileSpriteOffsets: True

--- a/mods/cameo/tilesets/wc2_swamp.yaml
+++ b/mods/cameo/tilesets/wc2_swamp.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: WC2_Sunset
 	Id: WC2SUNSET
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 2048
 	EditorTemplateOrder: Basic, Forest, Rocks, Sand, Rough
 	IgnoreTileSpriteOffsets: True

--- a/mods/cameo/tilesets/winter.yaml
+++ b/mods/cameo/tilesets/winter.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Winter (Tiberian Dawn, blank only)
 	Id: WINTER
-	TileSize: 48,48
+	TileSize: 24,24
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge, Zeruel87 Urban
 	HeightDebugColors: 880000


### PR DESCRIPTION
## Summary
- Adds the Settings > Display checkbox wiring for the new engine `GraphicSettings.LowVramSpriteScale`.
- Halves `TileSize` (48,48 -> 24,24) across every tileset so terrain shrinks in lockstep with the engine-side sprite/terrain-tile downscale.

## Status: WIP checkpoint, paused — not production ready
Requires cameo-mod/OpenRA#75, which lists the known blockers (voxel actors don't shrink, nearest-neighbor shimmer, chrome/UI icons untouched) found during in-game testing. Parking here for now.

## Test plan
- [ ] See engine PR blockers