### PR TITLE
Relocate Heat/Shockwave distortion renderers into Mods.Cameo

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/World/HeatDistortionRenderer.cs
+++ b/OpenRA.Mods.Cameo/Traits/World/HeatDistortionRenderer.cs
@@ -1,0 +1,214 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits
+{
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[Desc("Renders a screen-space heat-haze distortion effect that displaces the framebuffer.",
+		"Vertical-biased (heat rises), not radial. Add to the world actor.",
+		"Deliberately separate from GlowRenderer: glow blends light, this displaces pixels.")]
+	public class HeatDistortionRendererInfo : TraitInfo
+	{
+		[Desc("Gaussian falloff radius of each distortion in screen pixels.")]
+		public readonly float DistortionRadius = 80f;
+
+		[Desc("Peak pixel displacement at the centre of a distortion.")]
+		public readonly float DistortionStrength = 12f;
+
+		public override object Create(ActorInitializer init) { return new HeatDistortionRenderer(this); }
+	}
+
+	public sealed class HeatDistortionRenderer : IRenderPostProcessPass, INotifyActorDisposing
+	{
+		const int MaxDistortionsPerBatch = 16;
+
+		// Hard upper bound on queued (pending + fading) distortions. Draw is the only place these lists are
+		// drained, and it runs only on the render tick. If rendering stops (window minimized) or falls behind,
+		// the simulation keeps registering distortions with nothing to drain them. Capping bounds the worst
+		// case to a few extra shader batches in one frame instead of an unbounded flush that freezes the game.
+		const int MaxActiveEffects = 64;
+
+		// Fade timing and the shimmer animation follow logical game ticks, not render frames, so the effect
+		// lasts the same wall-clock duration at any framerate and freezes while the game is paused.
+		// fadeFrames/fadeInFrames are authored as render frames at ReferenceFps; convert to ticks to preserve the look.
+		const float ReferenceFps = 60f;
+		const float TicksPerSecond = 1000f / 40f; // normal game speed = 40ms timestep = 25 ticks/sec
+		const float FramesToTicks = TicksPerSecond / ReferenceFps;
+
+		static readonly string[] CentersKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"DistortionCenters[{i}]").ToArray();
+		static readonly string[] RadiiKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"DistortionRadii[{i}]").ToArray();
+		static readonly string[] StrengthsKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"DistortionStrengths[{i}]").ToArray();
+
+		readonly HeatDistortionRendererInfo info;
+		readonly Renderer renderer;
+		readonly IShader shader;
+		readonly IVertexBuffer<RenderPostProcessPassVertex> buffer;
+
+		readonly List<(WPos Center, float Scale)> pendingDistortions = new();
+		readonly List<(WPos Center, float Scale, float TicksRemaining, float TotalTicks, float FadeInTicks)> fadingDistortions = new();
+
+		readonly float[] centers = new float[MaxDistortionsPerBatch * 2];
+		readonly float[] radii = new float[MaxDistortionsPerBatch];
+		readonly float[] strengths = new float[MaxDistortionsPerBatch];
+
+		// Game-time (seconds) counter driving the shimmer animation, advanced by elapsed ticks so its speed is
+		// framerate-independent and pauses with the game. Render-only, so its value is irrelevant to sync.
+		float time;
+
+		// World tick at the previous Draw; used to advance fades/shimmer by elapsed ticks rather than render frames.
+		int lastWorldTick = -1;
+
+		public HeatDistortionRenderer(HeatDistortionRendererInfo info)
+		{
+			this.info = info;
+			renderer = Game.Renderer;
+			shader = renderer.CreateShader(new RenderPostProcessPassShaderBindings("heat_distortion"));
+			buffer = renderer.CreateVertexBuffer(new RenderPostProcessPassVertex[]
+			{
+				new(-1, -1), new(1, -1), new(1, 1),
+				new(1, 1), new(-1, 1), new(-1, -1)
+			}, false);
+		}
+
+		public void RegisterDistortion(WPos center, float scale = 1f, int fadeFrames = 0, int fadeInFrames = 0)
+		{
+			// Render-only cosmetic state that is drained exclusively by Draw (render tick). While the window
+			// is minimized the render tick never runs, so nothing drains these lists, yet the simulation keeps
+			// detonating warheads that call this. Dropping the registration while suspended keeps the lists from
+			// growing without bound and flushing in one frame on restore. Sync is unaffected: the simulation
+			// never reads this state.
+			if (Game.Renderer.WindowIsSuspended)
+				return;
+
+			// If no distortion is currently active, Draw has been idle (it only runs while effects exist) so
+			// lastWorldTick is stale; reset it, otherwise the first Draw would advance the fade by the whole
+			// idle gap and instantly expire this distortion.
+			if (pendingDistortions.Count == 0 && fadingDistortions.Count == 0)
+				lastWorldTick = -1;
+
+			if (fadeFrames > 0)
+			{
+				// Defensive bound for the render-starved (not suspended) case: drop the oldest, most-faded
+				// distortion rather than let the list grow without limit.
+				if (fadingDistortions.Count >= MaxActiveEffects)
+					fadingDistortions.RemoveAt(0);
+
+				var totalTicks = fadeFrames * FramesToTicks;
+				var fadeInTicks = fadeInFrames * FramesToTicks;
+				fadingDistortions.Add((center, scale, totalTicks, totalTicks, fadeInTicks));
+				return;
+			}
+
+			if (pendingDistortions.Count >= MaxActiveEffects)
+				return;
+
+			pendingDistortions.Add((center, scale));
+		}
+
+		PostProcessPassType IRenderPostProcessPass.Type => PostProcessPassType.AfterActors;
+		bool IRenderPostProcessPass.Enabled => pendingDistortions.Count > 0 || fadingDistortions.Count > 0;
+
+		void IRenderPostProcessPass.Draw(WorldRenderer wr)
+		{
+			// Advance fades and shimmer by the number of game ticks since the last Draw. At high framerates
+			// multiple frames render per tick (elapsed == 0, effect holds steady); while paused WorldTick is frozen.
+			var worldTick = wr.World.WorldTick;
+			var ticksElapsed = lastWorldTick < 0 ? 0f : Math.Max(0, worldTick - lastWorldTick);
+			lastWorldTick = worldTick;
+
+			time += ticksElapsed / TicksPerSecond;
+
+			var downscale = renderer.WorldDownscaleFactor;
+			var topLeft = wr.Viewport.TopLeft;
+
+			float2 ToFb(WPos pos)
+			{
+				var screenPx = wr.ScreenPxPosition(pos);
+				return new float2(
+					(screenPx.X - topLeft.X) * downscale,
+					(screenPx.Y - topLeft.Y) * downscale);
+			}
+
+			// Collect all distortions for this frame into one flat list so they can be batched together.
+			var batch = new List<(WPos Center, float Scale)>(pendingDistortions.Count + fadingDistortions.Count);
+			foreach (var d in pendingDistortions)
+				batch.Add(d);
+			pendingDistortions.Clear();
+
+			for (var i = fadingDistortions.Count - 1; i >= 0; i--)
+			{
+				var d = fadingDistortions[i];
+				var ticksPassed = d.TotalTicks - d.TicksRemaining;
+				float fadeScale;
+				if (d.FadeInTicks > 0 && ticksPassed < d.FadeInTicks)
+					fadeScale = ticksPassed / d.FadeInTicks;
+				else
+				{
+					var fadeOutTotal = d.TotalTicks - d.FadeInTicks;
+					fadeScale = fadeOutTotal > 0 ? d.TicksRemaining / fadeOutTotal : 1f;
+				}
+
+				fadeScale = Math.Clamp(fadeScale, 0f, 1f);
+				batch.Add((d.Center, d.Scale * fadeScale));
+
+				var remaining = d.TicksRemaining - ticksElapsed;
+				if (remaining <= 0f)
+					fadingDistortions.RemoveAt(i);
+				else
+					fadingDistortions[i] = (d.Center, d.Scale, remaining, d.TotalTicks, d.FadeInTicks);
+			}
+
+			// Draw distortions in fixed-size batches. Each batch takes one framebuffer snapshot and runs
+			// a single shader pass that loops over all sources, accumulating displacement before sampling.
+			for (var offset = 0; offset < batch.Count; offset += MaxDistortionsPerBatch)
+			{
+				var batchSize = Math.Min(MaxDistortionsPerBatch, batch.Count - offset);
+
+				for (var i = 0; i < batchSize; i++)
+				{
+					var d = batch[offset + i];
+					var p = ToFb(d.Center);
+
+					centers[i * 2] = p.X;
+					centers[i * 2 + 1] = p.Y;
+					radii[i] = info.DistortionRadius * d.Scale;
+					strengths[i] = info.DistortionStrength * d.Scale;
+				}
+
+				shader.SetTexture("WorldTexture", Game.Renderer.GetRenderBufferSnapshot());
+
+				// ANGLE/ES rejects glUniformXfv with count > 1 on array uniforms, so set each element individually.
+				for (var i = 0; i < batchSize; i++)
+				{
+					shader.SetVec(CentersKeys[i], centers[i * 2], centers[i * 2 + 1]);
+					shader.SetVec(RadiiKeys[i], radii[i]);
+					shader.SetVec(StrengthsKeys[i], strengths[i]);
+				}
+
+				shader.SetVec("DistortionCount", (float)batchSize);
+				shader.SetVec("Time", time);
+				shader.PrepareRender();
+				renderer.DrawBatch(buffer, shader, 0, 6, PrimitiveType.TriangleList);
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			buffer.Dispose();
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Traits/World/ShockwaveDistortionRenderer.cs
+++ b/OpenRA.Mods.Cameo/Traits/World/ShockwaveDistortionRenderer.cs
@@ -1,0 +1,216 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits
+{
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[Desc("Renders a screen-space shockwave-lens distortion: a refraction ring that expands outward",
+		"from an impact over a fraction of a second (pressure-wave look). Add to the world actor.",
+		"Deliberately separate from HeatDistortionRenderer: heat is vertical/ambient, this is radial/transient.")]
+	public class ShockwaveDistortionRendererInfo : TraitInfo
+	{
+		[Desc("Screen pixels the ring expands out to over its lifetime.")]
+		public readonly float MaxRadius = 300f;
+
+		[Desc("Thickness in screen pixels of the displaced ring band.")]
+		public readonly float RingThickness = 30f;
+
+		[Desc("Peak radial pixel displacement at the ring band.")]
+		public readonly float Strength = 20f;
+
+		public override object Create(ActorInitializer init) { return new ShockwaveDistortionRenderer(this); }
+	}
+
+	public sealed class ShockwaveDistortionRenderer : IRenderPostProcessPass, INotifyActorDisposing
+	{
+		const int MaxDistortionsPerBatch = 16;
+
+		// Hard upper bound on queued (pending + fading) shockwaves. Draw is the only place these lists are
+		// drained, and it runs only on the render tick. If rendering stops (window minimized) or falls behind,
+		// the simulation keeps registering shockwaves with nothing to drain them. Capping bounds the worst case
+		// to a few extra shader batches in one frame instead of an unbounded flush that freezes the game.
+		const int MaxActiveEffects = 64;
+
+		// Ring expansion/fade follows logical game ticks, not render frames, so the shockwave plays over the same
+		// wall-clock duration at any framerate and freezes while the game is paused.
+		// fadeFrames/fadeInFrames are authored as render frames at ReferenceFps; convert to ticks to preserve the look.
+		const float ReferenceFps = 60f;
+		const float TicksPerSecond = 1000f / 40f; // normal game speed = 40ms timestep = 25 ticks/sec
+		const float FramesToTicks = TicksPerSecond / ReferenceFps;
+
+		static readonly string[] CentersKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"ShockCenters[{i}]").ToArray();
+		static readonly string[] RadiiKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"RingRadii[{i}]").ToArray();
+		static readonly string[] StrengthsKeys = Enumerable.Range(0, MaxDistortionsPerBatch).Select(i => $"Strengths[{i}]").ToArray();
+
+		readonly ShockwaveDistortionRendererInfo info;
+		readonly Renderer renderer;
+		readonly IShader shader;
+		readonly IVertexBuffer<RenderPostProcessPassVertex> buffer;
+
+		readonly List<(WPos Center, float Scale)> pendingDistortions = new();
+		readonly List<(WPos Center, float Scale, float TicksRemaining, float TotalTicks, float FadeInTicks)> fadingDistortions = new();
+
+		// World tick at the previous Draw; used to advance the ring by elapsed ticks rather than render frames.
+		int lastWorldTick = -1;
+
+		readonly float[] centers = new float[MaxDistortionsPerBatch * 2];
+		readonly float[] radii = new float[MaxDistortionsPerBatch];
+		readonly float[] strengths = new float[MaxDistortionsPerBatch];
+
+		public ShockwaveDistortionRenderer(ShockwaveDistortionRendererInfo info)
+		{
+			this.info = info;
+			renderer = Game.Renderer;
+			shader = renderer.CreateShader(new RenderPostProcessPassShaderBindings("shockwave"));
+			buffer = renderer.CreateVertexBuffer(new RenderPostProcessPassVertex[]
+			{
+				new(-1, -1), new(1, -1), new(1, 1),
+				new(1, 1), new(-1, 1), new(-1, -1)
+			}, false);
+		}
+
+		public void RegisterShockwave(WPos center, float scale = 1f, int fadeFrames = 0, int fadeInFrames = 0)
+		{
+			// Render-only cosmetic state that is drained exclusively by Draw (render tick). While the window
+			// is minimized the render tick never runs, so nothing drains these lists, yet the simulation keeps
+			// detonating warheads that call this. Dropping the registration while suspended keeps the lists from
+			// growing without bound and flushing in one frame on restore. Sync is unaffected: the simulation
+			// never reads this state.
+			if (Game.Renderer.WindowIsSuspended)
+				return;
+
+			// If no shockwave is currently active, Draw has been idle (it only runs while effects exist) so
+			// lastWorldTick is stale; reset it, otherwise the first Draw would advance the ring by the whole
+			// idle gap and instantly expire this shockwave.
+			if (pendingDistortions.Count == 0 && fadingDistortions.Count == 0)
+				lastWorldTick = -1;
+
+			if (fadeFrames > 0)
+			{
+				// Defensive bound for the render-starved (not suspended) case: drop the oldest, most-faded
+				// shockwave rather than let the list grow without limit.
+				if (fadingDistortions.Count >= MaxActiveEffects)
+					fadingDistortions.RemoveAt(0);
+
+				var totalTicks = fadeFrames * FramesToTicks;
+				var fadeInTicks = fadeInFrames * FramesToTicks;
+				fadingDistortions.Add((center, scale, totalTicks, totalTicks, fadeInTicks));
+				return;
+			}
+
+			if (pendingDistortions.Count >= MaxActiveEffects)
+				return;
+
+			pendingDistortions.Add((center, scale));
+		}
+
+		PostProcessPassType IRenderPostProcessPass.Type => PostProcessPassType.AfterActors;
+
+		bool IRenderPostProcessPass.Enabled => pendingDistortions.Count > 0 || fadingDistortions.Count > 0;
+
+		void IRenderPostProcessPass.Draw(WorldRenderer wr)
+		{
+			// Advance the ring by the number of game ticks since the last Draw. At high framerates multiple
+			// frames render per tick (elapsed == 0, ring holds steady); while paused WorldTick is frozen.
+			var worldTick = wr.World.WorldTick;
+			var ticksElapsed = lastWorldTick < 0 ? 0f : Math.Max(0, worldTick - lastWorldTick);
+			lastWorldTick = worldTick;
+
+			var downscale = renderer.WorldDownscaleFactor;
+			var topLeft = wr.Viewport.TopLeft;
+
+			float2 ToFb(WPos pos)
+			{
+				var screenPx = wr.ScreenPxPosition(pos);
+				return new float2(
+					(screenPx.X - topLeft.X) * downscale,
+					(screenPx.Y - topLeft.Y) * downscale);
+			}
+
+			// Collect all shockwaves for this frame into one flat list (Center, Scale, Progress) so they can
+			// be batched together. Progress 0->1 drives the ring's expanding radius and its fade.
+			var batch = new List<(WPos Center, float Scale, float Progress)>(pendingDistortions.Count + fadingDistortions.Count);
+			foreach (var d in pendingDistortions)
+				batch.Add((d.Center, d.Scale, 0f));
+			pendingDistortions.Clear();
+
+			for (var i = fadingDistortions.Count - 1; i >= 0; i--)
+			{
+				var d = fadingDistortions[i];
+				var ticksPassed = d.TotalTicks - d.TicksRemaining;
+
+				// progress: how far the ring is through its lifetime (0 = just born, 1 = fully expanded/gone).
+				var progress = Math.Clamp(ticksPassed / d.TotalTicks, 0f, 1f);
+
+				// Optional ease-in on intensity (FadeInTicks). Most shockwaves use 0.
+				var fadeIn = d.FadeInTicks > 0 && ticksPassed < d.FadeInTicks
+					? ticksPassed / d.FadeInTicks
+					: 1f;
+
+				batch.Add((d.Center, d.Scale * fadeIn, progress));
+
+				var remaining = d.TicksRemaining - ticksElapsed;
+				if (remaining <= 0f)
+					fadingDistortions.RemoveAt(i);
+				else
+					fadingDistortions[i] = (d.Center, d.Scale, remaining, d.TotalTicks, d.FadeInTicks);
+			}
+
+			// Draw shockwaves in fixed-size batches. Each batch takes one framebuffer snapshot and runs a
+			// single shader pass that loops over all rings, accumulating radial displacement before sampling.
+			for (var offset = 0; offset < batch.Count; offset += MaxDistortionsPerBatch)
+			{
+				var batchSize = Math.Min(MaxDistortionsPerBatch, batch.Count - offset);
+
+				for (var i = 0; i < batchSize; i++)
+				{
+					var d = batch[offset + i];
+					var p = ToFb(d.Center);
+
+					centers[i * 2] = p.X;
+					centers[i * 2 + 1] = p.Y;
+
+					// Per-ring animated radius: expands from 0 to MaxRadius over the lifetime.
+					radii[i] = info.MaxRadius * d.Scale * d.Progress;
+
+					// Strength fades as the ring expands, so it vanishes as it reaches MaxRadius.
+					strengths[i] = info.Strength * d.Scale * (1f - d.Progress);
+				}
+
+				shader.SetTexture("WorldTexture", Game.Renderer.GetRenderBufferSnapshot());
+
+				// ANGLE/ES rejects glUniformXfv with count > 1 on array uniforms, so set each element individually.
+				for (var i = 0; i < batchSize; i++)
+				{
+					shader.SetVec(CentersKeys[i], centers[i * 2], centers[i * 2 + 1]);
+					shader.SetVec(RadiiKeys[i], radii[i]);
+					shader.SetVec(StrengthsKeys[i], strengths[i]);
+				}
+
+				shader.SetVec("DistortionCount", (float)batchSize);
+				shader.SetVec("RingThickness", info.RingThickness);
+				shader.PrepareRender();
+				renderer.DrawBatch(buffer, shader, 0, 6, PrimitiveType.TriangleList);
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			buffer.Dispose();
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Warheads/HeatDistortionWarhead.cs
+++ b/OpenRA.Mods.Cameo/Warheads/HeatDistortionWarhead.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Cameo.Traits;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cameo/Warheads/ShockwaveWarhead.cs
+++ b/OpenRA.Mods.Cameo/Warheads/ShockwaveWarhead.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Cameo.Traits;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="621c648"
+ENGINE_VERSION="f243759"
 
 ##############################################################################
 # Packaging

--- a/tools/porting-guides/flash-notifications/0001-flash-notifications.patch
+++ b/tools/porting-guides/flash-notifications/0001-flash-notifications.patch
@@ -1,0 +1,225 @@
+From b0b0544d4adae970fc747e9b01241ef6e80032fc Mon Sep 17 00:00:00 2001
+From: xan2622 <xan2622@online.fr>
+Date: Mon, 11 May 2026 17:29:01 +0300
+Subject: [PATCH] Add a heal debug command
+
+Co-authored-by: Gustas <37534529+PunkPun@users.noreply.github.com>
+---
+ OpenRA.Mods.Common/Commands/DevCommands.cs       | 16 ++++++++++++++++
+ .../Traits/Player/DeveloperMode.cs               | 12 ++++++++++++
+ .../Widgets/Logic/Ingame/DebugMenuLogic.cs       | 16 ++++++++++++++++
+ mods/cnc/chrome/ingame-debug.yaml                |  7 +++++++
+ mods/common/chrome/ingame-debug.yaml             |  8 ++++++++
+ mods/common/fluent/common.ftl                    |  1 +
+ mods/common/fluent/ingame-debug.ftl              |  1 +
+ mods/ra/chrome/ingame-debug.yaml                 |  8 ++++++++
+ mods/ts/chrome/ingame-debug.yaml                 |  8 ++++++++
+ 9 files changed, 77 insertions(+)
+
+diff --git a/OpenRA.Mods.Common/Commands/DevCommands.cs b/OpenRA.Mods.Common/Commands/DevCommands.cs
+index d05251dd2e..2d81c33fa3 100644
+--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
++++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
+@@ -78,6 +78,9 @@ public class DevCommands : IChatCommand, IWorldLoaded
+ 		[FluentReference]
+ 		const string ResetExplorationDescription = "description-reset-shroud";
+ 
++		[FluentReference]
++		const string HealSelectedActorsDescription = "description-heal-selected-actors";
++
+ 		[FluentReference]
+ 		const string KillSelectedActorsDescription = "description-kill-selected-actors";
+ 
+@@ -101,6 +104,7 @@ public static class Commands
+ 			public const string ResetExploration = "reset-shroud";
+ 			public const string PlayerExperience = "player-experience";
+ 			public const string Kill = "kill";
++			public const string Heal = "heal";
+ 			public const string Dispose = "dispose";
+ 		}
+ 
+@@ -123,6 +127,7 @@ public static class Commands
+ 			{ Commands.PlayerExperience, (PlayerExperienceDescription, PlayerExperience) },
+ 			{ PowerManager.CommandName, (PowerOutageDescription, PowerOutage) },
+ 			{ Commands.Kill, (KillSelectedActorsDescription, Kill) },
++			{ Commands.Heal, (HealSelectedActorsDescription, Heal) },
+ 			{ Commands.Dispose, (DisposeSelectedActorsDescription, Dispose) }
+ 		};
+ 
+@@ -255,6 +260,17 @@ static void PowerOutage(string arg, World world)
+ 			world.IssueOrder(new Order(PowerManager.OrderName, world.LocalPlayer.PlayerActor, false) { ExtraData = 250 });
+ 		}
+ 
++		static void Heal(string arg, World world)
++		{
++			foreach (var actor in world.Selection.Actors)
++			{
++				if (actor.IsDead)
++					continue;
++
++				world.IssueOrder(new Order(DeveloperMode.Orders.Heal, world.LocalPlayer.PlayerActor, Target.FromActor(actor), false));
++			}
++		}
++
+ 		static void Kill(string arg, World world)
+ 		{
+ 			foreach (var actor in world.Selection.Actors)
+diff --git a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+index 80f7c1d3cd..903e6e7788 100644
+--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
++++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+@@ -91,6 +91,7 @@ public static class Orders
+ 			public const string UnlimitedPower = "DevUnlimitedPower";
+ 			public const string BuildAnywhere = "DevBuildAnywhere";
+ 			public const string PlayerExperience = "DevPlayerExperience";
++			public const string Heal = "DevHeal";
+ 			public const string Kill = "DevKill";
+ 			public const string Dispose = "DevDispose";
+ 		}
+@@ -275,6 +276,17 @@ public void ResolveOrder(Actor self, Order order)
+ 					break;
+ 				}
+ 
++				case Orders.Heal:
++				{
++					if (order.Target.Type != TargetType.Actor)
++						break;
++
++					var actor = order.Target.Actor;
++					var health = actor.TraitOrDefault<IHealth>();
++					health?.InflictDamage(actor, actor, new Damage(-health.MaxHP), true);
++					break;
++				}
++
+ 				case Orders.Kill:
+ 				{
+ 					if (order.Target.Type != TargetType.Actor)
+diff --git a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+index d3caea7a90..7515f49c2d 100644
+--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
++++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+@@ -58,6 +58,22 @@ public DebugMenuLogic(Widget widget, World world)
+ 				cashAllButton.OnClick = () => IssueOrder(world, DeveloperMode.Orders.GiveCashAll);
+ 			}
+ 
++			var healButton = widget.GetOrNull<ButtonWidget>("HEAL_SELECTED");
++			if (healButton != null)
++			{
++				healButton.GetTooltipText = () => FluentProvider.GetMessage(TooltipDebugCommand, "command", '/' + DevCommands.Commands.Heal);
++				healButton.OnClick = () =>
++				{
++					foreach (var actor in world.Selection.Actors)
++					{
++						if (actor.IsDead)
++							continue;
++
++						world.IssueOrder(new Order(DeveloperMode.Orders.Heal, world.LocalPlayer.PlayerActor, Target.FromActor(actor), false));
++					}
++				};
++			}
++
+ 			var growResourcesButton = widget.GetOrNull<ButtonWidget>("GROW_RESOURCES");
+ 			if (growResourcesButton != null)
+ 			{
+diff --git a/mods/cnc/chrome/ingame-debug.yaml b/mods/cnc/chrome/ingame-debug.yaml
+index fdc03644ce..bb88de3b3e 100644
+--- a/mods/cnc/chrome/ingame-debug.yaml
++++ b/mods/cnc/chrome/ingame-debug.yaml
+@@ -150,6 +150,13 @@ Container@DEBUG_PANEL:
+ 					Width: PARENT_WIDTH - 17
+ 					Height: 35
+ 					Children:
++						Button@HEAL_SELECTED:
++							X: 15
++							Width: 146
++							Height: 35
++							Text: button-debug-panel-heal-selected
++							TooltipTemplate: BUTTON_TOOLTIP
++							TooltipContainer: TOOLTIP_CONTAINER
+ 						Button@DISPOSE_SELECTED:
+ 							X: 172
+ 							Width: 146
+diff --git a/mods/common/chrome/ingame-debug.yaml b/mods/common/chrome/ingame-debug.yaml
+index eb4243089d..15681aaf90 100644
+--- a/mods/common/chrome/ingame-debug.yaml
++++ b/mods/common/chrome/ingame-debug.yaml
+@@ -156,6 +156,14 @@ Container@DEBUG_PANEL:
+ 					Width: PARENT_WIDTH - 17
+ 					Height: 30
+ 					Children:
++						Button@HEAL_SELECTED:
++							X: 15
++							Width: 151
++							Height: 30
++							Font: Bold
++							Text: button-debug-panel-heal-selected
++							TooltipTemplate: BUTTON_TOOLTIP
++							TooltipContainer: TOOLTIP_CONTAINER
+ 						Button@DISPOSE_SELECTED:
+ 							X: 177
+ 							Width: 151
+diff --git a/mods/common/fluent/common.ftl b/mods/common/fluent/common.ftl
+index 11a53f7570..d086f0973f 100644
+--- a/mods/common/fluent/common.ftl
++++ b/mods/common/fluent/common.ftl
+@@ -736,6 +736,7 @@ description-power-outage = causes a 5-second power outage for the local player.
+ description-grow-resources = grows resources on the map.
+ description-clear-shroud = reveals the entire map.
+ description-reset-shroud = hides the entire map.
++description-heal-selected-actors = heals selected actors.
+ description-kill-selected-actors = kills selected actors.
+ description-dispose-selected-actors = disposes selected actors.
+ 
+diff --git a/mods/common/fluent/ingame-debug.ftl b/mods/common/fluent/ingame-debug.ftl
+index fbf8d74cef..e475c35297 100644
+--- a/mods/common/fluent/ingame-debug.ftl
++++ b/mods/common/fluent/ingame-debug.ftl
+@@ -8,6 +8,7 @@ checkbox-debug-panel-instant-charge = Instant Charge Time
+ checkbox-debug-panel-disable-visibility-checks = Disable Visibility Checks
+ button-debug-panel-give-cash = Give $20,000
+ button-debug-panel-give-cash-all = Give Cash All
++button-debug-panel-heal-selected = Heal Selected
+ button-debug-panel-dispose-selected = Dispose Selected
+ button-debug-panel-grow-resources = Grow Resources
+ button-debug-panel-kill-selected = Kill Selected
+diff --git a/mods/ra/chrome/ingame-debug.yaml b/mods/ra/chrome/ingame-debug.yaml
+index 337cd8a4a6..2d8dce77fd 100644
+--- a/mods/ra/chrome/ingame-debug.yaml
++++ b/mods/ra/chrome/ingame-debug.yaml
+@@ -168,6 +168,14 @@ Container@DEBUG_PANEL:
+ 					Width: PARENT_WIDTH - 17
+ 					Height: 30
+ 					Children:
++						Button@HEAL_SELECTED:
++							X: 15
++							Width: 151
++							Height: 30
++							Font: Bold
++							Text: button-debug-panel-heal-selected
++							TooltipTemplate: BUTTON_TOOLTIP
++							TooltipContainer: TOOLTIP_CONTAINER
+ 						Button@DISPOSE_SELECTED:
+ 							X: 177
+ 							Width: 151
+diff --git a/mods/ts/chrome/ingame-debug.yaml b/mods/ts/chrome/ingame-debug.yaml
+index b614cdb561..fa3d6b15db 100644
+--- a/mods/ts/chrome/ingame-debug.yaml
++++ b/mods/ts/chrome/ingame-debug.yaml
+@@ -156,6 +156,14 @@ Container@DEBUG_PANEL:
+ 					Width: PARENT_WIDTH - 17
+ 					Height: 30
+ 					Children:
++						Button@HEAL_SELECTED:
++							X: 15
++							Width: 151
++							Height: 30
++							Font: Bold
++							Text: button-debug-panel-heal-selected
++							TooltipTemplate: BUTTON_TOOLTIP
++							TooltipContainer: TOOLTIP_CONTAINER
+ 						Button@DISPOSE_SELECTED:
+ 							X: 177
+ 							Width: 151
+-- 
+2.42.0.windows.2
+

--- a/tools/porting-guides/flash-notifications/PORTING-GUIDE.md
+++ b/tools/porting-guides/flash-notifications/PORTING-GUIDE.md
@@ -1,0 +1,286 @@
+# Porting guide: flashing notifications
+
+Make a transient notification line **pulse** for a few cycles when it appears, to draw the
+eye to priority alerts (a unit under attack, construction complete, a superweapon ready).
+Off by default, opt-in per call, and fully YAML-configurable.
+
+This is a **porting guide, not a git patch** — it describes exactly what to add and where.
+Follow it by hand, or hand it to a coding agent to apply against whatever engine version
+your mod runs. (A `git am`-able `0001-flash-notifications.patch` is included alongside for
+engines close to the base commit below.)
+
+## What you get
+
+- Any transient line can flash on arrival by passing `flash: true`.
+- Effect modes (compose freely): text-colour pulse, bold-font swap, an underline rule, and a
+  whole-line background-block pulse (the boldest).
+- A player-facing on/off setting; zero cost when nothing is flashing.
+
+## How it works
+
+Notifications carry a new `Flash` flag. When the display widget adds a flashing line it wraps
+the line's colour/font/background getters in a square-wave that reads real time, and tracks
+the line in a small list that `Tick` drives and prunes. No simulation state changes — it's
+render-only chrome.
+
+## Compatibility
+
+- Written against OpenRA **`bleed` @ `b0b0544d4a`**. **Build-verified on pristine bleed** (0 errors).
+- **4 files, ~146 lines**, all additive — passing `flash` defaults to `false`, so nothing
+  flashes until a caller opts in.
+- No new files, no framework, no threading.
+
+## Package contents
+
+| File | Role |
+|---|---|
+| this guide | The 4 file edits + how to trigger and configure a flash. |
+| `0001-flash-notifications.patch` | Optional `git am`/`git apply` form for engines near the base commit. |
+
+---
+
+## Step 1 — Add the `Flash` flag to the notification record
+
+`OpenRA.Game/TextNotification.cs` — add a `Flash` field and thread it through the constructor:
+
+```csharp
+public readonly bool Flash;
+
+// add `bool flash = false` as the last constructor parameter:
+public TextNotification(TextNotificationPool pool, int clientId, string prefix, string text,
+    Color? prefixColor, Color? textColor, bool flash = false)
+{
+    // ... existing assignments ...
+    Flash = flash;
+}
+```
+
+## Step 2 — Thread `flash` through the manager
+
+`OpenRA.Game/TextNotificationsManager.cs` — add an optional `flash` arg to the transient and
+core add methods (defaults keep every existing caller unchanged):
+
+```csharp
+public static void AddTransientLine(Player player, string text, bool flash = false)
+{
+    // ... existing guard ...
+    AddTextNotification(TextNotificationPool.Transients, SystemClientId, SystemMessageLabel,
+        FluentProvider.GetMessage(text), flash: flash);
+}
+
+static void AddTextNotification(TextNotificationPool pool, int clientId, string prefix, string text,
+    Color? prefixColor = null, Color? textColor = null, bool flash = false)
+{
+    // ... build the notification passing flash through:
+    var textNotification = new TextNotification(pool, clientId, prefix, text, prefixColor, textColor, flash);
+    // ... existing cache/dispatch ...
+}
+```
+
+## Step 3 — Add the on/off setting
+
+`OpenRA.Game/Settings.cs`, inside the **`GameSettings`** class:
+
+```csharp
+[Desc("Flash priority game-event notification lines (e.g. base/unit under attack, superweapons) to draw attention.")]
+public bool FlashTransientNotifications = true;
+```
+
+The display widget gates on `Game.Settings.Game.FlashTransientNotifications`, so this is the
+player-facing master switch. (Optionally bind a Display-settings checkbox to it.)
+
+## Step 4 — Render the flash
+
+All in `OpenRA.Mods.Common/Widgets/TextNotificationsDisplayWidget.cs`.
+
+**4a. Configurable fields** — add near the other `public readonly` widget fields:
+
+```csharp
+[Desc("Colour the text is drawn in during the \"on\" phase of a flashing notification.")]
+public readonly Color FlashColor = Color.White;
+
+[Desc("Font swapped in during the \"on\" phase (e.g. a bold sibling). Empty = keep the normal font.")]
+public readonly string FlashFont = "Bold";
+
+[Desc("Draw a rule under the text during the \"on\" phase.")]
+public readonly bool FlashUnderline = false;
+
+[Desc("Duration in milliseconds of one flash cycle (one \"on\" phase plus one \"off\" phase).")]
+public readonly int FlashIntervalMs = 500;
+
+[Desc("Duration in milliseconds of the \"on\" phase within each cycle.")]
+public readonly int FlashOnMs = 250;
+
+[Desc("How many times a flashing notification flashes before settling.")]
+public readonly int FlashCount = 3;
+
+[Desc("Pulse the whole line's background block bright during the \"on\" phase (whole-line flash).")]
+public readonly bool FlashHighlight = false;
+
+[Desc("Id of the ColorBlock child in the line template whose colour is pulsed when FlashHighlight is set.")]
+public readonly string FlashHighlightBlock = "BACKGROUND";
+
+[Desc("Colour the background block is pulsed to during the \"on\" phase when FlashHighlight is set.")]
+public readonly Color FlashBackgroundColor = Color.White;
+
+[Desc("Text colour during the \"on\" phase when FlashHighlight is set (overrides FlashColor in highlight mode).")]
+public readonly Color FlashTextColor = Color.Black;
+```
+
+**4b. State + timing helpers** — add near the other private fields (e.g. after the
+`expirations` list):
+
+```csharp
+sealed class FlashLine
+{
+    public readonly LabelWidget Label;
+    public readonly string BaseFont;
+    public readonly long Start;
+
+    public FlashLine(LabelWidget label, string baseFont, long start)
+    {
+        Label = label;
+        BaseFont = baseFont;
+        Start = start;
+    }
+}
+
+readonly List<FlashLine> flashing = [];
+
+// Total flash lifetime; after this the line settles back to its normal appearance.
+long FlashDurationMs => (long)FlashIntervalMs * FlashCount;
+
+bool FlashActive(long start) => Game.RunTime - start < FlashDurationMs;
+
+// Square wave: "on" for the first FlashOnMs of every FlashIntervalMs cycle.
+bool FlashOn(long start)
+{
+    var elapsed = Game.RunTime - start;
+    return elapsed < FlashDurationMs && elapsed % FlashIntervalMs < FlashOnMs;
+}
+```
+
+**4c. Wrap the getters when a flashing line is added** — in `AddNotification`, right after the
+line widget is cloned + set up:
+
+```csharp
+if (notification.Flash && Game.Settings.Game.FlashTransientNotifications)
+{
+    var textLabel = notificationWidget.GetOrNull<LabelWidget>("TEXT");
+    if (textLabel != null)
+    {
+        var start = Game.RunTime;
+        var baseColor = textLabel.GetColor;
+        var onColor = FlashHighlight ? FlashTextColor : FlashColor;
+        textLabel.GetColor = () => FlashOn(start) ? onColor : baseColor();
+        flashing.Add(new FlashLine(textLabel, textLabel.Font, start));
+
+        // Whole-line flash: pulse the line's background block. It draws before the text, so the
+        // bright fill lands behind the (contrast-recoloured) text with no draw-order change.
+        if (FlashHighlight && !string.IsNullOrEmpty(FlashHighlightBlock))
+        {
+            var block = notificationWidget.GetOrNull<ColorBlockWidget>(FlashHighlightBlock);
+            if (block != null)
+            {
+                var baseBlockColor = block.GetColor;
+                block.GetColor = () => FlashOn(start) ? FlashBackgroundColor : baseBlockColor();
+            }
+        }
+    }
+}
+```
+
+**4d. Drive the font swap + prune** — at the top of `Tick()`:
+
+```csharp
+// Drive the bold font swap and prune finished flashes. Runs regardless of DisplayDurationMs.
+for (var i = flashing.Count - 1; i >= 0; i--)
+{
+    var f = flashing[i];
+    if (!FlashActive(f.Start))
+    {
+        if (!string.IsNullOrEmpty(FlashFont))
+            f.Label.Font = f.BaseFont;
+
+        flashing.RemoveAt(i);
+        continue;
+    }
+
+    if (!string.IsNullOrEmpty(FlashFont))
+        f.Label.Font = FlashOn(f.Start) ? FlashFont : f.BaseFont;
+}
+```
+
+**4e. (Optional) underline** — only if you want `FlashUnderline`. In `DrawOuter`, after the
+existing draw, and add the helper:
+
+```csharp
+// end of DrawOuter():
+if (FlashUnderline)
+    DrawFlashUnderlines();
+
+void DrawFlashUnderlines()
+{
+    foreach (var f in flashing)
+    {
+        if (!FlashOn(f.Start))
+            continue;
+
+        if (!Game.Renderer.Fonts.TryGetValue(f.Label.Font, out var font))
+            continue;
+
+        var text = f.Label.GetText();
+        if (string.IsNullOrEmpty(text))
+            continue;
+
+        var size = font.Measure(text);
+        var origin = f.Label.RenderOrigin;
+
+        // TEXT uses VAlign Middle; place the rule just below the glyphs.
+        var y = origin.Y + (f.Label.Bounds.Height + size.Y) / 2 + 1;
+        WidgetUtils.FillRectWithColor(new Rectangle(origin.X, y, size.X, 1), FlashColor);
+    }
+}
+```
+
+## Step 5 — Make a notification flash (C#)
+
+From any trait/logic, pass `flash: true`:
+
+```csharp
+TextNotificationsManager.AddTransientLine(player, "notification-unit-under-attack", flash: true);
+```
+
+Existing non-flashing calls need no change.
+
+## Step 6 — Style it (YAML)
+
+On your `TextNotificationsDisplayWidget` (in the in-game chrome), set any of:
+
+| Field | Default | Effect |
+|---|---|---|
+| `FlashHighlight` | `false` | Pulse the **whole line's background block** (boldest). |
+| `FlashHighlightBlock` | `BACKGROUND` | Id of the `ColorBlock` child to pulse. |
+| `FlashBackgroundColor` | white | Block colour during the pulse. |
+| `FlashTextColor` | black | Text colour during the pulse (highlight mode). |
+| `FlashColor` | white | Text colour during the pulse (non-highlight mode). |
+| `FlashFont` | `Bold` | Font swapped in during the pulse; empty = keep normal font. |
+| `FlashUnderline` | `false` | Rule under the text during the pulse. |
+| `FlashIntervalMs` | `500` | One full cycle (on + off). |
+| `FlashOnMs` | `250` | Length of the "on" phase. |
+| `FlashCount` | `3` | How many times it flashes before settling. |
+
+## Step 7 — Build & verify
+
+```sh
+dotnet build OpenRA.Mods.Common/OpenRA.Mods.Common.csproj -c Release
+```
+
+0 errors (verified on bleed). In-game: raise a priority alert with `flash: true` and confirm
+the line pulses, then settles; toggle `FlashTransientNotifications` off and confirm it stops.
+
+## Notes
+
+- `flash` defaults `false` everywhere → no behaviour change until a caller opts in.
+- The getters read `FlashOn`, so lines self-settle to their base look when the flash ends —
+  no per-frame teardown needed beyond the `Tick` prune.

--- a/tools/porting-guides/glow/GlowRenderer.cs
+++ b/tools/porting-guides/glow/GlowRenderer.cs
@@ -1,0 +1,341 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
+	[Desc("Renders a screen-space additive glow effect for beams and impacts. Add to the world actor.")]
+	public class GlowRendererInfo : TraitInfo
+	{
+		[Desc("Gaussian falloff radius of the glow in screen pixels.")]
+		public readonly float GlowRadius = 60f;
+
+		[Desc("Peak additive intensity of the glow (0-1).")]
+		public readonly float GlowIntensity = 0.7f;
+
+		public override object Create(ActorInitializer init) { return new GlowRenderer(this); }
+	}
+
+	public sealed class GlowRenderer : IRenderPostProcessPass, INotifyActorDisposing
+	{
+		// Must stay equal to MAX_BEAMS in postprocess_glow.frag (a mismatch silently drops the extra beams —
+		// SetVec on an out-of-range uniform name no-ops). Each beam costs ~13 fragment-uniform vectors, so 20
+		// => ~261. That is over the GLES2 guaranteed minimum (224) but well within the renderers OpenRA
+		// targets (ANGLE/D3D11 ~1024, desktop GL far more). Keep <= 17 if a raw GLES2 target is ever added.
+		const int MaxBeamsPerBatch = 20;
+
+		// Per batch the draw quad is shrunk to the beams' screen bounding box, so fragments outside the lit
+		// region are never shaded (the pass no longer runs full-screen). Each beam expands the box by the
+		// distance at which its exp(-(d/r)^e) falloff — scaled by the beam's peak brightness — falls below
+		// ~1/255, i.e. r * ln(255*peak)^(1/e). Exact per edge exponent: the default e>=2 gives a tight
+		// ~2-radius margin (cheaper than a fixed pad), while soft exponents widen the box so the clipped edge
+		// stays invisible. Floored so a faint glow still gets a small margin; capped so a pathologically soft
+		// exponent cannot grow the box back to full-screen.
+		const float PadRadiiFloor = 2f;
+		const float PadRadiiCap = 12f;
+
+		// Hard upper bound on the number of queued (pending + fading) glows. Draw is the only place
+		// these lists are drained, and it runs only on the render tick. If rendering stops (window
+		// minimized) or merely falls behind (replay running faster than it can draw), the simulation
+		// keeps registering glows with nothing to drain them. Capping the lists means the worst case is
+		// a handful of extra shader batches in one frame instead of an unbounded flush that freezes the game.
+		const int MaxActiveEffects = 64;
+
+		// Fade timing follows logical game ticks, not render frames, so a glow lasts the same wall-clock
+		// duration regardless of framerate (and freezes while the game is paused).
+		// The fadeFrames/fadeInFrames values in YAML were tuned as render frames at ReferenceFps; convert
+		// them to ticks (at normal-speed sim rate) so the original look is preserved at that framerate.
+		const float ReferenceFps = 60f;
+		const float TicksPerSecond = 1000f / 40f; // normal game speed = 40ms timestep = 25 ticks/sec
+		const float FramesToTicks = TicksPerSecond / ReferenceFps;
+
+		static readonly string[] BeamStartsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"BeamStarts[{i}]").ToArray();
+		static readonly string[] BeamEndsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"BeamEnds[{i}]").ToArray();
+		static readonly string[] GlowColorsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"GlowColors[{i}]").ToArray();
+		static readonly string[] GlowIntensitiesKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"GlowIntensities[{i}]").ToArray();
+		static readonly string[] GlowRadiiKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"GlowRadii[{i}]").ToArray();
+		static readonly string[] GlowRadiiEndKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"GlowRadiiEnd[{i}]").ToArray();
+		static readonly string[] EndpointBoostsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"EndpointBoosts[{i}]").ToArray();
+		static readonly string[] SelfBrightensKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"SelfBrightens[{i}]").ToArray();
+		static readonly string[] GlowFadeEndsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"GlowFadeEnds[{i}]").ToArray();
+		static readonly string[] EdgeExponentStartsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"EdgeExponentStarts[{i}]").ToArray();
+		static readonly string[] EdgeExponentEndsKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"EdgeExponentEnds[{i}]").ToArray();
+		static readonly string[] EndpointSquashesKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"EndpointSquashes[{i}]").ToArray();
+		static readonly string[] PoolRadiiKeys = Enumerable.Range(0, MaxBeamsPerBatch).Select(i => $"PoolRadii[{i}]").ToArray();
+
+		readonly GlowRendererInfo info;
+		readonly Renderer renderer;
+		readonly IShader shader;
+		readonly IVertexBuffer<RenderPostProcessPassVertex> buffer;
+
+		readonly List<(WPos Source, WPos Target, Color Color, float Scale, float ScaleEnd, float Intensity, float EndpointBoost, float SelfBrighten, float FadeEnd, float EdgeExponentStart, float EdgeExponentEnd, float EndpointSquash, float PoolScale)> pendingGlows = new();
+		readonly List<(WPos Source, WPos Target, Color Color, float Scale, float ScaleEnd, float Intensity, float EndpointBoost, float SelfBrighten, float FadeEnd, float EdgeExponentStart, float EdgeExponentEnd, float EndpointSquash, float PoolScale, float TicksRemaining, float TotalTicks, float FadeInTicks)> fadingGlows = new();
+		readonly Dictionary<WPos, int> glowsPerSource = new();
+
+		// World tick at the previous Draw; used to advance fades by elapsed ticks rather than render frames.
+		int lastWorldTick = -1;
+
+		readonly float[] beamStarts = new float[MaxBeamsPerBatch * 2];
+		readonly float[] beamEnds = new float[MaxBeamsPerBatch * 2];
+		readonly float[] glowColors = new float[MaxBeamsPerBatch * 3];
+		readonly float[] glowIntensities = new float[MaxBeamsPerBatch];
+		readonly float[] glowRadii = new float[MaxBeamsPerBatch];
+		readonly float[] glowRadiiEnd = new float[MaxBeamsPerBatch];
+		readonly float[] endpointBoosts = new float[MaxBeamsPerBatch];
+		readonly float[] selfBrightens = new float[MaxBeamsPerBatch];
+		readonly float[] glowFadeEnds = new float[MaxBeamsPerBatch];
+		readonly float[] edgeExponentStarts = new float[MaxBeamsPerBatch];
+		readonly float[] edgeExponentEnds = new float[MaxBeamsPerBatch];
+		readonly float[] endpointSquashes = new float[MaxBeamsPerBatch];
+		readonly float[] poolRadii = new float[MaxBeamsPerBatch];
+
+		// Reused per batch: the draw quad is resized to the batch's bounding box instead of full-screen.
+		readonly RenderPostProcessPassVertex[] quadVerts = new RenderPostProcessPassVertex[6];
+
+		public GlowRenderer(GlowRendererInfo info)
+		{
+			this.info = info;
+			renderer = Game.Renderer;
+			shader = renderer.CreateShader(new RenderPostProcessPassShaderBindings("glow"));
+
+			// Dynamic: SetData rewrites these six vertices every batch to cover only the beams' bounding box.
+			buffer = renderer.CreateVertexBuffer(new RenderPostProcessPassVertex[6], true);
+		}
+
+		// intensity is a brightness-only multiplier (independent of scale, which also drives radius).
+		// scaleEnd tapers the radius from scale (at source) to scaleEnd (at target) to form a cone;
+		// pass -1 to keep a uniform-radius beam.
+		// selfBrighten (>0) applies a radial gamma lift to the scene's own pixels under the glow (no
+		// added color), brightening shadows/midtones without blowing out highlights — a localized light.
+		// fadeEnd dims the body brightness toward the target (1 = no change).
+		// edgeExponentStart/edgeExponentEnd control the falloff exponent at the source/target (2 = the
+		// original Gaussian; higher gives a crisper edge, lower a softer/more diffuse one) and are
+		// interpolated along the segment the same way scale/scaleEnd are.
+		// endpointBoost (>0) adds a separate endpoint pool centred on the target at that peak brightness,
+		// combined with the body via a soft-max; 0 (the default for every non-searchlight caller) disables
+		// the pool entirely. poolScale is the pool's radius scale (independent of the body's scaleEnd) and
+		// endpointSquash (default 1) flattens the pool vertically into a ground-hugging ellipse.
+		public void RegisterGlow(WPos source, WPos target, Color color, float scale = 1f, int fadeFrames = 0, int fadeInFrames = 0, float intensity = 1f, float scaleEnd = -1f, float endpointBoost = 0f, float selfBrighten = 0f, float fadeEnd = 1f, float edgeExponentStart = 2f, float edgeExponentEnd = 2f, float endpointSquash = 1f, float poolScale = 0f)
+		{
+			// Render-only cosmetic state that is drained exclusively by Draw (render tick). While the
+			// window is minimized the render tick never runs, so nothing drains these lists, yet the
+			// simulation keeps detonating warheads and ticking searchlights that call this. Dropping the
+			// registration while suspended is what keeps the lists from growing without bound and flushing
+			// in one frame on restore. Sync is unaffected: the simulation never reads this state.
+			if (Game.Renderer.WindowIsSuspended)
+				return;
+
+			if (scaleEnd < 0f)
+				scaleEnd = scale;
+
+			// If no glow is currently active, Draw has been idle (it only runs while effects exist) so
+			// lastWorldTick is stale; reset it, otherwise the first Draw would advance the fade by the whole
+			// idle gap and instantly expire this glow.
+			if (pendingGlows.Count == 0 && fadingGlows.Count == 0)
+				lastWorldTick = -1;
+
+			if (fadeFrames > 0)
+			{
+				// Defensive bound for the render-starved case: drop the oldest, most-faded
+				// glow rather than let the list grow without limit.
+				if (fadingGlows.Count >= MaxActiveEffects)
+					fadingGlows.RemoveAt(0);
+
+				var totalTicks = fadeFrames * FramesToTicks;
+				var fadeInTicks = fadeInFrames * FramesToTicks;
+				fadingGlows.Add((source, target, color, scale, scaleEnd, intensity, endpointBoost, selfBrighten, fadeEnd, edgeExponentStart, edgeExponentEnd, endpointSquash, poolScale, totalTicks, totalTicks, fadeInTicks));
+				return;
+			}
+
+			// Cap at 2 simultaneous beam glows per source position per frame.
+			// Rapid-fire weapons that produce more than 2 beams per tick skip the extras.
+			glowsPerSource.TryGetValue(source, out var count);
+			if (count >= 2)
+				return;
+
+			if (pendingGlows.Count >= MaxActiveEffects)
+				return;
+
+			glowsPerSource[source] = count + 1;
+			pendingGlows.Add((source, target, color, scale, scaleEnd, intensity, endpointBoost, selfBrighten, fadeEnd, edgeExponentStart, edgeExponentEnd, endpointSquash, poolScale));
+		}
+
+		PostProcessPassType IRenderPostProcessPass.Type => PostProcessPassType.AfterActors;
+		bool IRenderPostProcessPass.Enabled => pendingGlows.Count > 0 || fadingGlows.Count > 0;
+
+		void IRenderPostProcessPass.Draw(WorldRenderer wr)
+		{
+			var downscale = renderer.WorldDownscaleFactor;
+			var topLeft = wr.Viewport.TopLeft;
+
+			float2 ToFb(WPos pos)
+			{
+				var screenPx = wr.ScreenPxPosition(pos);
+				return new float2(
+					(screenPx.X - topLeft.X) * downscale,
+					(screenPx.Y - topLeft.Y) * downscale);
+			}
+
+			// Collect all glows for this frame into one flat list so they can be batched together.
+			var batch = new List<(WPos Source, WPos Target, Color Color, float Scale, float ScaleEnd, float Intensity, float EndpointBoost, float SelfBrighten, float FadeEnd, float EdgeExponentStart, float EdgeExponentEnd, float EndpointSquash, float PoolScale)>(pendingGlows.Count + fadingGlows.Count);
+			foreach (var g in pendingGlows)
+				batch.Add(g);
+			pendingGlows.Clear();
+			glowsPerSource.Clear();
+
+			// Advance fades by the number of game ticks since the last Draw. At high framerates multiple
+			// frames render per tick (elapsed == 0, glow holds steady); while paused WorldTick is frozen.
+			var worldTick = wr.World.WorldTick;
+			var ticksElapsed = lastWorldTick < 0 ? 0f : Math.Max(0, worldTick - lastWorldTick);
+			lastWorldTick = worldTick;
+
+			for (var i = fadingGlows.Count - 1; i >= 0; i--)
+			{
+				var glow = fadingGlows[i];
+				var ticksPassed = glow.TotalTicks - glow.TicksRemaining;
+				float fadeScale;
+				if (glow.FadeInTicks > 0 && ticksPassed < glow.FadeInTicks)
+					fadeScale = ticksPassed / glow.FadeInTicks;
+				else
+				{
+					var fadeOutTotal = glow.TotalTicks - glow.FadeInTicks;
+					fadeScale = fadeOutTotal > 0 ? glow.TicksRemaining / fadeOutTotal : 1f;
+				}
+
+				fadeScale = Math.Clamp(fadeScale, 0f, 1f);
+				batch.Add((glow.Source, glow.Target, glow.Color, glow.Scale * fadeScale, glow.ScaleEnd * fadeScale, glow.Intensity, glow.EndpointBoost, glow.SelfBrighten * fadeScale, glow.FadeEnd, glow.EdgeExponentStart, glow.EdgeExponentEnd, glow.EndpointSquash, glow.PoolScale));
+
+				var remaining = glow.TicksRemaining - ticksElapsed;
+				if (remaining <= 0f)
+					fadingGlows.RemoveAt(i);
+				else
+					fadingGlows[i] = (glow.Source, glow.Target, glow.Color, glow.Scale, glow.ScaleEnd, glow.Intensity, glow.EndpointBoost, glow.SelfBrighten, glow.FadeEnd, glow.EdgeExponentStart, glow.EdgeExponentEnd, glow.EndpointSquash, glow.PoolScale, remaining, glow.TotalTicks, glow.FadeInTicks);
+			}
+
+			// Draw glows in fixed-size batches. Each batch takes one framebuffer snapshot and runs
+			// a single shader pass that loops over all beams, applying screen-blend math iteratively.
+			var fbW = (float)renderer.WorldFrameBufferSize.Width;
+			var fbH = (float)renderer.WorldFrameBufferSize.Height;
+			for (var offset = 0; offset < batch.Count; offset += MaxBeamsPerBatch)
+			{
+				var batchSize = Math.Min(MaxBeamsPerBatch, batch.Count - offset);
+
+				// Screen-space bounding box of this batch's beams (framebuffer px), expanded per beam by the
+				// glow/pool radius so the draw quad can be shrunk to just the lit region instead of full-screen.
+				var minX = float.MaxValue;
+				var minY = float.MaxValue;
+				var maxX = float.MinValue;
+				var maxY = float.MinValue;
+
+				for (var i = 0; i < batchSize; i++)
+				{
+					var g = batch[offset + i];
+					var p1 = ToFb(g.Source);
+					var p2 = ToFb(g.Target);
+
+					beamStarts[i * 2] = p1.X;
+					beamStarts[i * 2 + 1] = p1.Y;
+					beamEnds[i * 2] = p2.X;
+					beamEnds[i * 2 + 1] = p2.Y;
+					glowColors[i * 3] = g.Color.R / 255f;
+					glowColors[i * 3 + 1] = g.Color.G / 255f;
+					glowColors[i * 3 + 2] = g.Color.B / 255f;
+
+					// Brightness uses the average scale so a tapered cone is not dimmed by its narrow source;
+					// for uniform beams (Scale == ScaleEnd) this is identical to the source scale.
+					var brightnessScale = (g.Scale + g.ScaleEnd) * 0.5f;
+					glowIntensities[i] = info.GlowIntensity * brightnessScale * g.Intensity * (g.Color.A / 255f);
+					glowRadii[i] = info.GlowRadius * g.Scale;
+					glowRadiiEnd[i] = info.GlowRadius * g.ScaleEnd;
+					endpointBoosts[i] = g.EndpointBoost;
+					selfBrightens[i] = g.SelfBrighten;
+					glowFadeEnds[i] = g.FadeEnd;
+					edgeExponentStarts[i] = g.EdgeExponentStart;
+					edgeExponentEnds[i] = g.EdgeExponentEnd;
+					endpointSquashes[i] = g.EndpointSquash;
+					poolRadii[i] = info.GlowRadius * g.PoolScale;
+
+					// Widen the box by the beam's own visible reach: softer edge exponents and brighter peaks
+					// (body intensity, or the endpoint pool when EndpointBoost > 1) extend further before the
+					// contribution drops below ~1/255. eMin is the tighter (widest-reaching) of the two exponents.
+					var peak = glowIntensities[i] * Math.Max(1f, endpointBoosts[i]);
+					var eMin = Math.Max(0.25f, Math.Min(edgeExponentStarts[i], edgeExponentEnds[i]));
+					var falloffRadii = peak > 1f / 255f ? (float)Math.Pow(Math.Log(255f * peak), 1.0 / eMin) : 0f;
+					falloffRadii = Math.Clamp(falloffRadii, PadRadiiFloor, PadRadiiCap);
+					var pad = falloffRadii * Math.Max(Math.Max(glowRadii[i], glowRadiiEnd[i]), poolRadii[i]);
+					minX = Math.Min(minX, Math.Min(p1.X, p2.X) - pad);
+					minY = Math.Min(minY, Math.Min(p1.Y, p2.Y) - pad);
+					maxX = Math.Max(maxX, Math.Max(p1.X, p2.X) + pad);
+					maxY = Math.Max(maxY, Math.Max(p1.Y, p2.Y) + pad);
+				}
+
+				// Clamp the box to the framebuffer; skip the whole batch if it is entirely offscreen.
+				minX = Math.Max(0f, minX);
+				minY = Math.Max(0f, minY);
+				maxX = Math.Min(fbW, maxX);
+				maxY = Math.Min(fbH, maxY);
+				if (maxX <= minX || maxY <= minY)
+					continue;
+
+				// Map the box (framebuffer px — the same space as gl_FragCoord and the beam coordinates) to NDC
+				// and upload it as the draw quad. The passthrough vertex shader makes NDC == vertex position, so
+				// only fragments inside the box execute the glow shader instead of every pixel of the buffer.
+				var nx0 = minX / fbW * 2f - 1f;
+				var nx1 = maxX / fbW * 2f - 1f;
+				var ny0 = minY / fbH * 2f - 1f;
+				var ny1 = maxY / fbH * 2f - 1f;
+				quadVerts[0] = new RenderPostProcessPassVertex(nx0, ny0);
+				quadVerts[1] = new RenderPostProcessPassVertex(nx1, ny0);
+				quadVerts[2] = new RenderPostProcessPassVertex(nx1, ny1);
+				quadVerts[3] = new RenderPostProcessPassVertex(nx1, ny1);
+				quadVerts[4] = new RenderPostProcessPassVertex(nx0, ny1);
+				quadVerts[5] = new RenderPostProcessPassVertex(nx0, ny0);
+				buffer.SetData(quadVerts, 6);
+
+				shader.SetTexture("WorldTexture", Game.Renderer.GetRenderBufferSnapshot());
+
+				// ANGLE/ES rejects glUniformXfv with count > 1 on array uniforms, so set each element individually.
+				for (var i = 0; i < batchSize; i++)
+				{
+					shader.SetVec(BeamStartsKeys[i], beamStarts[i * 2], beamStarts[i * 2 + 1]);
+					shader.SetVec(BeamEndsKeys[i], beamEnds[i * 2], beamEnds[i * 2 + 1]);
+					shader.SetVec(GlowColorsKeys[i], glowColors[i * 3], glowColors[i * 3 + 1], glowColors[i * 3 + 2]);
+					shader.SetVec(GlowIntensitiesKeys[i], glowIntensities[i]);
+					shader.SetVec(GlowRadiiKeys[i], glowRadii[i]);
+					shader.SetVec(GlowRadiiEndKeys[i], glowRadiiEnd[i]);
+					shader.SetVec(EndpointBoostsKeys[i], endpointBoosts[i]);
+					shader.SetVec(SelfBrightensKeys[i], selfBrightens[i]);
+					shader.SetVec(GlowFadeEndsKeys[i], glowFadeEnds[i]);
+					shader.SetVec(EdgeExponentStartsKeys[i], edgeExponentStarts[i]);
+					shader.SetVec(EdgeExponentEndsKeys[i], edgeExponentEnds[i]);
+					shader.SetVec(EndpointSquashesKeys[i], endpointSquashes[i]);
+					shader.SetVec(PoolRadiiKeys[i], poolRadii[i]);
+				}
+
+				shader.SetVec("BeamCount", (float)batchSize);
+				shader.PrepareRender();
+				renderer.DrawBatch(buffer, shader, 0, 6, PrimitiveType.TriangleList);
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			buffer.Dispose();
+		}
+	}
+}

