### PR TITLE
Excise decoupled rendering from mod UI widgets (revert #136)

### DIFF
--- a/OpenRA.Mods.CA/Widgets/Logic/Ingame/ProductionTabsLogicCA.cs
+++ b/OpenRA.Mods.CA/Widgets/Logic/Ingame/ProductionTabsLogicCA.cs
@@ -27,28 +27,15 @@ namespace OpenRA.Mods.CA.Widgets.Logic
 
 			Action<bool> selectTab = reverse =>
 			{
-				// Decoupled rendering: switching tabs/groups refreshes the palette icons from live queue
-				// state, and picking up a completed building reads the live queue head - wait out any in-flight
-				// sim tick (one-shot input; matches original single-threaded timing).
-				Game.EnterWorldReadLock();
-				try
-				{
-					if (tabs.QueueGroup == button.ProductionGroup)
-						tabs.SelectNextTab(reverse);
-					else
-						tabs.QueueGroup = button.ProductionGroup;
+				if (tabs.QueueGroup == button.ProductionGroup)
+					tabs.SelectNextTab(reverse);
+				else
+					tabs.QueueGroup = button.ProductionGroup;
 
-					tabs.PickUpCompletedBuilding();
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
+				tabs.PickUpCompletedBuilding();
 			};
 
-			// Per-frame render read: use the tab state cached under the world read lock (see ProductionTabCA),
-			// not the live sim-mutated queue lists.
-			button.IsDisabled = () => !tabs.Groups[button.ProductionGroup].Tabs.Any(t => t.CachedVisible);
+			button.IsDisabled = () => !tabs.Groups[button.ProductionGroup].Tabs.Any(t => t.Queue.BuildableItems().Any() || t.Queue.AlwaysVisible);
 			button.OnMouseUp = mi => selectTab(mi.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnKeyPress = e => selectTab(e.Modifiers.HasModifier(Modifiers.Shift));
 			button.IsHighlighted = () => tabs.QueueGroup == button.ProductionGroup;

--- a/OpenRA.Mods.CA/Widgets/ProductionTabsCAWidget.cs
+++ b/OpenRA.Mods.CA/Widgets/ProductionTabsCAWidget.cs
@@ -26,13 +26,6 @@ namespace OpenRA.Mods.CA.Widgets
 		public string Name;
 		public ProductionQueue Queue;
 		public Actor Actor;
-
-		// Decoupled rendering: per-frame render/UI reads (tab visibility, done-highlight, group alert,
-		// type-button enabled state) must not enumerate the live sim-mutated queue lists. Refreshed by
-		// ProductionTabGroupCA.RefreshCachedState from the widget's Tick, under the world read lock.
-		public bool CachedVisible;
-		public bool CachedAnyDone;
-		public bool CachedAnyQueued;
 	}
 
 	public class ProductionTabGroupCA
@@ -40,24 +33,7 @@ namespace OpenRA.Mods.CA.Widgets
 		public List<ProductionTabCA> Tabs = new List<ProductionTabCA>();
 		public string Group;
 		public int NextQueueName = 1;
-
-		// Cached by RefreshCachedState (called under the world read lock); read every frame by the
-		// production-type button image lambda, so it must not touch live queue state.
-		public bool Alert { get; private set; }
-
-		public void RefreshCachedState()
-		{
-			var alert = false;
-			foreach (var t in Tabs)
-			{
-				t.CachedVisible = t.Queue.AlwaysVisible || t.Queue.BuildableItems().Any();
-				t.CachedAnyDone = t.Queue.AllQueued().Any(i => i.Done);
-				t.CachedAnyQueued = t.Queue.AllQueued().Any();
-				alert |= t.CachedAnyDone;
-			}
-
-			Alert = alert;
-		}
+		public bool Alert { get { return Tabs.Any(t => t.Queue.AllQueued().Any(i => i.Done)); } }
 
 		public void Update(IEnumerable<ProductionQueue> allQueues)
 		{
@@ -164,10 +140,9 @@ namespace OpenRA.Mods.CA.Widgets
 			if (queueGroup == null)
 				return true;
 
-			// Prioritize alerted queues (cached state - see ProductionTabCA)
-			var queues = Groups[queueGroup].Tabs
-					.OrderByDescending(t => t.CachedAnyDone ? 2 : !t.CachedAnyQueued ? 1 : 0)
-					.Select(t => t.Queue)
+			// Prioritize alerted queues
+			var queues = Groups[queueGroup].Tabs.Select(t => t.Queue)
+					.OrderByDescending(q => q.AllQueued().Any(i => i.Done) ? 2 : !q.AllQueued().Any() ? 1 : 0)
 					.ToList();
 
 			if (reverse) queues.Reverse();
@@ -213,8 +188,7 @@ namespace OpenRA.Mods.CA.Widgets
 
 		public IEnumerable<ProductionTabCA> GetTabs()
 		{
-			// Cached visibility (see ProductionTabCA) - called every frame from Draw/input paths.
-			return Groups[queueGroup].Tabs.Where(t => t.CachedVisible);
+			return Groups[queueGroup].Tabs.Where(t => t.Queue.BuildableItems().Any() || t.Queue.AlwaysVisible);
 		}
 
 		public override void Draw()
@@ -271,7 +245,7 @@ namespace OpenRA.Mods.CA.Widgets
 				// Draw number label
 				var textSize = font.Measure(tab.Name);
 				var position = new int2(rect.X + (rect.Width - textSize.X) / 2, (rect.Y + (rect.Height - textSize.Y) / 2) - 1);
-				font.DrawText(tab.Name, position, tab.CachedAnyDone ? Color.Gold : Color.White);
+				font.DrawText(tab.Name, position, tab.Queue.AllQueued().Any(i => i.Done) ? Color.Gold : Color.White);
 
 				tabsShown++;
 			}
@@ -304,63 +278,35 @@ namespace OpenRA.Mods.CA.Widgets
 			startTabIndex += amount;
 		}
 
-		// Set from the sim thread by ActorChanged; consumed by Tick on the main thread under the world read lock.
-		volatile bool queuesDirty = true;
-
-		// Is added to world.ActorAdded by the SidebarLogic handler.
-		// Decoupled rendering: world.ActorAdded/ActorRemoved fire on the SIM thread, so this must not
-		// touch widget state directly - it only marks the queue list dirty; the actual refresh happens in Tick
-		// under the world read lock on the main thread.
+		// Is added to world.ActorAdded by the SidebarLogic handler
 		public void ActorChanged(Actor a)
 		{
 			if (a.World.Disposing)
 				return;
 
-			if (a.Info.HasTraitInfo<ProductionQueueInfo>() || a.Info.HasTraitInfo<ProvidesPrerequisiteInfo>())
-				queuesDirty = true;
-		}
-
-		public override void TickOuter()
-		{
-			// Decoupled rendering: the queue-list + cached-render refresh MUST run every logic tick
-			// regardless of this widget's visibility. Widget.TickOuter only calls Tick() when IsVisible() is
-			// true, but IsVisible depends on Tabs being populated by this very refresh (chicken-and-egg: the
-			// tab strip could never appear after the first production queue is built), and the production-type
-			// buttons (a separate, always-visible container) read CachedVisible every frame even while the
-			// numbered tab strip itself is hidden. So drive the refresh from TickOuter, before the base
-			// visibility gate.
-			RefreshState();
-			base.TickOuter();
-		}
-
-		void RefreshState()
-		{
-			// Decoupled rendering: refresh queue/tab state only when the sim thread is not mid-tick, so
-			// the sidebar never reflects a half-updated world. Also refreshes the per-tab cached render state
-			// (visibility, done-highlight, alert) that Draw, GetTabs and the type buttons read.
-			if (!Game.TryEnterWorldReadLock())
-				return;
-
-			try
+			if (a.Info.HasTraitInfo<ProductionQueueInfo>())
 			{
-				if (queuesDirty)
-				{
-					queuesDirty = false;
-					RefreshQueues();
-				}
+				UpdateQueues(a);
 
-				foreach (var g in Groups.Values)
-					g.RefreshCachedState();
+				if (queueGroup == null)
+					return;
+
+				// Queue destroyed, was last of type: switch to a new group
+				if (Groups[queueGroup].Tabs.Count == 0)
+					QueueGroup = Groups.Where(g => g.Value.Tabs.Count > 0)
+						.Select(g => g.Key).FirstOrDefault();
+
+				// Queue destroyed, others of same type: switch to another tab
+				else if (!Groups[queueGroup].Tabs.Select(t => t.Queue).Contains(CurrentQueue))
+					SelectNextTab(false);
 			}
-			finally
-			{
-				Game.ExitWorldReadLock();
-			}
+			else if (a.Info.HasTraitInfo<ProvidesPrerequisiteInfo>())
+				UpdateQueues(a);
 		}
 
-		void RefreshQueues()
+		void UpdateQueues(Actor a)
 		{
-			var allQueues = world.ActorsWithTrait<ProductionQueue>()
+			var allQueues = a.World.ActorsWithTrait<ProductionQueue>()
 				.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld && p.Trait.Enabled)
 				.Select(p => p.Trait).ToList();
 
@@ -369,18 +315,6 @@ namespace OpenRA.Mods.CA.Widgets
 
 			if (allQueues.Count > 0 && CurrentQueue == null)
 				UpdateTab(allQueues.First());
-
-			if (queueGroup == null)
-				return;
-
-			// Queue destroyed, was last of type: switch to a new group
-			if (Groups[queueGroup].Tabs.Count == 0)
-				QueueGroup = Groups.Where(g => g.Value.Tabs.Count > 0)
-					.Select(g => g.Key).FirstOrDefault();
-
-			// Queue destroyed, others of same type: switch to another tab
-			else if (!Groups[queueGroup].Tabs.Select(t => t.Queue).Contains(CurrentQueue))
-				SelectNextTab(false);
 		}
 
 		void UpdateTab(ProductionQueue queue, bool recenter = false)
