### PR TITLE
Use snow D2K concrete on Winter

### DIFF
--- a/mods/cameo/tilesets/winter.yaml
+++ b/mods/cameo/tilesets/winter.yaml
@@ -1985,7 +1985,7 @@ Templates:
 			1: Rock
 	Template@856:
 		Id: 856
-		Images: d2kconcrete.png
+		Images: d2kconcrete_snow.png
 		Palette: greyscale
 		Frames: 0, 1, 2, 3, 4, 14
 		Size: 1,1


### PR DESCRIPTION
## What changed

- Use `d2kconcrete_snow.png` for Winter terrain template 856.

## Why

The Winter theater selected the orange Arrakis concrete variant, which looked incorrect on snow-covered maps such as Collateral Chaos. Snow and RA Snow already use the dedicated snow recolor.

## Validation

- Confirmed the Snow concrete asset exists.
- Confirmed the diff contains one insertion and one deletion in `winter.yaml`.
- `git diff --check` passed.
- No build required for this tileset-only change.