--- a/tools/porting-guides/glow/PORTING-GUIDE.md
+++ b/tools/porting-guides/glow/PORTING-GUIDE.md
@@ -1,0 +1,234 @@
+# Porting guide: weapon & explosion glow
+
+A screen-space **glow** effect for OpenRA: lasers, tesla bolts, muzzle flashes and
+explosions cast a soft additive halo onto the scene. Off by default, YAML-configurable
+per weapon/warhead, and gated by a single graphics setting.
+
+This is a **porting guide, not a git patch** — it describes exactly what to add and where,
+with drop-in source for the big pieces and small inline snippets for the rest. Follow it by
+hand, or hand it to a coding agent to apply against whatever engine version your mod runs.
+
+## What you get
+
+- **Beam/laser glow** — a tapered halo along any `BeamRenderable` (railguns, lasers).
+- **Tesla glow** — a halo along tesla zaps, independently tunable colour/scale/intensity.
+- **Explosion / impact glow** — a burst of light at a warhead's impact position.
+- All additive (screen blend), fading over time, and free when nothing is glowing.
+
+## How it works
+
+One world trait, `GlowRenderer`, is a full-screen **post-process pass** (`IRenderPostProcessPass`).
+Effects call `GlowRenderer.RegisterGlow(...)` each frame with a source→target segment, colour,
+radius and fade; the pass batches up to 20 glows and renders them in a single shader pass
+(`postprocess_glow.frag`) that reads the world framebuffer and screen-blends the halos on top.
+Nothing about the simulation changes — it's render-only cosmetic state.
+
+## Compatibility
+
+- Written against OpenRA **`bleed` @ `b0b0544d4a`**; the `IRenderPostProcessPass` framework it
+  builds on is stock upstream, so this applies to any recent bleed-tracking engine.
+- **Build-verified on pristine bleed** (`OpenRA.Mods.Common` + `OpenRA.Platforms.Default`, 0 errors).
+- No threading, no new framework — one trait, one shader, one shader-loader tweak, one setting.
+
+## Package contents
+
+| File | Role |
+|---|---|
+| `GlowRenderer.cs` (companion) | The render service — drop in verbatim. |
+| `postprocess_glow.frag` (companion) | The GLSL shader — drop in verbatim. |
+| this guide | The 3 small hand-edits + how to trigger and configure glow. |
+
+---
+
+## Step 1 — Add the render service
+
+Copy the companion **`GlowRenderer.cs`** into your engine at:
+
+```
+OpenRA.Mods.Common/Traits/World/GlowRenderer.cs
+```
+
+It's self-contained: namespace `OpenRA.Mods.Common.Traits`, implements `IRenderPostProcessPass`
++ `INotifyActorDisposing`, and exposes `RegisterGlow(...)`. If your mod keeps such traits in its
+own assembly, put it there instead and adjust the namespace — nothing in the engine references
+it by type, so it can live wherever your effects can reach it.
+
+## Step 2 — Add the shader
+
+Copy the companion **`postprocess_glow.frag`** into your engine's shader folder:
+
+```
+glsl/postprocess_glow.frag
+```
+
+It reuses the stock `glsl/postprocess.vert` vertex shader (already present in bleed). The
+shader name `"glow"` in `GlowRenderer` maps to `postprocess_glow.{vert,frag}` automatically —
+no manifest entry needed. `MAX_BEAMS` (20) in the shader must match `MaxBeamsPerBatch` in
+`GlowRenderer.cs`; keep them in sync if you change it.
+
+## Step 3 — Teach the shader loader about uniform arrays (required)
+
+The glow shader uses `uniform vec3 GlowColors[20]` style arrays and sets them **per element**
+(`GlowColors[0]`, `GlowColors[1]`, …). OpenGL only auto-registers the `[0]` name, and ANGLE/ES
+rejects bulk `glUniformXfv` with `count > 1`, so the loader must pre-register every element
+location. In `OpenRA.Platforms.Default/Shader.cs`, in the uniform-scanning loop of the
+constructor, right after `uniformCache[sampler] = loc;`, add:
+
+```csharp
+// For uniform arrays, OpenGL reports the name as "Name[0]"; register the bare "Name"
+// and pre-register all element locations ("Name[1]", "Name[2]", etc.).
+// ANGLE/ES rejects glUniformXfv with count > 1, so callers set individual elements
+// using these pre-registered per-element locations.
+if (sampler.EndsWith("[0]", StringComparison.Ordinal))
+{
+    var bareName = sampler.Substring(0, sampler.Length - 3);
+    uniformCache[bareName] = loc;
+    for (var j = 1; j < uniformSize; j++)
+    {
+        var elemName = $"{bareName}[{j}]";
+        var elemLoc = OpenGL.glGetUniformLocation(program, elemName);
+        OpenGL.CheckGLError();
+        uniformCache[elemName] = elemLoc;
+    }
+}
+```
+
+This needs the array length, so change the `glGetActiveUniform` call a few lines up from
+`out _, out _, out var type` to capture the size:
+
+```csharp
+OpenGL.glGetActiveUniform(program, i, 128, out _, out var uniformSize, out var type, sb);
+```
+
+That's the only required `Shader.cs` change; `GlowRenderer` sets elements through the stock
+`SetVec(string, float, …)` overloads. (A bulk `SetVec(string, float[], int components, int count)`
+overload also exists in the source engine but glow does not use it — skip it unless other
+effects need it.)
+
+## Step 4 — Add the on/off setting
+
+In `OpenRA.Game/Settings.cs`, inside the **`GraphicSettings`** class, add:
+
+```csharp
+[Desc("Enable screen-space glow effect along laser beams.")]
+public bool LaserGlow = true;
+```
+
+Every trigger below checks `Game.Settings.Graphics.LaserGlow`, so this is the player-facing
+master switch. (Optionally bind a checkbox to it in your Display settings — not required.)
+
+## Step 5 — Enable the pass in YAML
+
+Add the trait to your world actor (e.g. `world` in `rules/world.yaml`):
+
+```yaml
+World:
+    GlowRenderer:
+```
+
+## Step 6 — Trigger glow from your effects
+
+Glow is opt-in: something has to call `RegisterGlow`. The three patterns below cover weapons
+and explosions — copy whichever you need into your own renderables/warheads.
+
+**Explosion / impact glow** — in an impact warhead (pattern from `CreateEffectWarhead.DoImpact`):
+
+```csharp
+// YAML-exposed fields on the warhead:
+[Desc("Color of the glow at the impact position. Requires GlowScale > 0.")]
+public readonly Color GlowColor = Color.FromArgb(255, 255, 102, 0);
+[Desc("Scale of the glow effect at the impact position. Set above 0 to enable.")]
+public readonly float GlowScale = 0f;
+[Desc("Number of render frames for the glow to fade out over.")]
+public readonly int GlowFadeFrames = 60;
+[Desc("Number of render frames for the glow to fade in over. 0 = instant.")]
+public readonly int GlowFadeInFrames = 0;
+
+// at impact:
+if (GlowScale > 0 && Game.Settings.Graphics.LaserGlow)
+    world.WorldActor.TraitOrDefault<GlowRenderer>()
+        ?.RegisterGlow(pos, pos, GlowColor, GlowScale, GlowFadeFrames, GlowFadeInFrames);
+```
+
+**Beam / laser glow** — at the end of a beam renderable's render (pattern from `BeamRenderable`):
+
+```csharp
+if (Game.Settings.Graphics.LaserGlow)
+    wr.World.WorldActor.TraitOrDefault<GlowRenderer>()
+        ?.RegisterGlow(Pos, Pos + length, color, width.Length / 86f);
+```
+
+**Tesla glow** — thread glow fields from the projectile into its renderable, then (pattern from
+`TeslaZapRenderable`):
+
+```csharp
+// projectile (e.g. TeslaZap) YAML fields:
+public readonly Color GlowColor = Color.FromArgb(160, 200, 255);
+public readonly float GlowScale = 1f;      // 0 disables
+public readonly float GlowIntensity = 1.65f;
+
+// in the renderable's render:
+if (Game.Settings.Graphics.LaserGlow && glowScale > 0f && length.Length != 0)
+    wr.World.WorldActor.TraitOrDefault<GlowRenderer>()
+        ?.RegisterGlow(Pos, Pos + length, glowColor, glowScale, intensity: glowIntensity);
+```
+
+### `RegisterGlow` signature reference
+
+```csharp
+void RegisterGlow(
+    WPos source, WPos target, Color color,
+    float scale = 1f,          // radius at source
+    int fadeFrames = 0,        // 0 = one-frame flash; >0 fades out over N render frames
+    int fadeInFrames = 0,
+    float intensity = 1f,      // brightness only (does not grow radius)
+    float scaleEnd = -1f,      // taper radius to this at target; -1 = uniform
+    float endpointBoost = 0f,  // separate brighter pool at the target (0 = off)
+    float selfBrighten = 0f,   // radial gamma-lift of the scene under the glow
+    float fadeEnd = 1f,        // body brightness at the target end
+    float edgeExponentStart = 2f, float edgeExponentEnd = 2f, // 2 = Gaussian edge
+    float endpointSquash = 1f, // flatten the endpoint pool into a ground ellipse
+    float poolScale = 0f)      // endpoint pool radius
+```
+
+For a plain weapon/explosion glow you only need the first few args; the rest shape searchlight-
+style cones and ground pools.
+
+## Step 7 — Author it in YAML
+
+Once wired, modders tune glow entirely in weapon/warhead YAML — no code per weapon:
+
+```yaml
+# explosion glow on a warhead
+Warhead@glow: CreateEffect
+    GlowColor: FF6600
+    GlowScale: 3
+    GlowFadeFrames: 45
+
+# tesla bolt glow
+Projectile: TeslaZap
+    GlowColor: A0C8FF
+    GlowScale: 1.2
+    GlowIntensity: 1.65
+```
+
+The **"Weapon Glow Effects"** master switch is the `LaserGlow` setting from Step 4.
+
+## Step 8 — Build & verify
+
+```sh
+dotnet build OpenRA.Mods.Common/OpenRA.Mods.Common.csproj -c Release
+dotnet build OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj -c Release
+```
+
+Both should report 0 errors (verified on bleed). Then in-game: fire a glow-enabled weapon or
+detonate a glow warhead and confirm the halo renders; toggle the `LaserGlow` setting off and
+confirm it disappears. On a fullscreen/ANGLE build, verify Step 3 took (arrays of >1 element
+render correctly rather than only the first beam).
+
+## Notes
+
+- Everything is gated by `GlowScale > 0` and the `LaserGlow` setting, so applying this changes
+  nothing until a weapon opts in.
+- `MAX_BEAMS`/`MaxBeamsPerBatch` (20) bounds glows per batch; extras spill to the next batch.
+- Render-only and single-threaded — no sim/determinism impact.