@@ -459,19 +393,7 @@ namespace OpenRA.Mods.CA.Widgets
 				{
 					pressedTabIndex = tabIndex;
 					var tab = Groups[queueGroup].Tabs[tabIndex];
-
-					// Decoupled rendering: switching the queue refreshes the palette icons from live queue state - wait out
-					// any in-flight sim tick (one-shot input; matches original single-threaded timing).
-					Game.EnterWorldReadLock();
-					try
-					{
-						UpdateTab(tab.Queue);
-					}
-					finally
-					{
-						Game.ExitWorldReadLock();
-					}
-
+					UpdateTab(tab.Queue);
 					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", ClickSound, null);
 
 					if (mi.MultiTapCount > 1 && tab.Actor != null && tab.Actor.IsInWorld)
@@ -490,20 +412,16 @@ namespace OpenRA.Mods.CA.Widgets
 			if (e.Event != KeyInputEvent.Down)
 				return false;
 
-			if (PreviousProductionTabKey.IsActivatedBy(e) || NextProductionTabKey.IsActivatedBy(e))
+			if (PreviousProductionTabKey.IsActivatedBy(e))
 			{
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", ClickSound, null);
+				return SelectNextTab(true);
+			}
 
-				// Decoupled rendering: SelectNextTab switches the queue, refreshing palette icons from live queue state.
-				Game.EnterWorldReadLock();
-				try
-				{
-					return SelectNextTab(PreviousProductionTabKey.IsActivatedBy(e));
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
+			if (NextProductionTabKey.IsActivatedBy(e))
+			{
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", ClickSound, null);
+				return SelectNextTab(false);
 			}
 
 			return false;

--- a/OpenRA.Mods.Cameo/Widgets/CommanderTreeWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/CommanderTreeWidget.cs
@@ -68,11 +68,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 		ProductionQueue promotionsQueue;
 
 		readonly List<ProductionItem> sharedQueuedItems = new();
-
-		// Decoupled rendering: queue head cached in Tick under the world read lock; Draw must not
-		// index the live queue.
-		readonly HashSet<ProductionItem> cachedProducingItems = [];
-		readonly Dictionary<string, int> cachedHeadRemainingTime = [];
 		readonly HashSet<ActorInfo> visibleActors = new();
 		Player cachedQueueOwner;
 		IProductionIconOverlay[] iconOverlays = Array.Empty<IProductionIconOverlay>();
@@ -275,27 +270,17 @@ namespace OpenRA.Mods.Cameo.Widgets
 			if (node == null)
 				return false;
 
-			// Decoupled rendering: the click handlers read live queue state (CanQueue) - wait out any
-			// in-flight sim tick (one-shot input; matches original single-threaded timing).
-			Game.EnterWorldReadLock();
-			try
+			switch (mi.Button)
 			{
-				switch (mi.Button)
-				{
-					case MouseButton.Left:
-						HandleLeftClick(node, mi.Modifiers);
-						break;
-					case MouseButton.Right:
-						HandleRightClick(node, mi.Modifiers);
-						break;
-					case MouseButton.Middle:
-						HandleMiddleClick(node, mi.Modifiers);
-						break;
-				}
-			}
-			finally
-			{
-				Game.ExitWorldReadLock();
+				case MouseButton.Left:
+					HandleLeftClick(node, mi.Modifiers);
+					break;
+				case MouseButton.Right:
+					HandleRightClick(node, mi.Modifiers);
+					break;
+				case MouseButton.Middle:
+					HandleMiddleClick(node, mi.Modifiers);
+					break;
 			}
 
 			return true;
@@ -308,60 +293,20 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 			if (e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER || e.Key == Keycode.SPACE)
 			{
-				Game.EnterWorldReadLock();
-				try
-				{
-					HandleLeftClick(hoverNode, e.Modifiers);
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
-
+				HandleLeftClick(hoverNode, e.Modifiers);
 				return true;
 			}
 
 			return false;
 		}
 
-		// Decoupled rendering: set once the first UpdateNodes has run, so we only BLOCK for the world
-		// lock on the initial populate (see Tick).
-		bool hasPopulated;
-
 		public override void Tick()
 		{
-			// Decoupled rendering: EnsureQueue/UpdateNodes enumerate the live queue state (AllQueued,
-			// Producible). Per-frame refreshes use TryEnter so a busy sim thread never stalls the UI - a skipped
-			// frame just shows last frame's cached tree.
-			//
-			// The FIRST populate is special: the window loads offscreen (X/Y -9999) and CommanderTreeWindowLogic
-			// only moves it onscreen once ContentWidth/Height are set by UpdateNodes. In late game the sim holds
-			// the world lock most of each frame, so a non-blocking TryEnter can fail for many consecutive frames,
-			// leaving the just-opened window invisible (looks like the Promotions click did nothing - the user
-			// has to click repeatedly until a frame happens to win the lock race). The populate-on-open is a
-			// one-shot, like an input handler, so block for the lock that first time; this guarantees the window
-			// appears promptly without stalling the UI thread every subsequent frame.
-			var firstPopulate = !hasPopulated;
-			if (firstPopulate)
-				Game.EnterWorldReadLock();
-			else if (!Game.TryEnterWorldReadLock())
+			if (!EnsureQueue())
 				return;
 
-			try
-			{
-				// We hold the lock now; only ever block once even if EnsureQueue is not ready yet.
-				hasPopulated = true;
-
-				if (!EnsureQueue())
-					return;
-
-				EnsureCommanderTooltipInitialized();
-				UpdateNodes();
-			}
-			finally
-			{
-				Game.ExitWorldReadLock();
-			}
+			EnsureCommanderTooltipInitialized();
+			UpdateNodes();
 		}
 
 		void HandleLeftClick(CommanderNode node, Modifiers modifiers)
@@ -466,9 +411,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 			sharedQueuedItems.AddRange(promotionsQueue.AllQueued());
 
-			cachedProducingItems.Clear();
-			cachedHeadRemainingTime.Clear();
-
 			foreach (var kv in promotionsQueue.Producible)
 			{
 				var actor = kv.Key;
@@ -505,21 +447,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 				RebuildEdgesAndLayout();
 
 			UpdateHorizontalScrollLayout();
-
-			// Decoupled rendering: Draw must not call into the live queue. IsProducing and RemainingTimeActual
-			// are polymorphic (parallel queues produce every queued item and their RemainingTimeActual enumerates the
-			// sim-mutated Queue), so evaluate them here under the world read lock and cache what Draw needs.
-			foreach (var node in nodes.Values)
-			{
-				if (node.Icon.Queued.Count == 0)
-					continue;
-
-				var head = node.Icon.Queued[0];
-				if (promotionsQueue.IsProducing(head))
-					cachedProducingItems.Add(head);
-
-				cachedHeadRemainingTime[node.Actor.Name] = head.Queue.RemainingTimeActual(head);
-			}
 		}
 
 		CommanderNode CreateNode(ActorInfo actor)
@@ -1396,7 +1323,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 			if (totalQueued > 0)
 			{
 				var first = node.Icon.Queued[0];
-				var waiting = !cachedProducingItems.Contains(first) && !first.Done;
+				var waiting = !promotionsQueue.IsProducing(first) && !first.Done;
 
 				if (first.Done)
 					overlayFont.DrawTextWithContrast(readyText, iconPos + readyOffset, overlayTextColor, Color.Black, 1);
@@ -1404,7 +1331,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 					overlayFont.DrawTextWithContrast(holdText, iconPos + holdOffset, overlayTextColor, Color.Black, 1);
 				else if (!waiting)
 				{
-					var timeText = WidgetUtils.FormatTime(cachedHeadRemainingTime.GetValueOrDefault(node.Actor.Name), world.Timestep);
+					var timeText = WidgetUtils.FormatTime(first.Queue.RemainingTimeActual(first), world.Timestep);
 					var timeOffset = iconOffset - overlayFont.Measure(timeText).ToFloat2() / 2f;
 					overlayFont.DrawTextWithContrast(timeText, iconPos + timeOffset, overlayTextColor, Color.Black, 1);
 				}

--- a/OpenRA.Mods.Cameo/Widgets/CustomFormationsCommandBarLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/CustomFormationsCommandBarLogic.cs
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 		bool scatterDisabled = true;
 		bool stopDisabled = true;
 		bool waypointModeDisabled = true;
-		bool deployDisabled = true;
 
 		int deployHighlighted;
 		int scatterHighlighted;
@@ -75,8 +74,8 @@ namespace OpenRA.Mods.Cameo.Widgets
 						world.OrderGenerator = new CustomFormationsAttackMoveOrderGenerator(selectedActors, Game.Settings.Game.ResolveActionButton(MouseActionType.ConfirmOrder));
 				}
 
-				attackMoveButton.OnClick = () => UnderWorldLock(() => Toggle(true));
-				attackMoveButton.OnKeyPress = _ => UnderWorldLock(() => Toggle(false));
+				attackMoveButton.OnClick = () => Toggle(true);
+				attackMoveButton.OnKeyPress = _ => Toggle(false);
 			}
 
 			var forceMoveButton = widget.GetOrNull<ButtonWidget>("FORCE_MOVE");
@@ -86,13 +85,13 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 				forceMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return forceMoveDisabled; };
 				forceMoveButton.IsHighlighted = () => !forceMoveButton.IsDisabled() && IsForceModifiersActive(Modifiers.Alt);
