### PR TITLE
Fix cross-faction weapon Inherits chains

### DIFF
--- a/mods/cameo/weapons/d2k.yaml
+++ b/mods/cameo/weapons/d2k.yaml
@@ -4271,7 +4271,13 @@ d2k_heavy_air_drone:
 		Amount: 4
 
 aa_mine.ordos:
-	Inherits: air_drone.ixian
+	Inherits: ^TankDestroyerCannon
+	Inherits: ^LightChemicalWeapon
+	Inherits: ^FlakWeapon
+	Inherits: ^MediumMissile
+	Inherits: ^HeavyBomb
+	Inherits: ^D2KMissile
+	ReloadDelay: 132
 	Burst: 15
 	Range: 2c0
 	BurstDelays: 0
@@ -4292,6 +4298,77 @@ aa_mine.ordos:
 		CruiseAltitude: 2c124
 		AllowSnapping: true
 		TerrainHeightAware: true
+	Warhead@TankDestroyerCannon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@TankDestroyerCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@LightChemicalWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@LightChemicalWeaponFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@LightChemicalWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@FlakWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@FlakWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@MediumMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@MediumMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@HeavyBomb: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@HeavyBombPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@HeavyMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@HeavyMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+		ValidRelationships: Neutral, Enemy
+	Warhead@Shrapnel: FireShrapnel
+		ValidTargets: Ground, Water, Trees, Air
+		Weapon: PhoenixRocketShrapnel
+		Amount: 2
+		AimChance: 50
+		AimTargetStances: Enemy, Neutral
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Spread: 0c768

--- a/mods/cameo/weapons/outpost2.yaml
+++ b/mods/cameo/weapons/outpost2.yaml
@@ -300,8 +300,114 @@ edenTigerEMPAA:
 	ValidTargets: Air
 
 edenEMPGP:
-	Inherits: plymouthEMP
+	Inherits: ^TeslaChargedWeapon
+	Inherits: ^TeslaWeapon
+	Inherits: ^MediumFlameWeapon
+	Inherits: ^ShrapnelWeapon
+	Inherits: ^HeavyCannon
+	Inherits: ^MediumCannon
+	Inherits: ^MediumMissile
+	Inherits: ^HeavyMissile
 	ReloadDelay: 30
+	Range: 5500
+	MinRange: 1100
+	Report: bazook1.aud
+	ValidTargets: Ground, Water
+	Projectile: Missile
+		Arm: 0
+		Blockable: false
+		Inaccuracy: 128
+		Image: DRAGON
+		Shadow: true
+		HorizontalRateOfTurn: 15
+		ContrailLength: 8
+		Speed: 256
+		TrailImage: blue_smokey
+	Warhead@TeslaChargedWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@TeslaChargedExtraDamage: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@TeslaChargedWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@TeslaWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@TeslaExtraDamage: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@TeslaWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumFlameWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumFlameWeaponFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumFlameWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@ShrapnelWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@ShrapnelWeaponFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@ShrapnelWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@HeavyCannon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@HeavyCannonPercentage: HealthPercentageDamage
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumCannon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumCannonPercentage: HealthPercentageDamage
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@MediumMissilePercentage: HealthPercentageDamage
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@HeavyMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@HeavyMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 1
+		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
+	Warhead@EMPUnit: AffectsIntegrity
+		Damage: 32000
+		Spread: 1600
+	Warhead@Effect: CreateEffect
+		Explosions: op2_emp_static
+		ImpactSounds: xplos.aud
+		ImpactActors: false
+		ValidTargets: Ground, Ship, Trees
 	Warhead@2Ext: GrantExternalCondition
 		Condition: empdisable
 		Duration: 150

--- a/mods/cameo/weapons/redalert.yaml
+++ b/mods/cameo/weapons/redalert.yaml
@@ -8143,7 +8143,223 @@ MiniNuke:
 		Multiplier: 1,1
 
 ExecutionerDeath:
