### PR TITLE
Fix UI theme paths after asset rename

### DIFF
--- a/OpenRA.Mods.Cameo/CyberintelThemes.cs
+++ b/OpenRA.Mods.Cameo/CyberintelThemes.cs
@@ -12,9 +12,9 @@ using OpenRA.Primitives;
 namespace OpenRA.Mods.Cameo
 {
 	// Shared helper for the cyberintel UI colour theme. The baked variants ship in the tracked
-	// uibits/cyberintel-themes/<name>-ui.png + <name>-dialog.png. Applying a theme copies the chosen
+	// uibits/cyberintel_themes/<name>_ui.png + <name>_dialog.png. Applying a theme copies the chosen
 	// pair into a writable SupportDir folder (Content/cameo/theme) that mod.yaml mounts AFTER
-	// cameo|uibits, so the copies shadow the shipped cyberintel-ui.png / dialog.png by bare name
+	// cameo|uibits, so the copies shadow the shipped cyberintel_ui.png / dialog.png by bare name
 	// without ever touching the tracked files. Chrome is loaded once at launch, so a write only takes
 	// visible effect on a boot where the override file already existed at mount time — i.e. the next
 	// restart for a dropdown pick, and (for "random") from the second boot onward.
@@ -69,17 +69,17 @@ namespace OpenRA.Mods.Cameo
 			try
 			{
 				// Anchor on a uibits-only top-level file (cameologo.png) to find the tracked preset
-				// source folder — resolving via cyberintel-ui.png would return the SupportDir override
+				// source folder — resolving via cyberintel_ui.png would return the SupportDir override
 				// once it exists, not uibits.
 				if (!fileSystem.TryGetPackageContaining("cameologo.png", out var package, out _) || package is not Folder uibits)
 					return;
 
-				var themeDir = Path.Combine(uibits.Name, "cyberintel-themes");
+				var themeDir = Path.Combine(uibits.Name, "cyberintel_themes");
 				var outDir = Platform.ResolvePath("^SupportDir|Content/cameo/theme");
 				Directory.CreateDirectory(outDir);
 
-				File.Copy(Path.Combine(themeDir, theme + "-ui.png"), Path.Combine(outDir, "cyberintel-ui.png"), true);
-				File.Copy(Path.Combine(themeDir, theme + "-dialog.png"), Path.Combine(outDir, "dialog.png"), true);
+				File.Copy(Path.Combine(themeDir, theme + "_ui.png"), Path.Combine(outDir, "cyberintel_ui.png"), true);
+				File.Copy(Path.Combine(themeDir, theme + "_dialog.png"), Path.Combine(outDir, "dialog.png"), true);
 			}
 			catch (Exception e)
 			{

--- a/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cameo.Traits
 		public bool QuotaModeEnabled = false;
 
 		[Desc("Selected cyberintel UI colour theme. On change, the matching baked chrome sheets are ",
-			"copied over the active ones (applies after restart). Options live in uibits/cyberintel-themes/. ",
+			"copied over the active ones (applies after restart). Options live in uibits/cyberintel_themes/. ",
 			"\"random\" re-picks a colour on every boot.")]
 		public string UITheme = "random";
 	}


### PR DESCRIPTION
## What changed

- Update the UI theme loader to use the underscore-based asset directory and filenames.
- Write the generated override using the `cyberintel_ui.png` name referenced by the current chrome definitions.
- Update the settings description to match the renamed asset directory.

## Why

The no-hyphen asset rename changed `cyberintel-themes` and its files to underscore-based names, but `CyberintelThemes.Apply` still referenced the old paths. Theme selection was saved, but the file-copy exception was swallowed into the debug log, so restarting did not update the UI sheets.

## Impact

Fixed and Random UI colour themes once again update both the menu text colours and frame chrome after restart.

## Validation

- `tools\preflight-build.ps1`
- `./make all` (0 warnings, 0 errors)
- Verified `engine\bin\OpenRA.Mods.Cameo.dll` contains the corrected path marker
- In-game sequential restart testing confirmed Random updates both text and frames