-				forceMoveButton.OnClick = () => UnderWorldLock(() =>
+				forceMoveButton.OnClick = () =>
 				{
 					if (forceMoveButton.IsHighlighted())
 						world.CancelInputMode();
 					else
 						world.OrderGenerator = new ForceModifiersOrderGenerator(world, Modifiers.Alt, true);
-				});
+				};
 			}
 
 			var forceAttackButton = widget.GetOrNull<ButtonWidget>("FORCE_ATTACK");
@@ -104,13 +103,13 @@ namespace OpenRA.Mods.Cameo.Widgets
 				forceAttackButton.IsHighlighted = () => !forceAttackButton.IsDisabled() && IsForceModifiersActive(Modifiers.Ctrl)
 					&& world.OrderGenerator is not CustomFormationsAttackMoveOrderGenerator;
 
-				forceAttackButton.OnClick = () => UnderWorldLock(() =>
+				forceAttackButton.OnClick = () =>
 				{
 					if (forceAttackButton.IsHighlighted())
 						world.CancelInputMode();
 					else
 						world.OrderGenerator = new ForceModifiersOrderGenerator(world, Modifiers.Ctrl, true);
-				});
+				};
 			}
 
 			var guardButton = widget.GetOrNull<ButtonWidget>("GUARD");