-	Inherits: MiniNuke
+	ValidTargets: Ground, Trees, Water, Underwater, Air
+	Warhead@Damage: SpreadDamage
+		Spread: 1600
+		Falloff: 160, 80, 40, 20, 10
+		Damage: 160000
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		ValidTargets: Ground, Trees, Water, Air
+		AffectsParent: true
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@1Dam_impact: SpreadDamage
+		Spread: 500
+		Damage: 80000
+		Falloff: 1000, 500, 250, 125, 50, 25, 5
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 2
+		ValidTargets: Ground, Trees, Water, Air
+		AffectsParent: true
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@3Eff_impact: CreateEffect
+		Explosions: nuke_small
+		ImpactSounds: kaboom1.aud
+		ImpactActors: false
+	Warhead@4Dam_areanuke1: SpreadDamage
+		Spread: 1000
+		Damage: 40000
+		Falloff: 1000, 500, 250, 125, 50, 25
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 4
+		ValidTargets: Ground, Trees, Water, Underwater, Air
+		AffectsParent: true
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@4Res_areanukea: DestroyResource
+		Size: 3
+		Delay: 3
+		ResourceAmount: 3
+	Warhead@5Smu_areanukea: LeaveSmudge
+		SmudgeType: Scorch
+		InvalidTargets: Vehicle, Structure, Wall
+		Size: 1
+		Delay: 3
+	Warhead@6Eff_areanuke1: CreateEffect
+		ImpactSounds: kaboom22.aud
+		Delay: 5
+		ImpactActors: false
+	Warhead@7Dam_areanuke2: SpreadDamage
+		Spread: 1500
+		Damage: 20000
+		Falloff: 1000, 500, 250, 125, 50
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 6
+		ValidTargets: Ground, Trees, Water, Underwater, Air
+		AffectsParent: true
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@8Res_areanukeb: DestroyResource
+		Size: 6
+		Delay: 6
+		ResourceAmount: 6
+	Warhead@9Smu_areanukeb: LeaveSmudge
+		SmudgeType: Scorch
+		InvalidTargets: Vehicle, Structure, Wall
+		Size: 2
+		Delay: 6
+	Warhead@8Dam_areanuke2: SpreadDamage
+		Spread: 2000
+		Damage: 10000
+		Falloff: 1000, 500, 250, 125
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 8
+		ValidTargets: Ground, Trees, Water, Underwater, Air
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@11Res_areanukec: DestroyResource
+		Size: 9
+		Delay: 9
+		ResourceAmount: 9
+	Warhead@12Smu_areanukec: LeaveSmudge
+		SmudgeType: Scorch
+		InvalidTargets: Vehicle, Structure, Wall, Trees
+		Size: 3
+		Delay: 9
+	Warhead@10Dam_areanuke3: SpreadDamage
+		Spread: 2500
+		Damage: 5000
+		Falloff: 1000, 500, 250
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 10
+		ValidTargets: Ground, Trees, Water, Underwater, Air
+		AffectsParent: true
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@11Dam_areanuke3: SpreadDamage
+		Spread: 3000
+		Damage: 2500
+		Falloff: 1000, 500
+		Versus:
+			Wood: 100
+			Concrete: 96
+			Steel: 92
+			None: 88
+			Flak: 84
+			Plate: 80
+			Heroic: 76
+			Scout: 72
+			Light: 68
+			Medium: 64
+			Heavy: 60
+			Superheavy: 56
+			Fighter: 52
+			Bomber: 48
+			Helicopter: 44
+			Spaceship: 40
+		Delay: 12
+		ValidTargets: Ground, Trees, Water, Underwater, Air
+		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
+	Warhead@13Smu_areanuke3: LeaveSmudge
+		SmudgeType: Scorch
+		InvalidTargets: Vehicle, Structure, Wall, Trees
+		Size: 4
+		Delay: 12
+	Warhead@13Shake: ShakeScreen
+		Duration: 15
+		Intensity: 5
+		Multiplier: 1,1
 	Report: JUShoEx_OmegaShockwaveStereo.wav
 	SoundVolume: 10
 

--- a/mods/cameo/weapons/redalert2.yaml
+++ b/mods/cameo/weapons/redalert2.yaml
@@ -4231,9 +4231,22 @@ RA2vulcan:
 		Damage: 1
 
 RA2vulcan3:
-	Inherits: RA2vulcan2
+	Inherits: ^RA2SmallArms
+	Inherits: ^RA2Chaingun
+	ValidTargets: Ground, Water, Trees
 	ReloadDelay: 50
+	Range: 5724
+	Burst: 3
+	BurstDelays: 2
 	Report: baocatta.wav, baocattb.wav, baocattc.wav
+	Warhead@SmallArms: SpreadDamage
+		Damage: 2000
+	Warhead@SmallArmsPercentage: HealthPercentageDamage
+		Damage: 1
+	Warhead@Chaingun: SpreadDamage
+		Damage: 2000
+	Warhead@ChaingunPercentage: HealthPercentageDamage
+		Damage: 1
 
 BlackHawkCannon:
 	Inherits: ^RA2SmallArms
