### PR TITLE
Fix promotion/upgrade replacement units showing before unlock

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ixian/rules/infantry.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/rules/infantry.yaml
@@ -15,7 +15,7 @@ twin_rocket_trooper.ixian:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 20
-		Prerequisites: ~d2k_barracks.ixian, up_twin_rocket_trooper.ixian
+		Prerequisites: ~d2k_barracks.ixian, ~up_twin_rocket_trooper.ixian
 		Description: template-antitank-antiair-infantry.description
 		IconPalette: d2kunit
 	Valued:
@@ -120,7 +120,7 @@ storm_infantry.ixian:
 		Queue: Infantry, RAInfantry
 		Description: actor-shock_infantry.description
 		IconPalette: d2kunit
-		Prerequisites: ~d2k_barracks.ixian, up_storm_infantry.ixian, research_centre.ixian
+		Prerequisites: ~d2k_barracks.ixian, ~up_storm_infantry.ixian, research_centre.ixian
 	Mobile:
 		Speed: 44
 	Health:

--- a/mods/cameo/ContentPacks/D2k/Ixian/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/rules/vehicles.yaml
@@ -925,7 +925,7 @@ storm_raider.ixian:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~heavy_factory.ixian, up_stormraider.ixian, research_centre.ixian
+		Prerequisites: ~heavy_factory.ixian, ~up_stormraider.ixian, research_centre.ixian
 		Description: actor-shock_raider.description
 		IconPalette: player
 	Valued:
@@ -1002,7 +1002,7 @@ heavy_rocket_raider.ixian:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~heavy_factory.ixian, up_raider.ixian
+		Prerequisites: ~heavy_factory.ixian, ~up_raider.ixian
 		Description: actor-rocket_raider.description
 	Tooltip:
 		Name: Heavy Ix Raider

--- a/mods/cameo/ContentPacks/D2k/Ordos/rules/infantry.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/rules/infantry.yaml
@@ -15,7 +15,7 @@ aatrooper.ordos:
 		Name: Anti Air Trooper
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~d2k_barracks.ordos, up_aatrooper.ordos
+		Prerequisites: ~d2k_barracks.ordos, ~up_aatrooper.ordos
 		Queue: Infantry, RAInfantry
 		Description: template-antitank-antiair-infantry.description
 	Health:

--- a/mods/cameo/ContentPacks/D2k/Ordos/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/rules/vehicles.yaml
@@ -74,7 +74,7 @@ tleilax_labcrawl.ordos:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 100
-		Prerequisites: ~heavy_factory.ordos, up_tleilax_labcrawl.ordos, research_centre.ordos
+		Prerequisites: ~heavy_factory.ordos, ~up_tleilax_labcrawl.ordos, research_centre.ordos
 		Description: Tleilaxu Mobile Laboratory. Can contaminate enemy infantry and heal friendlies. Equipped with AA Rockets.
 		IconPalette: windows256
 	Valued:
@@ -906,7 +906,7 @@ python.ordos:
 		Cost: 2500
 	Buildable:
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~heavy_factory.ordos, up_python.ordos, outpost.ordos
+		Prerequisites: ~heavy_factory.ordos, ~up_python.ordos, outpost.ordos
 		BuildPaletteOrder: 50
 		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks
 		IconPalette: d2kunit
@@ -1455,7 +1455,7 @@ stealth_raider.ordos:
 	Valued:
 		Cost: 1300
 	Buildable:
-		Prerequisites: ~light_factory.ordos, up_stealth_raider.ordos
+		Prerequisites: ~light_factory.ordos, ~up_stealth_raider.ordos
 		BuildPaletteOrder: 30
 		Description: Invisible Raider Trike\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 		IconPalette: d2kunit
@@ -1684,7 +1684,7 @@ heavycombattank.ordos:
 		BuildPaletteOrder: 40
 		Description: template-mbt.description
 		IconPalette: d2kunit
-		Prerequisites: ~heavy_factory.ordos, up_heavycombattank.ordos
+		Prerequisites: ~heavy_factory.ordos, ~up_heavycombattank.ordos
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -1803,7 +1803,7 @@ autogun_tank.ordos:
 		Cost: 2800
 	Buildable:
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~heavy_factory.ordos, up_heavy_autogun_tank.ordos
+		Prerequisites: ~heavy_factory.ordos, ~up_heavy_autogun_tank.ordos
 		BuildPaletteOrder: 50
 		Description: Heavy Anti-Infantry Tank\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks
 	UpdatesPlayerStatistics:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/rules/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/rules/naval.yaml
@@ -398,7 +398,7 @@ tsun.asian:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 30
-		Prerequisites: ~cgyard.asian, up_tsunami.asian, cgmiac.asian
+		Prerequisites: ~cgyard.asian, ~up_tsunami.asian, cgmiac.asian
 		Queue: Naval, RANaval
 		Description: actor-aatsun.description
 	Selectable:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/rules/vehicles.yaml