@@ -132,8 +131,8 @@ namespace OpenRA.Mods.Cameo.Widgets
 						world.OrderGenerator = new GuardOrderGenerator(world, selectedActors, "Guard", "guard");
 				}
 
-				guardButton.OnClick = () => UnderWorldLock(() => Toggle(true));
-				guardButton.OnKeyPress = _ => UnderWorldLock(() => Toggle(false));
+				guardButton.OnClick = () => Toggle(true);
+				guardButton.OnKeyPress = _ => Toggle(false);
 			}
 
 			var scatterButton = widget.GetOrNull<ButtonWidget>("SCATTER");
@@ -163,21 +162,8 @@ namespace OpenRA.Mods.Cameo.Widgets
 				{
 					UpdateStateIfNecessary();
 
-					// Decoupled rendering: CanIssueDeployOrder dispatches a live trait on a selected actor the sim can
-					// dispose; evaluate under a non-blocking world lock and keep last frame's result when mid-tick.
-					if (!Game.TryEnterWorldReadLock())
-						return deployDisabled;
-
-					try
-					{
-						var queued = Game.GetModifierKeys().HasModifier(Modifiers.Shift);
-						deployDisabled = !selectedDeploys.Any(pair => pair.Trait.CanIssueDeployOrder(pair.Actor, queued));
-						return deployDisabled;
-					}
-					finally
-					{
-						Game.ExitWorldReadLock();
-					}
+					var queued = Game.GetModifierKeys().HasModifier(Modifiers.Shift);
+					return !selectedDeploys.Any(pair => pair.Trait.CanIssueDeployOrder(pair.Actor, queued));
 				};
 
 				deployButton.IsHighlighted = () => deployHighlighted > 0;
@@ -218,13 +204,13 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 				queueOrdersButton.IsDisabled = () => { UpdateStateIfNecessary(); return waypointModeDisabled; };
 				queueOrdersButton.IsHighlighted = () => !queueOrdersButton.IsDisabled() && IsForceModifiersActive(Modifiers.Shift);
-				queueOrdersButton.OnClick = () => UnderWorldLock(() =>
+				queueOrdersButton.OnClick = () =>
 				{
 					if (queueOrdersButton.IsHighlighted())
 						world.CancelInputMode();
 					else
 						world.OrderGenerator = new ForceModifiersOrderGenerator(world, Modifiers.Shift, false);
-				});
+				};
 			}
 
 			var keyOverrides = widget.GetOrNull<LogicKeyListenerWidget>("MODIFIER_OVERRIDES");
@@ -297,26 +283,8 @@ namespace OpenRA.Mods.Cameo.Widgets
 			return world.OrderGenerator is UnitOrderGenerator && Game.GetModifierKeys().HasFlag(modifiers);
 		}
 