@@ -5431,15 +5444,24 @@ IFVAttach:
 	Range: 4c512
 
 TanyaAttach:
-	Inherits: IvanAttach
+	Projectile: InstantHit
+	TargetActorCenter: true
+	Report: icraatta.wav
+	ReloadDelay: 20
+	Range: 2000
 	ValidTargets: Vehicle, Ship, Submarine
 	InvalidTargets: ivanattached, Monster
 	Warhead@1: AttachDelayedWeapon
 		Weapon: TanyaBomb
+		Type: ivanbomb
 		TriggerTime: 50
+		Range: 1
+	Warhead@2: TargetDamage
 
 TanyaBomb:
-	Inherits: IvanBomb
+	Inherits: ^Grenade
+	Inherits: ^ShrapnelWeapon
+	Inherits: ^HeavyBomb
 	Inherits: ^TankDestroyerCannon
 	Inherits: ^MediumCannon
 	Inherits: ^HeavyCannon
@@ -5485,10 +5507,18 @@ TanyaBomb:
 	Warhead@HeavyBombPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Air, Water, Underwater
 		Damage: 50
+	-Warhead@Effect1:
+	-Warhead@Effect2:
 	Warhead@Effect: CreateEffect
 		Explosions: self_destruct
 		ExplosionPalette: effect
 		ImpactSounds: gexpcraa.wav
+		ValidTargets: Ground, Air, Ship, Trees
+	Warhead@EffectWater: CreateEffect
+		Explosions: large_splash
+		ImpactSounds: gexpcraa.wav
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure, Bridge
 
 SEALAttach:
 	Inherits: TanyaAttach

--- a/mods/cameo/weapons/redalert2mod.yaml
+++ b/mods/cameo/weapons/redalert2mod.yaml
@@ -4830,14 +4830,20 @@ NaxiRifleConsE:
 		ContrailStartColor: FFAA55
 
 NaxiRifleLaser:
-	Inherits: NaxiRifle
+	Inherits: ^SmallArms
 	Inherits: ^RA2LaserWeapon
 	ReloadDelay: 60
 	Range: 4097
 	Report: vpriatta.wav
+	ValidTargets: Ground, Water, Air
 	Projectile: Bullet
+		Image: 50CAL
 		ContrailStartColor: ff2d2d
 		ContrailEndColor: f55105
+		ContrailEndColorUsePlayerColor: true
+		ContrailWidth: 200
+		ContrailLength: 20
+		Speed: 10000
 		Width: 25
 	Warhead@SmallArms: SpreadDamage
 		Damage: 4000
@@ -5175,18 +5181,27 @@ NaxiMP40E:
 		ContrailEndColor: E60000
 
 NaxiMP40Laser:
-	Inherits: NaxiMP40
+	Inherits: ^Grenade
+	Inherits: ^HeavyCannon
+	Inherits: ^RA2Chaingun
 	Inherits: ^SmallArms
 	Inherits: ^RA2LaserWeapon
+	ValidTargets: Ground, Water, Trees
 	Report: vpriatta.wav
 	Range: 4384
 	ReloadDelay: 100
 	Burst: 5
 	BurstDelays: 5
 	Projectile: Bullet
+		Image: 50CAL
 		ContrailStartColor: ff2d2d
 		ContrailEndColor: f55105
+		ContrailEndColorUsePlayerColor: true
+		ContrailStartWidth: 15
+		ContrailLength: 8
+		Speed: 10000
 		Width: 25
+		Inaccuracy: 600
 	Warhead@Grenade: SpreadDamage
 		Damage: 2000
 	Warhead@GrenadeFriendlyFire: SpreadDamage
@@ -5217,11 +5232,39 @@ NaxiMP40LaserE:
 	BurstDelays: 3
 
 NaxiFlamerTroop:
-	Inherits: AsianFlamerTurret
-	Range: 4830
+	Inherits: ^LightFlameWeapon
+	ValidTargets: Ground, Water, Trees
 	ReloadDelay: 60
 	Burst: 3
 	BurstDelays: 3
