### PR TITLE
Flash priority transient notifications (whole-line highlight + toggle)

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/Player/CriticalUnitAttackNotifier.cs
+++ b/OpenRA.Mods.Cameo/Traits/Player/CriticalUnitAttackNotifier.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Cameo.Traits
 		[Desc("Text notification to display.")]
 		public readonly string TextNotification = null;
 
+		[Desc("Flash the text notification to draw attention to it.")]
+		public readonly bool FlashTextNotification = false;
+
 		public override object Create(ActorInitializer init) { return new CriticalUnitAttackNotifier(this); }
 	}
 
@@ -57,7 +60,7 @@ namespace OpenRA.Mods.Cameo.Traits
 
 			if (Game.RunTime > lastNotifyTime + info.NotifyInterval)
 			{
-				TextNotificationsManager.AddTransientLine(self.Owner, info.TextNotification);
+				TextNotificationsManager.AddTransientLine(self.Owner, info.TextNotification, info.FlashTextNotification);
 				lastNotifyTime = Game.RunTime;
 			}
 		}

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="b104f6e"
+ENGINE_VERSION="8b1fff8"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/chrome/ingame-transients.yaml
+++ b/mods/cameo/chrome/ingame-transients.yaml
@@ -13,6 +13,16 @@ Container@TRANSIENTS_PANEL:
 			HideOverflow: False
 			TransientsTemplate: CAMEO_TRANSIENT_LINE_TEMPLATE
 			FeedbackTemplate: CAMEO_TRANSIENT_LINE_TEMPLATE
+			# Whole-line flash: pulse the line's BACKGROUND box bright (white) for 2 cycles,
+			# leaving the text styling unchanged. Blank FlashFont disables the bold swap so it's
+			# fill-only (an empty value, NOT "" — MiniYaml reads "" as a literal 2-char string).
+			FlashFont:
+			FlashCount: 2
+			FlashHighlight: True
+			# White, slightly transparent (C0 = ~75% opaque) so the battlefield shows through a little.
+			FlashBackgroundColor: FFFFFFC0
+			# Match the template's TextColor so the flash leaves the text unchanged.
+			FlashTextColor: AFEEEE
 
 # Transient notification line with a translucent box backing.
 # Width is pinned to the panel width (550): a PARENT_WIDTH ColorBlock would

--- a/mods/cameo/chrome/settings-display.yaml
+++ b/mods/cameo/chrome/settings-display.yaml
@@ -192,6 +192,21 @@ Container@DISPLAY_PANEL:
 					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
+						Container@FLASH_TRANSIENTS_CHECKBOX_CONTAINER:
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Checkbox@FLASH_TRANSIENTS_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-flash-transients-container.label
+									TooltipText: checkbox-flash-transients-container.tooltip
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 20
+					Children:
 						Container@PAUSE_SHELLMAP_CHECKBOX_CONTAINER:
 							X: 10
 							Width: PARENT_WIDTH / 2 - 10

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -308,6 +308,9 @@ checkbox-screen-shake = Screen Shake Effects
 checkbox-ground-fire-smoke = Ground Fire Smoke Effects
 checkbox-decoupled-rendering = Decoupled Render Thread (Experimental)
 checkbox-cross-map-sprite-cache-container = Reuse sprite atlases between maps (faster map loads)
+checkbox-flash-transients-container =
+    .label = Flash Priority Notifications
+    .tooltip = Flash important game-event notifications (base/unit under attack, superweapons) to draw attention
 
 ## settings-gameplay.yaml
 label-game-play-section-header = Gameplay

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -7312,6 +7312,7 @@ CPQDEBUGDUMMY:
 	Transforms:
 		PauseOnCondition: disabled || terrordroned
 		TransformTextNotification: New base hub has been deployed.
+		FlashTransformTextNotification: true
 	NewConstructionOptionsOnDeploy:
 	TransferTimedExternalConditionOnTransform:
 		Condition: invulnerability

--- a/mods/cameo/rules/player.yaml
+++ b/mods/cameo/rules/player.yaml
@@ -118,6 +118,7 @@ Player:
 		ValidTargets: Structure
 		Notification: BaseAttack
 		TextNotification: Structure under attack.
+		FlashTextNotification: true
 		AllyNotification: OurAllyIsUnderAttack
 		AllyTextNotification: Ally under attack.
 	HarvesterAttackNotifier:
@@ -126,6 +127,7 @@ Player:
 	CriticalUnitAttackNotifier:
 		NotifyInterval: 3000
 		TextNotification: Our MCV unit is under attack.
+		FlashTextNotification: true
 	EnemyWatcher:
 	Shroud:
 		FogCheckboxDisplayOrder: 3


### PR DESCRIPTION
Opts select high-priority transient notifications into the engine flash effect (cameo-mod/OpenRA#78, **merged**) and configures it as a **whole-line highlight**: the notification line''s background box pulses white for 2 cycles while the text styling is left unchanged.

## Changes
- **player.yaml** — `DamageNotifier` (structure under attack) and `CriticalUnitAttackNotifier` (MCV under attack) get `FlashTextNotification: true`.
- **defaults.yaml** — base-hub `Transforms` gets `FlashTransformTextNotification: true`.
- **ingame-transients.yaml** — `TRANSIENTS_DISPLAY` configured for the whole-line highlight (`FlashHighlight`, translucent-white `FlashBackgroundColor`, `FlashCount: 2`, `FlashTextColor` matched to the template so text is unchanged).
- **settings-display.yaml** + **fluent/en.ftl** — new "Flash Priority Notifications" checkbox under the existing "Show Game Event Notifications" toggle.
- **mod.config** — engine pin bumped to `8b1fff8` (cameo-mod/OpenRA cameo-engine HEAD, includes #78).

Engine dependency #78 is merged and the pin is bumped, so this builds from a clean engine fetch and is ready to merge.