-		static void UnderWorldLock(Action a)
-		{
-			// Decoupled rendering: run a one-shot command-bar callback under the blocking world lock so its OrderGenerator
-			// swap / order issue can't race the sim thread's OrderGenerator.Tick. No-op when decoupling is off.
-			Game.EnterWorldReadLock();
-			try { a(); }
-			finally { Game.ExitWorldReadLock(); }
-		}
-
 		void UpdateStateIfNecessary()
 		{
-			// Decoupled rendering: enumerates live Selection actors + their traits (TraitsImplementing hits CheckDestroyed
-			// on a disposed actor). Runs per frame (button IsDisabled during unlocked Ui.Draw) and from one-shot order
-			// callbacks. Guard with a non-blocking world lock: keep last frame's cached state when the sim is mid-tick.
-			// One-shot callers hold the blocking world lock, so this re-enters it (Monitor re-entrant) and refreshes.
-			if (!Game.TryEnterWorldReadLock())
-				return;
-
-			try
-			{
 			if (selectionHash == world.Selection.Hash)
 				return;
 
@@ -340,59 +308,36 @@ namespace OpenRA.Mods.Cameo.Widgets
 			waypointModeDisabled = !cbbInfos.Any(i => i == null || !i.DisableWaypointMode);
 
 			selectionHash = world.Selection.Hash;
-			}
-			finally
-			{
-				Game.ExitWorldReadLock();
-			}
 		}
 
 		void PerformKeyboardOrderOnSelection(Func<Actor, Order> f)
 		{
-			// Decoupled rendering: one-shot order issue under the blocking world lock (UpdateStateIfNecessary re-enters it).
-			Game.EnterWorldReadLock();
-			try
-			{
-				UpdateStateIfNecessary();
+			UpdateStateIfNecessary();
 
-				var orders = selectedActors
-					.Select(f)
-					.ToArray();
+			var orders = selectedActors
+				.Select(f)
+				.ToArray();
 
-				foreach (var o in orders)
-					world.IssueOrder(o);
+			foreach (var o in orders)
+				world.IssueOrder(o);
 
-				orders.PlayVoiceForOrders();
-			}
-			finally
-			{
-				Game.ExitWorldReadLock();
-			}
+			orders.PlayVoiceForOrders();
 		}
 
 		void PerformDeployOrderOnSelection(bool queued)
 		{
-			// Decoupled rendering: one-shot deploy issue under the blocking world lock (see above).
-			Game.EnterWorldReadLock();
-			try
-			{
-				UpdateStateIfNecessary();
+			UpdateStateIfNecessary();
 
-				var orders = selectedDeploys
-					.Where(pair => pair.Trait.CanIssueDeployOrder(pair.Actor, queued))
-					.Select(d => d.Trait.IssueDeployOrder(d.Actor, queued))
-					.Where(d => d != null)
-					.ToArray();
+			var orders = selectedDeploys
+				.Where(pair => pair.Trait.CanIssueDeployOrder(pair.Actor, queued))
+				.Select(d => d.Trait.IssueDeployOrder(d.Actor, queued))
+				.Where(d => d != null)
+				.ToArray();
 
-				foreach (var o in orders)
-					world.IssueOrder(o);
+			foreach (var o in orders)
+				world.IssueOrder(o);
 
-				orders.PlayVoiceForOrders();
-			}
-			finally
-			{
-				Game.ExitWorldReadLock();
-			}
+			orders.PlayVoiceForOrders();
 		}
 	}
 }

--- a/OpenRA.Mods.Cameo/Widgets/Logic/Ingame/PromotionTreeButtonLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/Ingame/PromotionTreeButtonLogic.cs
@@ -81,31 +81,13 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			var chromeName = button.ProductionGroup.ToLowerInvariant();
 			var icon = button.GetOrNull<ImageWidget>("ICON");
 			if (icon != null)
-			{
-				// Decoupled rendering: AllQueued() is the live, sim-mutated queue list. Re-evaluate the
-				// alert state only when the sim thread is not mid-tick; otherwise reuse the last value (this lambda
-				// runs every frame, so it is at worst one frame stale).
-				var cachedAlert = false;
 				icon.GetImageName = () =>
 				{
 					if (button.IsDisabled())
 						return chromeName + "-disabled";
 
-					if (Game.TryEnterWorldReadLock())
-					{
-						try
-						{
-							cachedAlert = queues.Any(q => q.AllQueued().Any(i => i.Done));
-						}
-						finally
-						{
-							Game.ExitWorldReadLock();
-						}
-					}
-
-					return cachedAlert ? chromeName + "-alert" : chromeName;
+					return queues.Any(q => q.AllQueued().Any(i => i.Done)) ? chromeName + "-alert" : chromeName;
 				};
-			}
 		}
 
 		void OpenCommanderTree()