+	Range: 4830
+	StartBurstReport: flamer2.aud
+	Projectile: Bullet
+		Speed: 180, 240
+		LaunchAngle: 10, 20
+		Image: tsflameall
+		Palette: tseffect
+	Warhead@LightFlameWeapon: SpreadDamage
+		Damage: 4000
+	Warhead@LightFlameWeaponFriendlyFire: SpreadDamage
+		Damage: 2000
+	Warhead@LightFlameWeaponPercentage: HealthPercentageDamage
+		Damage: 2
+	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
+		Amount: 4000
+	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
+		Amount: 2000
+	Warhead@Effect: CreateEffect
+		Explosions: ra2_initfire
+		ExplosionPalette: ra2effect
+		-ImpactSounds:
+		ImpactActors: false
+		ValidTargets: Ground, Water
+	Warhead@FireShrapnel: FireShrapnel
+		Weapon: AsianFlameFragment
+		Amount: 2
+		AimChance: 0
+		AimTargetStances: Enemy, Neutral
 
 NaxiFlamerTroopE:
 	Inherits: NaxiFlamerTroop
@@ -5230,7 +5273,18 @@ NaxiFlamerTroopE:
 	BurstDelays: 3
 
 NaxiFlamerTroopExplode:
-	Inherits: AsianFlamerTurret
+	Inherits: ^LightFlameWeapon
+	ValidTargets: Ground, Water, Trees
+	ReloadDelay: 30
+	Burst: 6
+	BurstDelays: 3
+	Range: 6666
+	StartBurstReport: flamer2.aud
+	Projectile: Bullet
+		Speed: 180, 240
+		LaunchAngle: 10, 20
+		Image: tsflameall
+		Palette: tseffect
 	Warhead@LightFlameWeapon: SpreadDamage
 		Damage: 6000
 	Warhead@LightFlameWeaponFriendlyFire: SpreadDamage
@@ -5241,6 +5295,17 @@ NaxiFlamerTroopExplode:
 		Amount: 6000
 	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
 		Amount: 3000
+	Warhead@Effect: CreateEffect
+		Explosions: ra2_initfire
+		ExplosionPalette: ra2effect
+		-ImpactSounds:
+		ImpactActors: false
+		ValidTargets: Ground, Water
+	Warhead@FireShrapnel: FireShrapnel
+		Weapon: AsianFlameFragment
+		Amount: 2
+		AimChance: 0
+		AimTargetStances: Enemy, Neutral
 
 NaxiSniper:
 	Inherits: ^SniperWeapon
@@ -6633,7 +6698,9 @@ NaxiAntiTankCannonCorrosion:
 	Inherits@Corrosion: ^NaxOxidationShells
 
 NaxiAlienPistol:
-	Inherits: Lunar_Green105mm
+	Inherits: ^TeslaWeapon
+	Inherits: ^RA2MediumCannon
+	Inherits@Upgraded: ^LunarNaxisUpgradedCannons
 	Report: nax_aliengun.wav
 	Range: 5136
 	ReloadDelay: 50

--- a/mods/cameo/weapons/tiberiansun.yaml
+++ b/mods/cameo/weapons/tiberiansun.yaml
@@ -2169,9 +2169,60 @@ TSQuadBazooka:
 	BurstDelays: 8
 
 TSHellfireTwin:
-	Inherits: TSHellfire
+	Inherits: ^HeavyCannon
+	Inherits: ^TankDestroyerCannon
+	Inherits: ^ShrapnelWeapon
+	Inherits: ^Grenade
+	Inherits: ^HeavyMissile
+	Inherits: ^MediumMissile
+	ValidTargets: Ground, Water, Trees, Air
+	ReloadDelay: 32
+	Range: 5740
+	Report: orcamis1.aud
 	Burst: 2
 	BurstDelays: 8
+	Warhead@HeavyCannon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@HeavyCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
+	Warhead@TankDestroyerCannon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@TankDestroyerCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
+	Warhead@ShrapnelWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@ShrapnelWeaponFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+	Warhead@ShrapnelWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
+	Warhead@Grenade: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@GrenadeFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2000
+	Warhead@GrenadePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
+	Warhead@HeavyMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@HeavyMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
+	Warhead@MediumMissile: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@MediumMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 2
 ####################################################################################################
 #		Tiberian Sun Other
 ####################################################################################################

--- a/mods/cameo/weapons/warcraft2.yaml
+++ b/mods/cameo/weapons/warcraft2.yaml
@@ -1351,24 +1351,155 @@ wc2gruntslice2:
 		ImpactSounds: wc2_sword1.aud,wc2_sword2.aud,wc2_sword3.aud
 
 wc2axeFire:
-	Inherits: wc2arrowFire
+	Inherits: ^FlakWeapon
+	Inherits: ^Chaingun
+	Inherits: ^MediumCannon
+	Inherits: ^Grenade
+	Inherits: ^TankDestroyerCannon
+	Inherits: ^ArrowWeapon
 	ReloadDelay: 38
 	Range: 6445
 	Report: wc2_axe.aud
-	Projectile:
+	ValidTargets: Ground, Water, Air
+	Projectile: Missile
 		Image: wc2_orc_trollaxethrower_axe
+		Speed: 600
+		HorizontalRateOfTurn: 60
+		VerticalRateOfTurn: 60
+		RangeLimit: 12000
+		AllowSnapping: True
+		CloseEnough: 600
+		ContrailLength: 0
+	Warhead@FlakWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@FlakWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@Chaingun: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@ChaingunPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@MediumCannon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@MediumCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@Grenade: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@GrenadeFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2000
+	Warhead@GrenadePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@TankDestroyerCannon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@TankDestroyerCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@ArrowWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@ArrowWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
 	Warhead@Effect: CreateEffect
 		ImpactSounds: wc2_axe.aud
+		ValidTargets: Ground, Water, Air
 
 wc2axeFirespear:
-	Inherits: wc2highArrowFire
+	Inherits: ^FlakWeapon
+	Inherits: ^Chaingun
+	Inherits: ^MediumCannon
+	Inherits: ^Grenade
+	Inherits: ^TankDestroyerCannon
+	Inherits: ^ArrowWeapon
+	Inherits: ^LaserWeapon
+	Inherits: ^HeavyMissile
+	Inherits: ^HeavyAAWeapon
 	ReloadDelay: 40
 	Range: 7711
 	Report: wc2_axe.aud
-	Projectile:
+	ValidTargets: Ground, Water, Air
+	Projectile: Missile
 		Image: wc2_orc_trollaxethrower_axe
+		Speed: 700
+		LaunchAngle: 70
+		HorizontalRateOfTurn: 70
+		VerticalRateOfTurn: 70
+		RangeLimit: 14000
+		AllowSnapping: True
+		CloseEnough: 700
+		ContrailLength: 0
+		-TrailImage:
+		-MaximumLaunchSpeed:
+		-MinimumLaunchSpeed:
+	Warhead@FlakWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@FlakWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@Chaingun: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@ChaingunPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@MediumCannon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@MediumCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@Grenade: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@GrenadeFriendlyFire: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2000
+	Warhead@GrenadePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@TankDestroyerCannon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@TankDestroyerCannonPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@ArrowWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@ArrowWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@LaserWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@LaserWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@HeavyMissile: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@HeavyMissilePercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
+	Warhead@HeavyAAWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 4000
+	Warhead@HeavyAAWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Air
+		Damage: 2
 	Warhead@Effect: CreateEffect
 		ImpactSounds: wc2_axe.aud
+		ValidTargets: Ground, Water, Air
 
 wc2ogrepunch:
 	Inherits: ^SwordWeapon
@@ -1540,10 +1671,28 @@ wc2catapultFire:
 # Death Knight basic attack
 wc2deathknightFire:
 	Inherits: ^HeavyFlameWeapon
-	Inherits: wc2mageFire
+	Inherits: ^TeslaChargedWeapon
+	ReloadDelay: 40
+	Range: 8000
 	Report: wc2_touchdrk.aud
-	Projectile:
+	ValidTargets: Ground, Water, Trees, Air
+	Projectile: Bullet
+		Speed: 640
 		Image: wc2_effect_death_knight_attack
+	Warhead@TeslaChargedWeapon: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 8000
+	Warhead@TeslaChargedExtraDamage: SpreadDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4000
+	Warhead@TeslaChargedWeaponPercentage: HealthPercentageDamage
+		ValidTargets: Ground, Water, Trees, Air
+		Damage: 4
+	Warhead@Effect: CreateEffect
+		Image: wc2_effect_death_knight_attack
+		Explosions: hit
+		ImpactSounds: wc2_firehit.aud
+		ValidTargets: Ground, Air
 	Warhead@HeavyFlameWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Trees, Air
 		Damage: 8000
@@ -1556,8 +1705,6 @@ wc2deathknightFire:
 		ValidTargets: Ground, Water, Trees, Air
 		Damage: 4
 		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@Effect:
-		Image: wc2_effect_death_knight_attack
 
 # Primary deathcoil projectile
 # 50 WC2 Damage = 11250 ORA damage. Divide by 3 since there's 3 projectiles.