@@ -751,7 +751,7 @@ mecha.asian:
 		Name: Pulverizer Mecha
 	Buildable:
 		BuildPaletteOrder: 75
-		Prerequisites: ~cgweap.asian, up_mecha.asian, cgtech.asian
+		Prerequisites: ~cgweap.asian, ~up_mecha.asian, cgtech.asian
 		Queue: Vehicle, RAVehicle
 		Description: actor-aamecha.description
 	Mobile:
@@ -864,7 +864,7 @@ railt2.asian:
 		Name: Heavy Railgun Tank
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~cgweap.asian, up_railt2.asian, cgtech.asian
+		Prerequisites: ~cgweap.asian, ~up_railt2.asian, cgtech.asian
 		Queue: Vehicle, RAVehicle
 	Mobile:
 		Locomotor: tracked

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/rules/vehicles.yaml
@@ -882,7 +882,7 @@ quantumtank.steel:
 		Name: Quantum Tank
 	Buildable:
 		BuildPaletteOrder: 30
-		Prerequisites: ~qaweap.steel, up_quantumtank.steel
+		Prerequisites: ~qaweap.steel, ~up_quantumtank.steel
 		Queue: Vehicle, RAVehicle
 		Description: template-mbt.description
 	Mobile:
@@ -1068,7 +1068,7 @@ manta_hunt.steel:
 		Name: Barracuda
 	Buildable:
 		BuildPaletteOrder: 40
-		Prerequisites: ~qaweap.steel, up_manta_hunt.steel
+		Prerequisites: ~qaweap.steel, ~up_manta_hunt.steel
 		Queue: Vehicle, RAVehicle
 		Description: Kills Infantry better
 	Mobile:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/rules/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/rules/aircraft.yaml
@@ -314,7 +314,7 @@ me262.nax:
 		Cost: 1500
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: ~airfield.nax, up_me262.nax
+		Prerequisites: ~airfield.nax, ~up_me262.nax
 		Queue: Aircraft, RAAircraft
 		Description: actor-bpln.description
 	Health:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/rules/vehicles.yaml
@@ -356,7 +356,7 @@ kingtiger.nax:
 		Name: King Tiger Heavy Tank
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap.nax, up_kingtiger.nax
+		Prerequisites: ~weap.nax, ~up_kingtiger.nax
 		Queue: Vehicle, RAVehicle
 		Description: template-mbt.description
 	Mobile:
@@ -618,7 +618,7 @@ brummbar.nax:
 		Name: Brummbär
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap.nax, radar.nax, up_kingtiger.nax
+		Prerequisites: ~weap.nax, radar.nax, ~up_kingtiger.nax
 		Queue: Vehicle, RAVehicle
 		Description: actor-nax_brummbar.description
 	Mobile:
@@ -770,7 +770,7 @@ jagdpanzer.nax:
 		Name: Jagdpanzer
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap.nax, radar.nax, up_kingtiger.nax
+		Prerequisites: ~weap.nax, radar.nax, ~up_kingtiger.nax
 		Queue: Vehicle, RAVehicle
 		Description: actor-nax_jagdpanzer.description
 	Mobile:
@@ -1278,7 +1278,7 @@ assault.nax:
 		Name: Imperial Assault Tank
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap.nax, up_kingtiger.nax, ~disabled
+		Prerequisites: ~weap.nax, ~up_kingtiger.nax, ~disabled
 		Queue: Vehicle, RAVehicle
 		Description: template-mbt.description
 	Mobile:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/rules/vehicles.yaml
@@ -426,7 +426,7 @@ mtnk.latin:
 		Cost: 1800
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~cgweap.latin, up_mtnk.latin
+		Prerequisites: ~cgweap.latin, ~up_mtnk.latin
 		Queue: Vehicle, RAVehicle
 		Description: template-mbt.description
 	Mobile:
@@ -888,7 +888,7 @@ cartel.latin:
 		Name: Cartel Truck
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~cgweap.latin, cgspy.latin, up_cartel.latin
+		Prerequisites: ~cgweap.latin, cgspy.latin, ~up_cartel.latin
 		Queue: Vehicle, RAVehicle
 		Description: actor-latin_humvee.description
 	Mobile:
@@ -1039,7 +1039,7 @@ burrito.latin:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 80
-		Prerequisites: ~cgweap.latin, up_burrito.latin, cgup.latin
+		Prerequisites: ~cgweap.latin, ~up_burrito.latin, cgup.latin
 		Description: actor-latin_burrito.description
 	Tooltip:
 		Name: Burrito

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/infantry.yaml
@@ -177,7 +177,7 @@ gdiempgrenadier:
 		Name: EMP Grenadier
 	Buildable:
 		BuildPaletteOrder: 40
-		Prerequisites: ~pyle, upgdiempgrenadier
+		Prerequisites: ~pyle, ~upgdiempgrenadier
 		Queue: Infantry, RAInfantry
 		Description: actor-empgrenadier.description
 	Mobile:
@@ -234,7 +234,7 @@ gdimissilesoldier:
 		Name: Sonic Missile Soldier
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~pyle, upgdimissilesoldier
+		Prerequisites: ~pyle, ~upgdimissilesoldier
 		Queue: Infantry, RAInfantry
 		Description: actor-e3.description
 	Mobile:
@@ -442,7 +442,7 @@ gdihavoc:
 	Buildable:
 		BuildLimit: 1
 		BuildPaletteOrder: 50
-		Prerequisites: ~pyle, eye, upgdihavoc
+		Prerequisites: ~pyle, eye, ~upgdihavoc
 		Queue: Infantry, RAInfantry
 		Description: actor-havoc.description
 	RenderSprites:

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/rules/vehicles.yaml
@@ -550,7 +550,7 @@ gdiassaultapc:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 40
-		Prerequisites: ~weap, eye, upgdiassaultapc
+		Prerequisites: ~weap, eye, ~upgdiassaultapc
 		Description: template-opentopped.description
 	Mobile:
 		Speed: 100
@@ -633,7 +633,7 @@ gdihumvee:
 		Name: Humvee Mk. II
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~weap, upgdihumvee
+		Prerequisites: ~weap, ~upgdihumvee
 		Queue: Vehicle, RAVehicle
 		Description: actor-jeep.description
 	Valued:
@@ -726,7 +726,7 @@ gdipredator:
 		Name: Predator Tank
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap, upgdipredator
+		Prerequisites: ~weap, ~upgdipredator
 		Queue: Vehicle, RAVehicle
 		Description: actor-gdipredator.description
 	Mobile:
@@ -826,7 +826,7 @@ gdimammoth3:
 		Name: Mammoth Tank Mk. III
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~weap, eye, upgdimammoth3
+		Prerequisites: ~weap, eye, ~upgdimammoth3
 		Queue: Vehicle, RAVehicle
 		Description: actor-htnk.description
 	Mobile:
@@ -914,7 +914,7 @@ gdiexosuit:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 20
-		Prerequisites: ~weap, eye, upgdihavoc
+		Prerequisites: ~weap, eye, ~upgdihavoc
 		Description: actor-exosuit.description
 	Mobile:
 		TurnSpeed: 40

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/aircraft.yaml
@@ -137,7 +137,7 @@ nodvenom:
 		Name: Venom
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~hpad.nod, td_nod_templeprime, upnodvenom
+		Prerequisites: ~hpad.nod, td_nod_templeprime, ~upnodvenom
 		Queue: Aircraft, RAAircraft
 		Description: actor-venom.description
 	Aircraft:

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/infantry.yaml
@@ -207,7 +207,7 @@ cheme3:
 		Locomotor: chem
 	Buildable:
 		BuildPaletteOrder: 30
-		Prerequisites: ~hand, upchemicalrocket
+		Prerequisites: ~hand, ~upchemicalrocket
 		Queue: Infantry, RAInfantry
 		Description: actor-cheme3.description
 	Armament@PRIMARY: ##########
@@ -307,7 +307,7 @@ tsblackhandflamer:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 100
-		Prerequisites: ~hand, hq.nod, upblackhandflamer
+		Prerequisites: ~hand, hq.nod, ~upblackhandflamer
 		Description: actor-blackhandflamer.description
 	Valued:
 		Cost: 600
@@ -364,7 +364,7 @@ tsstealthsoldier:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 100
-		Prerequisites: ~hand, tmpl, upstealthsoldier
+		Prerequisites: ~hand, tmpl, ~upstealthsoldier
 		Description: actor-stealthsoldier.description
 	Valued:
 		Cost: 500
@@ -430,7 +430,7 @@ nodlasercommando:
 	Buildable:
 		BuildLimit: 1
 		BuildPaletteOrder: 50
-		Prerequisites: ~hand, td_nod_templeprime, upnodvenom
+		Prerequisites: ~hand, td_nod_templeprime, ~upnodvenom
 		Queue: Infantry, RAInfantry
 		Description: actor-lasercommando.description
 	RenderSprites:

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/rules/vehicles.yaml
@@ -18,7 +18,7 @@ nodspecter:
 	Tooltip:
 		Name: Specter Artillery
 	Buildable:
-		Prerequisites: ~afld, hq.nod, upnodspecter
+		Prerequisites: ~afld, hq.nod, ~upnodspecter
 		BuildPaletteOrder: 60
 		Queue: Vehicle, RAVehicle
 		Description: actor-specter.description
@@ -557,7 +557,7 @@ chembike:
 		Cost: 750
 	Buildable:
 		BuildPaletteOrder: 30
-		Prerequisites: ~afld, upchemicalbike
+		Prerequisites: ~afld, ~upchemicalbike
 		Queue: Vehicle, RAVehicle
 		Description: actor-bike.description
 	Mobile:
@@ -634,7 +634,7 @@ chemstnk:
 		Type: Medium
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: ~afld, tmpl, upchemicalstealthtank
+		Prerequisites: ~afld, tmpl, ~upchemicalstealthtank
 		Queue: Vehicle, RAVehicle
 		Description: actor-stnk.description
 	Armament:
@@ -678,7 +678,7 @@ chemssm:
 		BuildPaletteOrder: 100
 		Queue: Vehicle, RAVehicle
 		Description: actor-mssm.description
-		Prerequisites: ~afld, td_nod_templeprime, upchemicalssmlauncher
+		Prerequisites: ~afld, td_nod_templeprime, ~upchemicalssmlauncher
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -735,7 +735,7 @@ nodbuggy2:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 50
-		Prerequisites: ~afld, upnodbuggy2
+		Prerequisites: ~afld, ~upnodbuggy2
 	Valued:
 		Cost: 500
 	Mobile:
@@ -826,7 +826,7 @@ nodltnk2:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 50
-		Prerequisites: ~afld, upnodltnk2
+		Prerequisites: ~afld, ~upnodltnk2
 		Description: actor-ltnk2.description
 	Mobile:
 		Speed: 100
@@ -892,7 +892,7 @@ nodftnk2:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 50
-		Prerequisites: ~afld, hq.nod, upnodftnk2
+		Prerequisites: ~afld, hq.nod, ~upnodftnk2
 		Description: actor-ftnk.description
 	Mobile:
 		Speed: 75
@@ -950,7 +950,7 @@ tanodharv:
 		Sequence: harvesting
 		Palette: ra2effect
 	Buildable:
-		Prerequisites: ~afld, upstealthsoldier
+		Prerequisites: ~afld, ~upstealthsoldier
 		Queue: Vehicle, RAVehicle
 	RenderSprites:
 		Image: tanodharv

--- a/mods/cameo/rules/redalert.yaml
+++ b/mods/cameo/rules/redalert.yaml
@@ -929,7 +929,7 @@ ra_conscript_ak:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
-		Prerequisites: ~barr, ra_doctrine_conscription
+		Prerequisites: ~barr, ~ra_doctrine_conscription
 		Queue: Infantry, RAInfantry
 		AdditionalActors: ra_cons_molo
 		Description: actor-e2.description
@@ -1327,7 +1327,7 @@ ra_dragunov:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 25
-		Prerequisites: ~barr, ra_doctrine_conscription
+		Prerequisites: ~barr, ~ra_doctrine_conscription
 		Queue: Infantry, RAInfantry
 		Description: Powerful Anti Material Sniper. Strong vs Tanks and Aircraft
 	Mobile:
@@ -1372,7 +1372,7 @@ e3flamer:
 	Tooltip:
 		Name: Fire Rocket Soldier
 	Buildable:
-		Prerequisites: ~barr, ra_doctrine_inferno
+		Prerequisites: ~barr, ~ra_doctrine_inferno
 		Queue: Infantry, RAInfantry
 	Valued:
 		Cost: 400
@@ -1704,7 +1704,7 @@ ra_zapper:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 130
-		Prerequisites: ~barr, stek, ra_doctrine_teslatech
+		Prerequisites: ~barr, stek, ~ra_doctrine_teslatech
 		Description: actor-shok.description
 	Valued:
 		Cost: 1200
@@ -2314,7 +2314,7 @@ ra_grad:
 		Name: Grad
 	Buildable:
 		BuildPaletteOrder: 50
-		Prerequisites: ~raweap, stek, ra_doctrine_heavyarmor
+		Prerequisites: ~raweap, stek, ~ra_doctrine_heavyarmor
 		Queue: Vehicle, RAVehicle
 		Description: actor-v2rl.description
 	Mobile:
@@ -2460,7 +2460,7 @@ V2RLNUKE:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 80
-		Prerequisites: ~raweap, stek, ra_doctrine_nuclearwar
+		Prerequisites: ~raweap, stek, ~ra_doctrine_nuclearwar
 		Description: actor-v2rl.description
 	Valued:
 		Cost: 2300
@@ -2716,7 +2716,7 @@ hammertank:
 	Inherits@UnstableIsotopesUpgradeRA1: ^UnstableIsotopesUpgradeRA1
 	Buildable:
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~raweap, ra_upgrade_hammertank, ~!ra_upgrade_heavyteslatank, ~!ra_upgrade_kotintank
+		Prerequisites: ~raweap, ~ra_upgrade_hammertank, ~!ra_upgrade_heavyteslatank, ~!ra_upgrade_kotintank
 		BuildPaletteOrder: 120
 		Description: actor-kotin.description
 	Valued:
@@ -2796,7 +2796,7 @@ TTNK2:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 170
-		Prerequisites: ~raweap, ra_upgrade_heavyteslatank
+		Prerequisites: ~raweap, ~ra_upgrade_heavyteslatank
 		Description: actor-ttnk2.description
 	Valued:
 		Cost: 3500