--- a/OpenRA.Mods.Cameo/Widgets/Logic/ProductionTooltipCameoLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/ProductionTooltipCameoLogic.cs
@@ -65,147 +65,133 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 
 			tooltipContainer.BeforeRender = () =>
 			{
-				// Decoupled rendering: the relayout dispatches the virtual ProductionQueue.GetProductionCost
-				// and GetBuildTime (the parallel-queue GetBuildTime walks live world production traits) during the
-				// unlocked Ui.Draw. Refresh under a non-blocking world lock; if the sim thread is mid-tick, keep last
-				// frame's tooltip layout (last* are not updated, so it retries next frame). No-op when off.
-				if (!Game.TryEnterWorldReadLock())
+				var tooltipIcon = getTooltipIcon();
+
+				var actor = tooltipIcon?.Actor;
+				if (actor == null)
 					return;
 
-				try
+				var hotkey = tooltipIcon.Hotkey?.GetValue() ?? Hotkey.Invalid;
+				if (actor == lastActor && hotkey == lastHotkey && (pm == null || pm.PowerState == lastPowerState))
+					return;
+
+				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
+				var name = tooltip != null ? FluentProvider.GetMessage(tooltip.Name) : actor.Name;
+				var buildable = BuildableInfo.GetTraitForQueue(actor, tooltipIcon.ProductionQueue?.Info.Type);
+
+				var cost = 0;
+				if (tooltipIcon.ProductionQueue != null)
+					cost = tooltipIcon.ProductionQueue.GetProductionCost(actor);
+				else
 				{
-					var tooltipIcon = getTooltipIcon();
-
-					var actor = tooltipIcon?.Actor;
-					if (actor == null)
-						return;
-
-					var hotkey = tooltipIcon.Hotkey?.GetValue() ?? Hotkey.Invalid;
-					if (actor == lastActor && hotkey == lastHotkey && (pm == null || pm.PowerState == lastPowerState))
-						return;
-
-					var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
-					var name = tooltip != null ? FluentProvider.GetMessage(tooltip.Name) : actor.Name;
-					var buildable = BuildableInfo.GetTraitForQueue(actor, tooltipIcon.ProductionQueue?.Info.Type);
-
-					var cost = 0;
-					if (tooltipIcon.ProductionQueue != null)
-						cost = tooltipIcon.ProductionQueue.GetProductionCost(actor);
-					else
-					{
-						var valued = actor.TraitInfoOrDefault<ValuedInfo>();
-						if (valued != null)
-							cost = valued.Cost;
-					}
-
-					nameLabel.GetText = () => name;
-
-					var nameSize = font.Measure(name);
-					var hotkeyWidth = 0;
-					hotkeyLabel.Visible = hotkey.IsValid();
-
-					if (hotkeyLabel.Visible)
-					{
-						var hotkeyText = $"({hotkey.DisplayString()})";
-
-						hotkeyWidth = font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
-						hotkeyLabel.GetText = () => hotkeyText;
-						hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
-					}
-
-					var prereqs = buildable.Prerequisites
-						.Select(a => ActorName(mapRules, a))
-						.Where(s => !s.StartsWith('~') && !s.StartsWith('!'))
-						.ToList();
-
-					var requiresSize = int2.Zero;
-					if (prereqs.Count > 0)
-					{
-						var requiresText = FluentProvider.GetMessage(Requires, "prerequisites", prereqs.JoinWith(", "));
-						requiresLabel.GetText = () => requiresText;
-						requiresSize = requiresFont.Measure(requiresText);
-						requiresLabel.Visible = true;
-						requiresLabel.Bounds.Y = requiresLabelY;
-						descLabel.Bounds.Y = descLabelY + requiresLabel.Bounds.Height;
-					}
-					else
-					{
-						requiresLabel.Visible = false;
-						descLabel.Bounds.Y = descLabelY;
-					}
-
-					var powerSize = new int2(0, 0);
-					if (pm != null)
-					{
-						var power = actor.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(i => i.Amount);
-						var powerText = power.ToString(NumberFormatInfo.CurrentInfo);
-						powerLabel.GetText = () => powerText;
-						powerLabel.GetColor = () => (pm.PowerProvided - pm.PowerDrained >= -power || power > 0)
-							? Color.White : Color.Red;
-						powerLabel.Visible = power != 0;
-						powerIcon.Visible = power != 0;
-						powerSize = font.Measure(powerText);
-					}
-
-					var buildTime = tooltipIcon.ProductionQueue?.GetBuildTime(actor, buildable) ?? 0;
-					var timeModifier = pm != null && pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerModifier : 100;
-
-					var timeText = formatBuildTime.Update(buildTime * timeModifier / 100);
-					timeLabel.GetText = () => timeText;
-					timeLabel.TextColor =
-						(pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100)
-							? Color.Red
-							: Color.White;
-					var timeSize = font.Measure(timeText);
-
-					costLabel.IsVisible = () => cost != 0;
-					costIcon.IsVisible = () => cost != 0;
-					var costText = cost.ToString(NumberFormatInfo.CurrentInfo);
-					costLabel.GetText = () => costText;
-					costLabel.GetColor = () => pr.GetCashAndResources() >= cost ? Color.White : Color.Red;
-					var costSize = font.Measure(costText);
-
-					var tooltipExtras = actor.TraitInfos<TooltipExtrasInfo>();
-					extrasLabel.Text = String.Join("\n", tooltipExtras.Select(extra => FluentProvider.GetMessage(extra.Description)));
-					var extraSize = new int2(0, 0);
-
-					if (extrasLabel.Text != "") {
-						extraSize = extrasFont.Measure(extrasLabel.Text);
-						extrasLabel.Visible = true;
-						descLabel.Bounds.Y += extraSize.Y;
-						requiresLabel.Bounds.Y += extraSize.Y;
-					}
-
-					var desc = string.IsNullOrEmpty(buildable.Description) ? "" : FluentProvider.GetMessage(buildable.Description);
-					descLabel.GetText = () => desc;
-					var descSize = descFont.Measure(desc);
-					descLabel.Bounds.Width = descSize.X;
-					descLabel.Bounds.Height = descSize.Y + descLabelPadding;
-
-					var leftWidth = new[] { nameSize.X + hotkeyWidth, requiresSize.X, descSize.X, extraSize.X }.Aggregate(Math.Max);
-					var rightWidth = new[] { powerSize.X, timeSize.X, costSize.X }.Aggregate(Math.Max);
-
-					timeIcon.Bounds.X = powerIcon.Bounds.X = costIcon.Bounds.X = leftWidth + 2 * nameLabel.Bounds.X;
-					timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
-					widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
-
-					// Set the bottom margin to match the left margin
-					var leftHeight = descLabel.Bounds.Bottom + descLabel.Bounds.X;
-
-					// Set the bottom margin to match the top margin
-					var rightHeight = (powerLabel.Visible ? powerIcon.Bounds.Bottom : timeIcon.Bounds.Bottom) + costIcon.Bounds.Top;
-
-					widget.Bounds.Height = Math.Max(leftHeight, rightHeight);
-
-					lastActor = actor;
-					lastHotkey = hotkey;
-					if (pm != null)
-						lastPowerState = pm.PowerState;
+					var valued = actor.TraitInfoOrDefault<ValuedInfo>();
+					if (valued != null)
+						cost = valued.Cost;
 				}
-				finally
+
+				nameLabel.GetText = () => name;
+
+				var nameSize = font.Measure(name);
+				var hotkeyWidth = 0;
+				hotkeyLabel.Visible = hotkey.IsValid();
+
+				if (hotkeyLabel.Visible)
 				{
-					Game.ExitWorldReadLock();
+					var hotkeyText = $"({hotkey.DisplayString()})";
+
+					hotkeyWidth = font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
+					hotkeyLabel.GetText = () => hotkeyText;
+					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
+
+				var prereqs = buildable.Prerequisites
+					.Select(a => ActorName(mapRules, a))
+					.Where(s => !s.StartsWith('~') && !s.StartsWith('!'))
+					.ToList();
+
+				var requiresSize = int2.Zero;
+				if (prereqs.Count > 0)
+				{
+					var requiresText = FluentProvider.GetMessage(Requires, "prerequisites", prereqs.JoinWith(", "));
+					requiresLabel.GetText = () => requiresText;
+					requiresSize = requiresFont.Measure(requiresText);
+					requiresLabel.Visible = true;
+					requiresLabel.Bounds.Y = requiresLabelY;
+					descLabel.Bounds.Y = descLabelY + requiresLabel.Bounds.Height;
+				}
+				else
+				{
+					requiresLabel.Visible = false;
+					descLabel.Bounds.Y = descLabelY;
+				}
+
+				var powerSize = new int2(0, 0);
+				if (pm != null)
+				{
+					var power = actor.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(i => i.Amount);
+					var powerText = power.ToString(NumberFormatInfo.CurrentInfo);
+					powerLabel.GetText = () => powerText;
+					powerLabel.GetColor = () => (pm.PowerProvided - pm.PowerDrained >= -power || power > 0)
+						? Color.White : Color.Red;
+					powerLabel.Visible = power != 0;
+					powerIcon.Visible = power != 0;
+					powerSize = font.Measure(powerText);
+				}
+
+				var buildTime = tooltipIcon.ProductionQueue?.GetBuildTime(actor, buildable) ?? 0;
+				var timeModifier = pm != null && pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerModifier : 100;
+
+				var timeText = formatBuildTime.Update(buildTime * timeModifier / 100);
+				timeLabel.GetText = () => timeText;
+				timeLabel.TextColor =
+					(pm != null && pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerModifier > 100)
+						? Color.Red
+						: Color.White;
+				var timeSize = font.Measure(timeText);
+
+				costLabel.IsVisible = () => cost != 0;
+				costIcon.IsVisible = () => cost != 0;
+				var costText = cost.ToString(NumberFormatInfo.CurrentInfo);
+				costLabel.GetText = () => costText;
+				costLabel.GetColor = () => pr.GetCashAndResources() >= cost ? Color.White : Color.Red;
+				var costSize = font.Measure(costText);
+
+				var tooltipExtras = actor.TraitInfos<TooltipExtrasInfo>();
+				extrasLabel.Text = String.Join("\n", tooltipExtras.Select(extra => FluentProvider.GetMessage(extra.Description)));
+				var extraSize = new int2(0, 0);
+
+				if (extrasLabel.Text != "") {
+					extraSize = extrasFont.Measure(extrasLabel.Text);
+					extrasLabel.Visible = true;
+					descLabel.Bounds.Y += extraSize.Y;
+					requiresLabel.Bounds.Y += extraSize.Y;
+				}
+
+				var desc = string.IsNullOrEmpty(buildable.Description) ? "" : FluentProvider.GetMessage(buildable.Description);
+				descLabel.GetText = () => desc;
+				var descSize = descFont.Measure(desc);
+				descLabel.Bounds.Width = descSize.X;
+				descLabel.Bounds.Height = descSize.Y + descLabelPadding;
+
+				var leftWidth = new[] { nameSize.X + hotkeyWidth, requiresSize.X, descSize.X, extraSize.X }.Aggregate(Math.Max);
+				var rightWidth = new[] { powerSize.X, timeSize.X, costSize.X }.Aggregate(Math.Max);
+
+				timeIcon.Bounds.X = powerIcon.Bounds.X = costIcon.Bounds.X = leftWidth + 2 * nameLabel.Bounds.X;
+				timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
+				widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
+
+				// Set the bottom margin to match the left margin
+				var leftHeight = descLabel.Bounds.Bottom + descLabel.Bounds.X;
+
+				// Set the bottom margin to match the top margin
+				var rightHeight = (powerLabel.Visible ? powerIcon.Bounds.Bottom : timeIcon.Bounds.Bottom) + costIcon.Bounds.Top;
+
+				widget.Bounds.Height = Math.Max(leftHeight, rightHeight);
+
+				lastActor = actor;
+				lastHotkey = hotkey;
+				if (pm != null)
+					lastPowerState = pm.PowerState;
 			};
 		}
 