--- a/tools/porting-guides/glow/postprocess_glow.frag
+++ b/tools/porting-guides/glow/postprocess_glow.frag
@@ -1,0 +1,87 @@
+#version {VERSION}
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+#define MAX_BEAMS 20
+
+uniform sampler2D WorldTexture;
+uniform vec2 BeamStarts[MAX_BEAMS];
+uniform vec2 BeamEnds[MAX_BEAMS];
+uniform vec3 GlowColors[MAX_BEAMS];
+uniform float GlowIntensities[MAX_BEAMS];
+uniform float GlowRadii[MAX_BEAMS];
+uniform float GlowRadiiEnd[MAX_BEAMS];
+uniform float EndpointBoosts[MAX_BEAMS];
+uniform float SelfBrightens[MAX_BEAMS];
+uniform float GlowFadeEnds[MAX_BEAMS];
+uniform float EdgeExponentStarts[MAX_BEAMS];
+uniform float EdgeExponentEnds[MAX_BEAMS];
+uniform float EndpointSquashes[MAX_BEAMS];
+uniform float PoolRadii[MAX_BEAMS];
+uniform float BeamCount;
+
+out vec4 fragColor;
+
+// Returns (distance, t) where t is the clamped projection parameter along [a, b].
+vec2 segmentDistT(vec2 p, vec2 a, vec2 b)
+{
+	vec2 ab = b - a;
+	float t = clamp(dot(p - a, ab) / max(dot(ab, ab), 0.0001), 0.0, 1.0);
+	return vec2(length(p - (a + t * ab)), t);
+}
+
+void main()
+{
+	vec4 c = texelFetch(WorldTexture, ivec2(gl_FragCoord.xy), 0);
+	vec3 rgb = c.rgb;
+	int count = int(BeamCount);
+
+	for (int i = 0; i < MAX_BEAMS; ++i)
+	{
+		if (i >= count)
+			break;
+
+		// Beam body: radius tapers from GlowRadii (source) to GlowRadiiEnd (wide end), the edge
+		// exponent (2 = Gaussian) tapers from EdgeExponentStarts to EdgeExponentEnds so the cross
+		// section can be crisp near the source and soften further out, and brightness fades from
+		// full at the source to GlowFadeEnds at the wide end (a plain linear fade, as if scattering
+		// into fog). This is the whole effect for a uniform beam and for every non-searchlight glow.
+		vec2 dt = segmentDistT(gl_FragCoord.xy, BeamStarts[i], BeamEnds[i]);
+		float d = dt.x;
+		float t = dt.y;
+
+		float r = mix(GlowRadii[i], GlowRadiiEnd[i], t);
+		float edgeExponent = mix(EdgeExponentStarts[i], EdgeExponentEnds[i], t);
+		float bodyFade = mix(1.0, GlowFadeEnds[i], t);
+		float falloff = bodyFade * exp(-pow(d / max(r, 0.0001), edgeExponent));
+
+		// Endpoint pool: a separate glow centred on BeamEnds, brightness EndpointBoosts (peak,
+		// values > 1 punch through brighter than the body), radius PoolRadii independent of the body
+		// width, flattened vertically by EndpointSquashes into a ground-hugging ellipse. The pool and
+		// body are combined with a p-norm soft-max (pow(a^P + b^P, 1/P)): it rounds the crossover so
+		// there is no hard-max crease/ring, yet unlike a polynomial smooth-max it returns 0 where both
+		// are 0 (no screen-wide brightness floor). EndpointBoosts == 0 (every non-searchlight glow, and
+		// the uniform Beam shape) skips the pool entirely, leaving the body falloff byte-identical.
+		if (EndpointBoosts[i] > 0.0)
+		{
+			vec2 toEnd = gl_FragCoord.xy - BeamEnds[i];
+			float poolD = length(vec2(toEnd.x, toEnd.y / max(EndpointSquashes[i], 0.0001)));
+			float pool = EndpointBoosts[i] * exp(-pow(poolD / max(PoolRadii[i], 0.0001), EdgeExponentEnds[i]));
+			float P = 3.0;
+			falloff = pow(pow(falloff, P) + pow(pool, P), 1.0 / P);
+		}
+
+		// Colored additive glow (screen blend, asymptotic to white).
+		vec3 contrib = GlowColors[i] * (GlowIntensities[i] * falloff);
+		rgb = rgb + contrib * (1.0 - rgb);
+
+		// Self-brighten: a radial gamma lift on the scene's own pixels (no added color). Gamma < 1
+		// raises shadows and midtones strongly while leaving highlights at white (no blow-out) and
+		// black at black, so the sprite under the muzzle reads as lit rather than washed out.
+		float gamma = 1.0 + SelfBrightens[i] * falloff;
+		rgb = pow(max(rgb, 0.0), vec3(1.0 / gamma));
+	}
+
+	fragColor = vec4(rgb, c.a);
+}


### PR DESCRIPTION
⛔ **DO NOT MERGE until cameo-mod/OpenRA#82 merges + a pin bump is added to this branch.**
Merging early double-defines the traits (they'd exist in both `Mods.Common` and `Mods.Cameo`) → broken build.

---

Moves `HeatDistortionRenderer` / `ShockwaveDistortionRenderer` from the engine's
`OpenRA.Mods.Common` into `OpenRA.Mods.Cameo` (namespace `OpenRA.Mods.Cameo.Traits`), and
points the `HeatDistortionWarhead` / `ShockwaveWarhead` usings at the new namespace.

Paired with engine PR cameo-mod/OpenRA#82, which removes the two files from `Mods.Common`.
Only these mod warheads trigger the traits and nothing in the engine references them, so they
belong mod-side — keeping `cameo-engine` closer to pristine upstream.

**To land:** merge #82 → bump `ENGINE_VERSION` here to that merge commit → then merge this.