### PR TITLE
Muzzle glow: cover all ground vehicles + artillery pitch

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
+++ b/OpenRA.Mods.Cameo/Traits/Render/WithMuzzleGlow.cs
@@ -83,6 +83,11 @@ namespace OpenRA.Mods.Cameo.Traits.Render
 		[Desc("Minimum ticks between flashes from this trait (0 = flash on every shot). Use to tame very rapid-fire weapons.")]
 		public readonly int MinInterval = 0;
 
+		[Desc("Upward tilt of the plume from the ground, as a WAngle (1024 = 360 degrees). 0 = flat along the",
+			"barrel's facing (direct-fire tanks). Raise it for indirect-fire artillery so the flash points up",
+			"and forward like a howitzer muzzle instead of lying flat.")]
+		public readonly WAngle Pitch = WAngle.Zero;
+
 		public override object Create(ActorInitializer init) { return new WithMuzzleGlow(this); }
 	}
 
@@ -129,9 +134,12 @@ namespace OpenRA.Mods.Cameo.Traits.Render
 			var source = self.CenterPosition + a.MuzzleOffset(self, barrel);
 			var yaw = a.MuzzleOrientation(self, barrel).Yaw;
 
-			// Yaw 0 faces north (-Y); project the plume forward out of the barrel.
+			// Yaw 0 faces north (-Y); project the plume forward out of the barrel. Pitch tilts it up out of
+			// the ground plane (Z) so indirect-fire artillery flashes point up-and-forward; Pitch 0 stays flat.
 			var length = (int)(Info.Length.Length * lengthJitter);
-			var coneTip = source + new WVec(0, -length, 0).Rotate(WRot.FromYaw(yaw));
+			var horizontal = length * Info.Pitch.Cos() / 1024;
+			var vertical = length * Info.Pitch.Sin() / 1024;
+			var coneTip = source + new WVec(0, -horizontal, vertical).Rotate(WRot.FromYaw(yaw));
 
 			// Plume: bright/wide at the muzzle (StartScale), narrowing forward (EndScale), no far pool.
 			glowRenderer.RegisterGlow(source, coneTip, Info.Color, Info.StartScale,

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -1438,6 +1438,9 @@
 	Inherits@AntiBuil: ^PrioritizeBuilding
 	Inherits@AntiDef: ^PrioritizeDefence
 	Inherits@AntiInf: ^PrioritizeInfantry
+	# Indirect-fire: tilt the muzzle flash up out of the ground like a howitzer (Pitch is a WAngle, 1024=360deg).
+	WithMuzzleGlow:
+		Pitch: 113
 	AutoTargetPriority@INFANTRY:
 		ValidTargets: Infantry
 		Priority: 10
@@ -2031,6 +2034,10 @@
 
 ^Vehicle:
 	Inherits: ^BasicUnit
+	# Muzzle-flash glow for every ground vehicle; gated per-armament by MuzzleSequence, so only
+	# gun/MG units flash (harvesters, MCVs, transports without a muzzle stay dark). Ships opt out
+	# via ^BoatUnit; non-gun creatures reusing a vehicle template opt out with -WithMuzzleGlow.
+	Inherits@muzzleglow: ^MuzzleGlowCannon
 	Inherits@2: ^IronCurtainable
 	Inherits@mindcontrol: ^MindControllable
 	Inherits@rad: ^VehicleRadiation
@@ -2209,7 +2216,6 @@
 		Payload: 300
 		Type: GrinderCash
 		Sounds: bgrinda.wav
-	Inherits@muzzleglow: ^MuzzleGlowCannon
 
 # Shared muzzle-glow tuning for cannon/gun units — inherited by ^Tank and by cannon defence
 # turrets so both use identical values. Geometry/fades fall back to the trait defaults;
@@ -2233,6 +2239,8 @@
 
 ^BoatUnit:
 	Inherits: ^Vehicle
+	# Ships weren't part of the muzzle-flash pass; opt the whole naval line out (re-enable per-ship if wanted).
+	-WithMuzzleGlow:
 	Inherits@snipe: ^DriverKillImmune
 	Mobile:
 		Locomotor: naval


### PR DESCRIPTION
Two changes to the muzzle-flash glow, both mod-only (no engine/pin change):

### 1. Cover all ground vehicles
Moves `WithMuzzleGlow` from `^Tank` down to **`^Vehicle`**. Every ground vehicle now flashes, **still gated per-armament by `MuzzleSequence`** — so only gun/MG units flash; harvesters, MCVs and other muzzle-less vehicles stay dark. This replaces per-template wiring and picks up in one place:
- scout vehicles (RA1 Ranger, Nod Buggy/Bike),
- D2k tanks (they inherit `^D2KVehicle` → `^Vehicle`, not `^Tank`),
- walkers/mechs/droids (Gun Strider, Cannon Droid, Pulverizer Mecha…).

The now-redundant `^Tank` wiring is removed (it inherits `^Vehicle`).

**Ships** opt out via `-WithMuzzleGlow` on `^BoatUnit` (weren't part of this pass; easy to re-enable). Non-gun creatures that reuse a vehicle template (e.g. the Ordos Leech) are naturally excluded now that the trait rides `^Vehicle` rather than `^ScoutVehicleTemplate`.

### 2. Artillery pitch
New `Pitch` (WAngle) field on `WithMuzzleGlow` that tilts the plume up out of the ground plane (adds a Z component to the cone tip). Set on `^ArtilleryTemplate` (`Pitch: 113` ≈ 40°) so indirect-fire artillery flashes point **up-and-forward like a howitzer** instead of lying flat. `Pitch: 0` (default) is the unchanged flat direct-fire behaviour.

Builds on the merged muzzle-glow feature (#172) + Tank-muzzle-flashes setting (#176). Defense turrets and the shared `^MuzzleGlowCannon` tuning are unchanged.