--- a/OpenRA.Mods.Cameo/Widgets/ObserverPromotionsIconsWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/ObserverPromotionsIconsWidget.cs
@@ -45,10 +45,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 		readonly CachedTransform<Player, PlayerStatistics> stats = new(player => player.PlayerActor.TraitOrDefault<PlayerStatistics>());
 
-		// Decoupled rendering: PlayerStatistics.Units is mutated by the sim thread; enumerate it only
-		// under the world read lock, render from this snapshot (kept from last frame when the sim is mid-tick).
-		readonly List<ArmyUnit> cachedUnits = [];
-
 		int lastIconIdx;
 		int currentTooltipToken;
 
@@ -95,28 +91,17 @@ namespace OpenRA.Mods.Cameo.Widgets
 			if (player == null)
 				return;
 
-			if (Game.TryEnterWorldReadLock())
-			{
-				try
-				{
-					var playerStatistics = stats.Update(player);
+			var playerStatistics = stats.Update(player);
 
-					cachedUnits.Clear();
-					cachedUnits.AddRange(playerStatistics.Units.Values
-						.Where(u => u.Count > 0 && u.Icon != null && u.ActorInfo.HasTraitInfo<PromotionUpgradeInfo>())
-						.OrderBy(u => u.ProductionQueueOrder)
-						.ThenBy(u => u.BuildPaletteOrder));
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
-			}
+			var items = playerStatistics.Units.Values
+				.Where(u => u.Count > 0 && u.Icon != null && u.ActorInfo.HasTraitInfo<PromotionUpgradeInfo>())
+				.OrderBy(u => u.ProductionQueueOrder)
+				.ThenBy(u => u.BuildPaletteOrder);
 
 			Game.Renderer.EnableAntialiasingFilter();
 
 			var queueCol = 0;
-			foreach (var unit in cachedUnits)
+			foreach (var unit in items)
 			{
 				var icon = unit.Icon;
 				var topLeftOffset = new int2(queueCol * (IconWidth + IconSpacing), 0);

--- a/OpenRA.Mods.Cameo/Widgets/PlayerUpgradesIconsWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/PlayerUpgradesIconsWidget.cs
@@ -44,10 +44,6 @@ namespace OpenRA.Mods.Cameo.Widgets
 
 		readonly CachedTransform<Player, PlayerStatistics> stats = new(player => player.PlayerActor.TraitOrDefault<PlayerStatistics>());
 
-		// Decoupled rendering: PlayerStatistics.Units is mutated by the sim thread; enumerate it only
-		// under the world read lock, render from this snapshot (kept from last frame when the sim is mid-tick).
-		readonly List<ArmyUnit> cachedUnits = [];
-
 		int lastIconIdx;
 		int currentTooltipToken;
 
@@ -94,28 +90,17 @@ namespace OpenRA.Mods.Cameo.Widgets
 			if (player == null)
 				return;
 
-			if (Game.TryEnterWorldReadLock())
-			{
-				try
-				{
-					var playerStatistics = stats.Update(player);
+			var playerStatistics = stats.Update(player);
 
-					cachedUnits.Clear();
-					cachedUnits.AddRange(playerStatistics.Units.Values
-						.Where(u => u.Count > 0 && u.Icon != null && u.ActorInfo.HasTraitInfo<PlayerDisplayUpgradeInfo>())
-						.OrderBy(u => u.ProductionQueueOrder)
-						.ThenBy(u => u.BuildPaletteOrder));
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
-			}
+			var items = playerStatistics.Units.Values
+				.Where(u => u.Count > 0 && u.Icon != null && u.ActorInfo.HasTraitInfo<PlayerDisplayUpgradeInfo>())
+				.OrderBy(u => u.ProductionQueueOrder)
+				.ThenBy(u => u.BuildPaletteOrder);
 
 			Game.Renderer.EnableAntialiasingFilter();
 
 			var queueCol = 0;
-			foreach (var unit in cachedUnits)
+			foreach (var unit in items)
 			{
 				var icon = unit.Icon;
 				var topLeftOffset = new int2(queueCol * (IconWidth + IconSpacing), 0);

--- a/OpenRA.Mods.Cameo/Widgets/QuotaProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/QuotaProductionPaletteWidget.cs
@@ -4,7 +4,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA;
 using OpenRA.Graphics;
@@ -79,44 +78,25 @@ namespace OpenRA.Mods.Cameo.Widgets
 			return base.HandleMouseInput(mi);
 		}
 
-		// Decoupled rendering: GetQuota/GetAliveCount read dictionaries the sim thread mutates
-		// (ResolveOrder/Tick). Refresh this overlay snapshot under the world read lock; when the sim is
-		// mid-tick, draw last frame's overlays instead of reading live state.
-		readonly List<(float2 Pos, string Text)> cachedQuotaOverlays = [];
-
 		public override void Draw()
 		{
 			base.Draw();
 
-			if (Game.TryEnterWorldReadLock())
+			var quotaManager = World.LocalPlayer?.PlayerActor?.TraitOrDefault<QuotaProductionManager>();
+			if (quotaManager == null || !quotaManager.Enabled || CurrentQueue == null)
+				return;
+
+			foreach (var icon in icons.Values)
 			{
-				try
-				{
-					cachedQuotaOverlays.Clear();
+				var quota = quotaManager.GetQuota(icon.Name);
+				if (quota <= 0) continue;
 
-					var quotaManager = World.LocalPlayer?.PlayerActor?.TraitOrDefault<QuotaProductionManager>();
-					if (quotaManager != null && quotaManager.Enabled && CurrentQueue != null)
-					{
-						foreach (var icon in icons.Values)
-						{
-							var quota = quotaManager.GetQuota(icon.Name);
-							if (quota <= 0) continue;
-
-							var alive = quotaManager.GetAliveCount(icon.Name);
-							var text = $"{alive}/{quota}";
-							var textSize = quotaFont.Measure(text);
-							cachedQuotaOverlays.Add((icon.Pos + new float2(IconSize.X - textSize.X - 1, IconSize.Y - textSize.Y - 1), text));
-						}
-					}
-				}
-				finally
-				{
-					Game.ExitWorldReadLock();
-				}
-			}
-
-			foreach (var (pos, text) in cachedQuotaOverlays)
+				var alive = quotaManager.GetAliveCount(icon.Name);
+				var text = $"{alive}/{quota}";
+				var textSize = quotaFont.Measure(text);
+				var pos = icon.Pos + new float2(IconSize.X - textSize.X - 1, IconSize.Y - textSize.Y - 1);
 				quotaFont.DrawTextWithContrast(text, pos, Color.Cyan, Color.Black, 1);
+			}
 		}
 	}
 }

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="c5d5c6d"
+ENGINE_VERSION="621c648"
 
 ##############################################################################
 # Packaging


### PR DESCRIPTION
Reverts #136, removing the **decoupled rendering** integration from the mod's UI widgets.

### What
Removes the `Game.*WorldReadLock` world-read-lock guards that #136 added to 9 `Mods.Cameo` / `Mods.CA` widgets (production tabs, commander tree, custom-formations command bar, promotion tree, quota production palette, player-upgrade / observer-promotion icons, production tooltip). These mirrored the engine's decoupled render thread, which is being removed engine-side (cameo-mod/OpenRA#81).

### Safety
Every removed lock was **uncontended single-threaded**, so removing the guards is behaviour-neutral — a revert to the original path. Removing the *calls* compiles against the engine whether or not the `WorldReadLock` API still exists, so this is safe to land independently; it becomes required once the engine excision merges. Engine pin unchanged.

### Testing
Built clean (0 warnings). In-game verified: production tabs, promotions tree, quota palette, observer/spectator widgets, replay, save/load — all render and interact without issue.