@@ -2897,7 +2897,7 @@ Kotin:
 	Inherits@UnstableIsotopesUpgradeRA1: ^UnstableIsotopesUpgradeRA1
 	Buildable:
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~raweap, ra_upgrade_kotintank
+		Prerequisites: ~raweap, ~ra_upgrade_kotintank
 		BuildPaletteOrder: 120
 		Description: actor-kotin.description
 	Valued:
@@ -3116,7 +3116,7 @@ Kotin:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 180
-		Prerequisites: ~raweap, stek, ra_doctrine_heavyarmor
+		Prerequisites: ~raweap, stek, ~ra_doctrine_heavyarmor
 		Description: actor-htnk.description
 	Valued:
 		Cost: 4000
@@ -3478,7 +3478,7 @@ ra_industrialminer:
 	Tooltip:
 		Name: Soviet Heavy Industrial Miner
 	Buildable:
-		Prerequisites: ~raweap, ~raproc.soviet, ra_doctrine_industrialefficiency
+		Prerequisites: ~raweap, ~raproc.soviet, ~ra_doctrine_industrialefficiency
 	Valued:
 		Cost: 1200
 	StoresResources:
@@ -3979,7 +3979,7 @@ MODBTR:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 120
-		Prerequisites: ~raweap, ra_doctrine_conscription
+		Prerequisites: ~raweap, ~ra_doctrine_conscription
 		Description: actor-btr.description
 	Valued:
 		Cost: 1600
@@ -4551,7 +4551,7 @@ yaktesla:
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		BuildPaletteOrder: 30
-		Prerequisites: ~raafld, ra_upgrade_yaktesla
+		Prerequisites: ~raafld, ~ra_upgrade_yaktesla
 		Description: actor-yak.description
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
@@ -4667,7 +4667,7 @@ yakarmored:
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		BuildPaletteOrder: 30
-		Prerequisites: ~raafld, ra_upgrade_yakarmored
+		Prerequisites: ~raafld, ~ra_upgrade_yakarmored
 		Description: actor-yak.description
 	Valued:
 		Cost: 1600
@@ -4769,7 +4769,7 @@ yaknuclear:
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		BuildPaletteOrder: 30
-		Prerequisites: ~raafld, ra_upgrade_yaknuclear
+		Prerequisites: ~raafld, ~ra_upgrade_yaknuclear
 		Description: actor-yak.description
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
@@ -5202,7 +5202,7 @@ su57:
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		BuildPaletteOrder: 50
-		Prerequisites: ~raafld, stek, ra_doctrine_heavyarmor
+		Prerequisites: ~raafld, stek, ~ra_doctrine_heavyarmor
 		Description: actor-su57.description
 	Valued:
 		Cost: 3000
@@ -5500,7 +5500,7 @@ ra_kamov:
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		BuildPaletteOrder: 20
-		Prerequisites: ~raafld, ra_doctrine_teslatech
+		Prerequisites: ~raafld, ~ra_doctrine_teslatech
 		Description: actor-hind.description
 	Valued:
 		Cost: 2100
@@ -8014,7 +8014,7 @@ ra_gigafactory:
 	Inherits: RAWEAP
 	Inherits@shape: ^4x3Shape
 	Buildable:
-		Prerequisites: ~rafact.soviet, raproc.soviet, ra_doctrine_industrialefficiency
+		Prerequisites: ~rafact.soviet, raproc.soviet, ~ra_doctrine_industrialefficiency
 		BuildDuration: 750
 		BuildDurationModifier: 100
 		Description: template-factory.description
@@ -8592,7 +8592,7 @@ ra_largeairfield:
 		# Reveal from the building center instead, like the Soviet War Factory.
 		Type: CenterPosition
 	Buildable:
-		Prerequisites: ~rafact.soviet, dome.soviet, ra_doctrine_industrialefficiency
+		Prerequisites: ~rafact.soviet, dome.soviet, ~ra_doctrine_industrialefficiency
 		BuildDuration: 625
 		BuildDurationModifier: 100
 		Description: actor-raafld.description
@@ -10246,7 +10246,7 @@ sheridan:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
-		Prerequisites: ~raweapa, upsheridan
+		Prerequisites: ~raweapa, ~upsheridan
 		Queue: Vehicle, RAVehicle
 		Description: actor-sheridan.description
 	Mobile:
@@ -10590,7 +10590,7 @@ reconranger:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 30
-		Prerequisites: ~raweapa, upreconranger
+		Prerequisites: ~raweapa, ~upreconranger
 		Description: actor-jeep.description2
 	Valued:
 		Cost: 500
@@ -10682,7 +10682,7 @@ MODTIGER:
 	Inherits@ChronoArmor: ^ChronoArmor
 	Buildable:
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~raweapa, upalliedtiger
+		Prerequisites: ~raweapa, ~upalliedtiger
 		BuildPaletteOrder: 110
 		Description: actor-tiger.description
 	Tooltip:
@@ -10939,7 +10939,7 @@ HBOX:
 	Buildable:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 50
-		Prerequisites: ~rafact.allies, uphbox
+		Prerequisites: ~rafact.allies, ~uphbox
 		Description: actor-hbox.description
 	Valued:
 		Cost: 1300
@@ -11005,7 +11005,7 @@ SAPC:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 130
-		Prerequisites: ~raweapa, atek, upphasetransport
+		Prerequisites: ~raweapa, atek, ~upphasetransport
 		Description: actor-sapc.description
 	Valued:
 		Cost: 1800
@@ -12396,7 +12396,7 @@ cyberdog:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 29
-		Prerequisites: upcyberdog, ~barr
+		Prerequisites: ~upcyberdog, ~barr
 		Description: Cybernetically modified dog that is far more durable and can attack vehicles.
 	Valued:
 		Cost: 1000
@@ -13728,7 +13728,7 @@ MODCARR:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 60
-		Prerequisites: ~modraweapj, uparmoredcarr
+		Prerequisites: ~modraweapj, ~uparmoredcarr
 		Description: actor-gtnk.description
 	Valued:
 		Cost: 700
@@ -13841,7 +13841,7 @@ typechiha:
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 50
-		Prerequisites: ~modraweapj, upchiha
+		Prerequisites: ~modraweapj, ~upchiha
 		Description: template-mbt.description
 	Valued:
 		Cost: 1200
@@ -14076,7 +14076,7 @@ MODBGGY:
 	Buildable:
 		BuildPaletteOrder: 30
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~modraweapj, upgrenadebuggy
+		Prerequisites: ~modraweapj, ~upgrenadebuggy
 		Description: actor-jpbggy.description
 	Mobile:
 		Speed: 120

--- a/mods/cameo/rules/redalert2.yaml
+++ b/mods/cameo/rules/redalert2.yaml
@@ -6203,7 +6203,7 @@ RA2HMGTK:
 		RequiresCondition: tree
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: ~ra2gaweap, ra2_allies_upgrade_heavymiragetank, ra2gatech
+		Prerequisites: ~ra2gaweap, ~ra2_allies_upgrade_heavymiragetank, ra2gatech
 		Queue: Vehicle, RAVehicle
 		Description: actor-mgtk.description
 	Mobile:

--- a/mods/cameo/rules/starcraft.yaml
+++ b/mods/cameo/rules/starcraft.yaml
@@ -3525,7 +3525,7 @@ SCMADCAP:
 	Power:
 		Amount: -15
 	Buildable:
-		Prerequisites: ~scbarracks, upmadcap
+		Prerequisites: ~scbarracks, ~upmadcap
 		Queue: Infantry, RAInfantry
 		Description: actor-scmadcap.description
 	Mobile:
@@ -4467,7 +4467,7 @@ SCGOLIATH2:
 		Amount: -120
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~scarmory, upgoliathmk2
+		Prerequisites: ~scarmory, ~upgoliathmk2
 		Description: actor-scgoliath2.description
 	Mobile:
 		Speed: 75
@@ -4750,7 +4750,7 @@ SCSUNDOG:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
-		Prerequisites: ~scstarport, upsundog
+		Prerequisites: ~scstarport, ~upsundog
 		Queue: Aircraft, RAAircraft
 		Description: actor-scsundog.description
 	Aircraft:
@@ -4893,7 +4893,7 @@ SCWYVERN:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
-		Prerequisites: ~scstarport, scarmory, upwyvern
+		Prerequisites: ~scstarport, scarmory, ~upwyvern
 		Queue: Aircraft, RAAircraft
 		Description: actor-scwyvern.description
 	Aircraft:
@@ -5219,7 +5219,7 @@ SCMEDIVAC:
 		OverrideActor: scdropship
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~scstarport, upsilvertongue
+		Prerequisites: ~scstarport, ~upsilvertongue
 		Queue: Aircraft, RAAircraft
 		Description: actor-scmedivac.description
 	Aircraft:
@@ -8198,7 +8198,7 @@ SCLEGIONNAIRE:
 		Amount: -35
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~scgateway, uplegionnaire
+		Prerequisites: ~scgateway, ~uplegionnaire
 		Queue: Infantry, RAInfantry
 		Description: actor-sclegionnaire.description
 	Mobile:
@@ -8881,7 +8881,7 @@ SCTALON:
 		Amount: -15
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: ~scspawningpool, uptalon
+		Prerequisites: ~scspawningpool, ~uptalon
 		Queue: SCZergInfantry
 		AdditionalActors: sczergling, sczergling
 		Description: actor-sctalon.description

--- a/mods/cameo/rules/tiberiansun.yaml
+++ b/mods/cameo/rules/tiberiansun.yaml
@@ -7107,7 +7107,7 @@ TSTALTITAN:
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~tsgtweap, uptitanmkii
+		Prerequisites: ~tsgtweap, ~uptitanmkii
 		Description: General purpose mechanized walker.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
 		Locomotor: heavytracked