@@ -1622,60 +1769,90 @@ wc2deathknightHaste:
 		ValidTargets: haste_target
 
 wc2deathknightDeathAndDecay:
-	Inherits: wc2mageBlizzard
+	ReloadDelay: 50
+	Range: 8000
 	Report: wc2_decay.aud
-	Warhead@InitialSpreader:
+	ValidTargets: Ground, Water, Air, Trees
+	Projectile: InstantHit
+	Warhead@1Dam_impact: SpreadDamage
+		Spread: 0c1
+		Damage: 1
+	ValidTargets: Ground, Water, Air, Trees
+		AffectsParent: True
+		DamageTypes: Prone50Percent, TriggerProne
+	Warhead@InitialSpreader: FireCluster
 		Weapon: wc2deathknightDeathAndDecay_Spread
 		RandomClusterCount: 5
 		Dimensions: 5, 5
 		Footprint: __x__ _xxx_ xxxxx _xxx_ __x__
 
 wc2deathknightDeathAndDecay_Spread:
-	Inherits: wc2mageBlizzard_Spread
+	ValidTargets: Ground, Water, Air, Trees
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@Projectiles1: FireCluster
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 1
 		Dimensions: 1, 1
 		Footprint: x
 	Warhead@Projectiles2: FireCluster
+		Delay: 30
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 2
 		Dimensions: 3,3
 		Footprint: _x_ xxx _x_
 	Warhead@Projectiles3: FireCluster
+		Delay: 60
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 3
 		Dimensions: 1, 1
 		Footprint: x
 	Warhead@Projectiles4: FireCluster
+		Delay: 90
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 4
 		Dimensions: 3,3
 		Footprint: _x_ xxx _x_
 	Warhead@Projectiles5: FireCluster
+		Delay: 120
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 5
 		Dimensions: 1, 1
 		Footprint: x
 	Warhead@Projectiles6: FireCluster
+		Delay: 150
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 6
 		Dimensions: 3,3
 		Footprint: _x_ xxx _x_
 	Warhead@Projectiles7: FireCluster
+		Delay: 180
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 5
 		Dimensions: 1, 1
 		Footprint: x
 	Warhead@Projectiles8: FireCluster
+		Delay: 210
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 4
 		Dimensions: 3,3
 		Footprint: _x_ xxx _x_
 	Warhead@Projectiles9: FireCluster
+		Delay: 240
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 3
 		Dimensions: 1, 1
 		Footprint: x
 	Warhead@Projectiles10: FireCluster
+		Delay: 270
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 2
 		Dimensions: 3,3
 		Footprint: _x_ xxx _x_
 	Warhead@Projectiles11: FireCluster
+		Delay: 300
 		Weapon: wc2deathknightDeathAndDecay_Hit
+		RandomClusterCount: 1
 		Dimensions: 1, 1
 		Footprint: x
 


### PR DESCRIPTION
## Summary
- AedisToru flagged that weapon `Inherits:` can silently cross faction boundaries even in themes whose *rules* are already per-faction-split (Lunar Tiger inheriting the Naxi Maus weapon). Full audit of every `weapons/*.yaml` file found 19 flagged instances across 7 themes; 2 were false positives on verification, leaving 17 real bugs.
- Fixed 16 of them by cloning each dependent weapon's cross-faction base inline (merged fields, kept only safe `^`-template inherits) instead of promoting the base to a shared template. Verified gameplay-identical by diffing each edited weapon against its untouched base.
- `LunarTigerCannon` was already fixed independently by AedisToru (commit `a77394902`) partway through this audit.
- One case is left open: TiberianSun's `TSCABALObeliskLaserFire` inherits Nod's `TSObeliskLaserFire` — CABAL buildings are generally modeled as Nod tech-upgrades elsewhere in that file, so this may be intentional. Needs a call on whether CABAL counts as a separate faction here.
- TiberianDawn, TKM, and StarCraft were audited and found clean.

Full findings and per-weapon rationale: `docs/weapon-crossfaction-inherit-audit/audit.md` (not included in this PR — internal docs, will follow separately if wanted).

## Test plan
- [ ] Confirm affected units (Lunar Tiger already confirmed by AedisToru; Naxi Alien/Flamer/MP40/Rifle-laser units, Ordos AA mine, Eden EMP GP, Orc troll-axe/death-knight units, GDI/CABAL Orca-twin, RA1 Executioner death, RA2 Conscript/Tanya) behave identically in-game to before this change
- [ ] Decide on `TSCABALObeliskLaserFire` (leave as-is / fix) in a follow-up