@@ -7176,7 +7176,7 @@ TSJUGG2:
 	Buildable:
 		BuildPaletteOrder: 60
 		Queue: Vehicle, RAVehicle
-		Prerequisites: ~tsgtweap, tsgttech, upjuggmkii
+		Prerequisites: ~tsgtweap, tsgttech, ~upjuggmkii
 		Description: General purpose mechanized walker.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
 		Locomotor: heavytracked
@@ -7490,7 +7490,7 @@ TSTALWOLV:
 		BuildPaletteOrder: 25
 		BuildDuration: 250
 		BuildDurationModifier: 100
-		Prerequisites: ~tsgtweap, upwolverinemkii
+		Prerequisites: ~tsgtweap, ~upwolverinemkii
 		Description: Anti-personnel walker.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Mobile:
 		TurnSpeed: 32
@@ -7682,7 +7682,7 @@ TSMKII:
 		Name: Mammoth MK. II
 	Buildable:
 		BuildPaletteOrder: 140
-		Prerequisites: ~tsgtweap, tsgttech, !existingmkii, upmammothmkii
+		Prerequisites: ~tsgtweap, tsgttech, !existingmkii, ~upmammothmkii
 		Queue: Vehicle, RAVehicle
 		BuildLimit: 1
 		Description: Slow heavy walker. Armed with dual railguns and rocket launchers. Strong vs Everything. Maximum 1 can be built.
@@ -10447,7 +10447,7 @@ TSZONEORCA:
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Aircraft, RAAircraft
-		Prerequisites: ~tsgthpad, upzoneorca
+		Prerequisites: ~tsgthpad, ~upzoneorca
 		Description: Fast assault gunship with\ndual missile launchers.\n  Strong vs Aircraft, Vehicles
 	Aircraft:
 		Speed: 165

--- a/mods/cameo/rules/tkm.yaml
+++ b/mods/cameo/rules/tkm.yaml
@@ -905,7 +905,7 @@ tkmmarine:
 		Cost: 300
 	Buildable:
 		BuildPaletteOrder: 1
-		Prerequisites: ~tkmbarracks, upnatoarsenal
+		Prerequisites: ~tkmbarracks, ~upnatoarsenal
 		Queue: Infantry, RAInfantry
 		IconPalette: ra2
 	Tooltip:
@@ -1051,7 +1051,7 @@ tkmthermonaut:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
-		Prerequisites: ~tkmbarracks, uptitanarsenal, tkmradar
+		Prerequisites: ~tkmbarracks, ~uptitanarsenal, tkmradar
 		Queue: Infantry, RAInfantry
 		IconPalette: player
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
@@ -1113,7 +1113,7 @@ tkmtrooper:
 		Cost: 200
 	Buildable:
 		BuildPaletteOrder: 1
-		Prerequisites: ~tkmbarracks, uptitanarsenal
+		Prerequisites: ~tkmbarracks, ~uptitanarsenal
 		Queue: Infantry, RAInfantry
 		IconPalette: ra2
 	Tooltip:
@@ -1350,7 +1350,7 @@ tkmsniper:
 		Name: Sniper
 	Buildable:
 		BuildPaletteOrder: 40
-		Prerequisites: ~tkmbarracks, upberezkacloak, tkmradar
+		Prerequisites: ~tkmbarracks, ~upberezkacloak, tkmradar
 		Queue: Infantry, RAInfantry
 		Description: actor-ra2snipe.description
 	Mobile:
@@ -1540,7 +1540,7 @@ tkmspetsnaz:
 	Buildable:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 120
-		Prerequisites: ~tkmbarracks, uptitanarsenal, tkmradar
+		Prerequisites: ~tkmbarracks, ~uptitanarsenal, tkmradar
 		Description: actor-seal.description
 	Armament@PRIMARY:
 		Weapon: tkmsmg
@@ -1874,7 +1874,7 @@ tkmquadtruck:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 22
-		Prerequisites: ~tkmfactory, upberezkacloak, tkmradar
+		Prerequisites: ~tkmfactory, ~upberezkacloak, tkmradar
 		Queue: Vehicle, RAVehicle
 		Description: actor-jeep.description
 	Mobile:
@@ -1925,7 +1925,7 @@ tkmzaza:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 22
-		Prerequisites: ~tkmfactory, uptitanarsenal, tkmtechcenter
+		Prerequisites: ~tkmfactory, ~uptitanarsenal, tkmtechcenter
 		Queue: Vehicle, RAVehicle
 		Description: actor-jeep.description
 	Mobile:
@@ -2011,7 +2011,7 @@ tkmstryker:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 22
-		Prerequisites: ~tkmfactory, upnatoarsenal, tkmradar
+		Prerequisites: ~tkmfactory, ~upnatoarsenal, tkmradar
 		Queue: Vehicle, RAVehicle
 		Description: actor-jeep.description
 	Mobile:
@@ -2071,7 +2071,7 @@ tkmabrams:
 		Name: Abrams
 	Buildable:
 		BuildPaletteOrder: 23
-		Prerequisites: ~tkmfactory, upnatoarsenal, tkmradar
+		Prerequisites: ~tkmfactory, ~upnatoarsenal, tkmradar
 		Queue: Vehicle, RAVehicle
 		Description: TKM NATO heavy armor.\n Strong vs Vehicles\n Weak vs Aircraft, Infantry
 	Mobile:
@@ -2125,7 +2125,7 @@ tkmabramspoint:
 	Tooltip:
 		Name: Abrams (Point Defense System)
 	Buildable:
-		Prerequisites: ~tkmfactory, uppointdefensesystem, tkmradar, ~disabled
+		Prerequisites: ~tkmfactory, ~uppointdefensesystem, tkmradar, ~disabled
 		Queue: Vehicle, RAVehicle
 		Description: TKM NATO heavy armor.\n Strong vs Vehicles\n Weak vs Aircraft, Infantry
 	RenderRangeCircle:
@@ -2154,7 +2154,7 @@ t72:
 		Name: T-72M
 	Buildable:
 		BuildPaletteOrder: 23
-		Prerequisites: ~tkmfactory, uptitanarsenal, tkmradar
+		Prerequisites: ~tkmfactory, ~uptitanarsenal, tkmradar
 		Queue: Vehicle, RAVehicle
 		Description: TKM Russian heavy armor.\n Strong vs Vehicles\n Weak vs Aircraft, Infantry
 	Mobile:
@@ -2235,7 +2235,7 @@ tkmtrenchtruck:
 		NoTransformNotification: BuildingCannotPlaceAudio
 	Buildable:
 		BuildPaletteOrder: 23
-		Prerequisites: ~tkmfactory, tkmtechcenter, upberezkacloak, ~!uptrenchtank
+		Prerequisites: ~tkmfactory, tkmtechcenter, ~upberezkacloak, ~!uptrenchtank
 		Queue: Vehicle, RAVehicle
 		Description: TKM forward base. Provides Buildable Area.
 		BuildDuration: 3000
@@ -3037,7 +3037,7 @@ tkmtrenchtank:
 		NoTransformNotification: BuildingCannotPlaceAudio
 	Buildable:
 		BuildPaletteOrder: 23
-		Prerequisites: ~tkmfactory, tkmtechcenter, uptrenchtank
+		Prerequisites: ~tkmfactory, tkmtechcenter, ~uptrenchtank
 		Queue: Vehicle, RAVehicle
 		Description: TKM forward base.\n Strong vs Infantry, Buildings, Vehicles\n Weak vs Aircraft
 		BuildDuration: 3000

--- a/mods/cameo/rules/warcraft2.yaml
+++ b/mods/cameo/rules/warcraft2.yaml
@@ -5648,7 +5648,7 @@ wc2_orc_troll_berserker:
 	Tooltip:
 		Name: Troll Berserker
 	Buildable:
-		Prerequisites: ~wc2_orc_troll_lumber_mill, wc2_o_berserkerupg, ~!wc2_upgrade_troll_spearthrower
+		Prerequisites: ~wc2_orc_troll_lumber_mill, ~wc2_o_berserkerupg, ~!wc2_upgrade_troll_spearthrower
 		Description: Elite ranged infantry.\nNot as durable as Grunt.\nCan attack air.
 	Selectable:
 		Class: wc2_orc_troll_axethrower


### PR DESCRIPTION
## Summary
- Units that fully replace an earlier unit via a promotion purchase or doctrine/tech upgrade (e.g. RA1 Hammer Tank replacing Heavy Tank, Siege Mammoth Tank replacing Mammoth Tank) showed up greyed-out in the build palette before actually being unlocked.
- Root cause: the engine only uses a tilde-prefixed (`~`) `Buildable.Prerequisites` entry to hide a palette icon; a bare entry still gates buildability but never hides the icon. The replacement unit's own unlock-token prerequisite was missing the tilde.
- Adds `~` to the unlock-token prerequisite on 99 replacement-unit actors across every active theme (D2k, RA2Mod, TiberianDawn, RA1, RA2, StarCraft, TiberianSun, TKM, Warcraft2).

## Verification
- `--faction-report` (per-faction buildability closure): byte-identical before/after — no gameplay/buildability change anywhere.
- `--tilde-audit visibility` (per-faction hidden/visible snapshot): only 3 of ~56k lines differ (`HBOX`/allies, `ra_gigafactory`/soviet, `ra_largeairfield`/soviet), each flipping from prematurely-visible to correctly-hidden as intended.

## Test plan
- [ ] In-game spot check: confirm Hammer Tank / Heavy Tesla Tank / Kotin Nuclear Tank / Siege Mammoth Tank (RA1 Soviet) stay hidden until researched
- [ ] Spot check 1-2 fixes in another theme (e.g. D2k Ordos Heavy Autogun Tank)