### PR TITLE
Fix rename migration display and voxel regressions

### DIFF
--- a/docs/audit/display_text_review.md
+++ b/docs/audit/display_text_review.md
@@ -1,0 +1,484 @@
+# Display-text migration repair manifest
+
+This manifest was generated and approved before repair. `FIX` means the exact pre-migration value was recovered through a rename-only blame chain and has now been restored. `KEEP` is a technical reference inside a display-named field. `REVIEW` is never changed automatically.
+
+Findings: **429**; FIX: **428**; KEEP: **1**; REVIEW: **0**.
+
+Active findings — FIX: **223**; KEEP: **1**; REVIEW: **0**.
+
+## Identifier-family separation
+
+| internal id | FIX | KEEP | REVIEW |
+|---|---:|---:|---:|
+| `ixian_autonomouscarryall` | 16 | 0 | 0 |
+| `ixian_concretewall` | 20 | 0 | 0 |
+| `ixian_ixresearchcenter` | 0 | 1 | 0 |
+| `ra1_allies_alliedbarracks` | 3 | 0 | 0 |
+| `ra1_allies_alliedsniper` | 47 | 0 | 0 |
+| `ra1_allies_gapgenerator` | 10 | 0 | 0 |
+| `ra1_allies_mechanic` | 7 | 0 | 0 |
+| `ra1_allies_sheridanassaulttank` | 6 | 0 | 0 |
+| `ra1_soviet_attackdog` | 8 | 0 | 0 |
+| `ra1_soviet_cyberdog` | 11 | 0 | 0 |
+| `ra1_soviet_hindattackhelicopter` | 15 | 0 | 0 |
+| `ra1_soviet_ironcurtain` | 16 | 0 | 0 |
+| `ra1_soviet_kotinnucleartank` | 7 | 0 | 0 |
+| `ra1_soviet_migattackbomber` | 24 | 0 | 0 |
+| `ra1_soviet_shocktrooper` | 1 | 0 | 0 |
+| `ra1_soviet_volkov` | 10 | 0 | 0 |
+| `ra1_soviet_yakscoutplane` | 13 | 0 | 0 |
+| `td_gdi_advancedcommunicationscenter` | 7 | 0 | 0 |
+| `td_gdi_apc` | 29 | 0 | 0 |
+| `td_gdi_grenadier` | 1 | 0 | 0 |
+| `td_gdi_humvee` | 6 | 0 | 0 |
+| `td_gdi_mlrs` | 15 | 0 | 0 |
+| `td_gdi_orca` | 11 | 0 | 0 |
+| `td_nod_gunturret` | 89 | 0 | 0 |
+| `td_nod_handofnod` | 22 | 0 | 0 |
+| `td_nod_reconbike` | 23 | 0 | 0 |
+| `td_nod_samsite` | 17 | 0 | 0 |
+| `tkm_t30` | 1 | 0 | 0 |
+
+## KEEP (1)
+
+| active | location | field | current value | historical value | provenance | reason |
+|---|---|---|---|---|---|---|
+| yes | `mods/cameo/ContentPacks/D2k/Ixian/yaml/upgrades.yaml:112` | `Description` | upgrade_d2k_advanced_ixian_technology.description, ~ixian_ixresearchcenter | upgrade_d2k_advanced_ixian_technology.description, ~research_centre.ixian | `d763966177` | Description contains an explicit hidden prerequisite reference |
+
+## REVIEW (0)
+
+| active | location | field | current value | historical value | provenance | reason |
+|---|---|---|---|---|---|---|
+
+## FIX (428)
+
+| active | location | field | current value | historical value | provenance | reason |
+|---|---|---|---|---|---|---|
+| yes | `mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml:552` | `Name` | Machine td_nod_gunturret Turret | Machine Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml:617` | `Name` | td_nod_gunturret Turret | Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:166` | `Name` | td_gdi_advancedcommunicationscenter In The Sky | Eye In The Sky | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:554` | `Name` | td_gdi_advancedcommunicationscenter on the Sky | Eye on the Sky | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:777` | `Name` | Advanced ixian_autonomouscarryall | Advanced Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:808` | `Name` | Advanced ixian_autonomouscarryall | Advanced Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:833` | `Name` | Advanced ixian_autonomouscarryall | Advanced Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml:848` | `Name` | Advanced ixian_autonomouscarryall | Advanced Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml:22` | `Name` | Ordos td_gdi_apc | Ordos APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml:7` | `Name` | Autonomous ixian_autonomouscarryall | Autonomous Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml:155` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml:170` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/D2k/Shared/yaml/buildings.yaml:245` | `Name` | Concrete ixian_concretewall | Concrete Wall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/naval.yaml:149` | `Name` | Asian td_nod_gunturret Boat | Asian Gun Boat | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/promotions.yaml:72` | `Name` | Unlock td_gdi_mlrs | Unlock MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/vehicles.yaml:557` | `Name` | Type 89 td_gdi_mlrs | Type 89 MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/vehicles.yaml:39` | `Name` | td_nod_gunturret Strider | Gun Strider | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/translations/en.ftl:45` | `FluentValue` | Machine td_nod_gunturret crew. | Machine gun crew. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/translations/en.ftl:56` | `FluentValue` | Commando armed with a td_nod_gunturret that creates black holes. | Commando armed with a gun that creates black holes. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/translations/en.ftl:60` | `FluentValue` | ra1_allies_alliedsniper Infantry with long range. | Sniper Infantry with long range. | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/infantry.yaml:230` | `Name` | Naxi Mercenary ra1_allies_alliedsniper | Naxi Mercenary Sniper | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/infantry.yaml:1036` | `Name` | BMW td_nod_reconbike | BMW Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/promotions.yaml:47` | `Description` | Enables construction of the ra1_soviet_ironcurtain Nokana. | Enables construction of the Iron Nokana. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/translations/en.ftl:66` | `FluentValue` | ra1_soviet_hindattackhelicopter Transport | Hind Transport | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/translations/en.ftl:67` | `FluentValue` | ixian_autonomouscarryall helicopter armed with a machine gun. | Carryall helicopter armed with a machine gun. | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml:12` | `Name` | ra1_soviet_hindattackhelicopter Transport | Hind Transport | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml:76` | `Name` | ra1_soviet_hindattackhelicopter Transport | Hind Transport | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml:204` | `Name` | ra1_soviet_migattackbomber-21 | MiG-21 | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml:285` | `Name` | ra1_soviet_migattackbomber-21 | MiG-21 | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml:561` | `Name` | Latin Sentry td_nod_gunturret | Latin Sentry Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml:18` | `Name` | Mortar td_nod_reconbike | Mortar Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml:649` | `Name` | Latin td_gdi_apc | Latin APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:9` | `FluentValue` | GDI td_gdi_apc | GDI APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:10` | `FluentValue` | Allied td_gdi_apc | Allied APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:44` | `FluentValue` | td_gdi_orca | Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:70` | `FluentValue` | GDI ra1_allies_alliedsniper | GDI Sniper | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:71` | `FluentValue` | ra1_allies_alliedsniper armed with an anti-materiel rifle. | Sniper armed with an anti-materiel rifle. | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:131` | `FluentContinuation` | Increases GDI ra1_allies_alliedsniper and A10 damage by 10%. | Increases GDI Sniper and A10 damage by 10%. | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl:132` | `FluentContinuation` | Also adds a machine td_nod_gunturret to the Battle and Predator Tank and increases damage by 5%. | Also adds a machine gun to the Battle and Predator Tank and increases damage by 5%. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml:46` | `Name` | td_gdi_orca | Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml:122` | `Name` | td_nod_gunturret | gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml:147` | `Name` | td_gdi_orca | Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/infantry.yaml:277` | `Name` | GDI Heavy ra1_allies_alliedsniper | GDI Heavy Sniper | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/promotions.yaml:36` | `Name` | Unlock ra1_allies_alliedsniper | Unlock Sniper | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/promotions.yaml:50` | `Name` | Unlock Assault td_gdi_apc | Unlock Assault APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml:45` | `Name` | GDI td_gdi_apc | GDI APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml:415` | `Name` | GDI td_gdi_mlrs | GDI MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml:549` | `Name` | Assault td_gdi_apc | Assault APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:35` | `FluentValue` | Recon td_nod_reconbike | Recon Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:85` | `FluentValue` | Nod td_nod_gunturret Turret | Nod Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:86` | `FluentValue` | Allied td_nod_gunturret Turret | Allied Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:97` | `FluentValue` | Nod td_nod_samsite Site | Nod SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:98` | `FluentValue` | Soviet td_nod_samsite Site | Soviet SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:136` | `FluentValue` | Black td_nod_handofnod Flamer | Black Hand Flamer | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:195` | `FluentContinuation` | Increases Range of td_nod_gunturret Turrets and the SSM by 10%. | Increases Range of Gun Turrets and the SSM by 10%. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:215` | `FluentContinuation` | Recon td_nod_reconbike: Adds a Point Defense Laser. | Recon Bike: Adds a Point Defense Laser. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl:219` | `FluentContinuation` | td_nod_gunturret Turret and Attack Submarine: Increases damage and spread of the warhead. | Gun Turret and Attack Submarine: Increases damage and spread of the warhead. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml:46` | `Name` | td_nod_handofnod of Nod | Hand of Nod | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml:395` | `Name` | Nod td_nod_gunturret Turret | Nod Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml:497` | `Name` | Nod td_nod_samsite Site | Nod SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/infantry.yaml:321` | `Name` | Black td_nod_handofnod Flamer | Black Hand Flamer | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/promotions.yaml:22` | `Name` | Unlock Chemical Attack td_nod_reconbike | Unlock Chemical Attack Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/promotions.yaml:120` | `Name` | Unlock Black td_nod_handofnod Flamer | Unlock Black Hand Flamer | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/promotions.yaml:124` | `Description` | Allows training of Black td_nod_handofnod Flamers. | Allows training of Black Hand Flamers. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml:274` | `Name` | Recon td_nod_reconbike | Recon Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml:555` | `Name` | Chemical Attack td_nod_reconbike | Chemical Attack Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/CABAL/translations/en.ftl:66` | `FluentValue` | Heavy cybernetic infantry armed with a gatling td_nod_gunturret and anti-air missiles. | Heavy cybernetic infantry armed with a gatling gun and anti-air missiles. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/CABAL/translations/en.ftl:134` | `FluentValue` | Scarab td_gdi_apc | Scarab APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/CABAL/translations/en.ftl:250` | `FluentValue` | td_nod_handofnod of CABAL | Hand of CABAL | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/upgrades.yaml:95` | `Name` | td_nod_handofnod of CABAL | Hand of CABAL | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml:544` | `Name` | Scarab td_gdi_apc | Scarab APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml:13` | `Name` | td_gdi_orca Fighter | Orca Fighter | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml:87` | `Name` | Zone td_gdi_orca Fighter | Zone Orca Fighter | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml:259` | `Name` | td_gdi_orca Bomber | Orca Bomber | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml:332` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/defenses.yaml:222` | `Name` | td_nod_samsite Tower | SAM Tower | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/husks.yaml:5` | `Name` | td_gdi_orca Fighter | Orca Fighter | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/husks.yaml:21` | `Name` | td_gdi_orca Bomber | Orca Bomber | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/husks.yaml:41` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/promotions.yaml:60` | `Name` | Unlock Zone td_gdi_orca | Unlock Zone Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/upgrades.yaml:64` | `Name` | ra1_allies_mechanic Engineering | Mech Engineering | `5d4341a51b` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml:122` | `Name` | Amphibious td_gdi_apc | Amphibious APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml:564` | `Name` | Hover td_gdi_mlrs | Hover MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/Nod/yaml/buildings.yaml:244` | `Name` | td_nod_handofnod of Nod | Hand of Nod | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml:219` | `Name` | td_nod_samsite Site | SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/Nod/yaml/upgrades.yaml:85` | `Description` | Procure tiberium core missile technology to Rocket Soldier, td_nod_samsite Site, Attack Cycle and Stealth Tank, increasing their firepower. | Procure tiberium core missile technology to Rocket Soldier, SAM Site, Attack Cycle and Stealth Tank, increasing their firepower. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/ContentPacks/TiberianSun/Nod/yaml/vehicles.yaml:74` | `Name` | Subterranean td_gdi_apc | Subterranean APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:29` | `FluentValue` | Attack ra1_soviet_attackdog | Attack Dog | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:34` | `FluentValue` | Allied ra1_allies_alliedsniper | Allied Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:129` | `FluentValue` | Mobile ra1_allies_gapgenerator Generator | Mobile Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:158` | `FluentValue` | ra1_allies_sheridanassaulttank | Sheridan | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:166` | `FluentValue` | Allows construction of the ra1_allies_gapgenerator Generator | Allows construction of the Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:167` | `FluentContinuation` | and the Mobile ra1_allies_gapgenerator Generator and the Phase Transport. | and the Mobile Gap Generator and the Phase Transport. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:168` | `FluentValue` | Unlock ra1_allies_gapgenerator Generator Technology | Unlock Gap Generator Technology | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:187` | `FluentValue` | ra1_soviet_volkov | Volkov | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:218` | `FluentValue` | ra1_soviet_kotinnucleartank Nuclear Tank | Kotin Nuclear Tank | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:229` | `FluentValue` | ra1_soviet_migattackbomber | MiG | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:236` | `FluentValue` | ra1_soviet_yakscoutplane | Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:255` | `FluentValue` | ra1_soviet_hindattackhelicopter | Hind | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:306` | `FluentValue` | ra1_soviet_ironcurtain Curtain | Iron Curtain | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:335` | `FluentValue` | AA td_nod_gunturret | AA Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:338` | `FluentValue` | ra1_allies_gapgenerator Generator | Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:542` | `FluentValue` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:698` | `FluentValue` | ra1_soviet_migattackbomber Bomber | MiG Bomber | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:980` | `FluentValue` | Mutant ra1_allies_alliedsniper | Mutant Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1002` | `FluentValue` | Elite mutant officer whose td_nod_gunturret also reaches aircraft. | Elite mutant officer whose gun also reaches aircraft. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1056` | `FluentValue` | Fast scout car whose machine td_nod_gunturret can also strafe aircraft. | Fast scout car whose machine gun can also strafe aircraft. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1109` | `FluentValue` | td_gdi_apc Truck | APC Truck | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1119` | `FluentContinuation` | Replaced by the td_gdi_mlrs after that promotion. | Replaced by the MLRS after that promotion. | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1148` | `FluentValue` | Forgotten td_gdi_mlrs | Forgotten MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1151` | `FluentContinuation` | Requires the td_gdi_mlrs promotion and replaces the Missile Van. | Requires the MLRS promotion and replaces the Missile Van. | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1182` | `FluentContinuation` | Nine garrisoned infantry fire from inside; its own td_nod_gunturret covers the approaches. | Nine garrisoned infantry fire from inside; its own gun covers the approaches. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1191` | `FluentValue` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1300` | `FluentValue` | Scrap-built machine td_nod_gunturret tower. | Scrap-built machine gun tower. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1315` | `FluentValue` | Juggerflak ixian_concretewall | Juggerflak Wall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1316` | `FluentValue` | ixian_concretewall-mounted Juggernaut flak battery. | Wall-mounted Juggernaut flak battery. | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1437` | `FluentValue` | Unlock td_gdi_mlrs | Unlock MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1439` | `FluentContinuation` | Allows construction of the Forgotten td_gdi_mlrs rocket artillery, replacing the Missile Van. | Allows construction of the Forgotten MLRS rocket artillery, replacing the Missile Van. | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1446` | `FluentContinuation` | Follows the td_gdi_mlrs promotion. | Follows the MLRS promotion. | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1463` | `FluentValue` | td_nod_samsite Site | SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1634` | `FluentContinuation` | Nuclear V2 Launcher, ra1_soviet_migattackbomber and Su-57: 15% | Nuclear V2 Launcher, Mig and Su-57: 15% | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1635` | `FluentContinuation` | Missile Submarine, td_nod_samsite Site and ra1_soviet_hindattackhelicopter: 10% | Missile Submarine, SAM Site and Hind: 10% | `c9b73aeb4c`, `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1636` | `FluentContinuation` | Mammoth Tank, Monster Tank and ra1_soviet_volkov: 5% | Mammoth Tank, Monster Tank and Volkov: 5% | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1640` | `FluentContinuation` | Adds Napalm Warheads to the V1 Truck, ra1_soviet_migattackbomber, Su-57 and all tanks. | Adds Napalm Warheads to the V1 Truck, Mig, Su-57 and all tanks. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1642` | `FluentContinuation` | Adds Incendiary Bullets to the Rifle Infantry, ra1_soviet_yakscoutplane, ra1_soviet_hindattackhelicopter and Gatling Tank. | Adds Incendiary Bullets to the Rifle Infantry, Yak, Hind and Gatling Tank. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1651` | `FluentValue` | Reduces the Reload Delay of Tanks, Hinds and ra1_soviet_volkov by 40%. | Reduces the Reload Delay of Tanks, Hinds and Volkov by 40%. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1742` | `FluentValue` | All Tanks, td_nod_gunturret Turrets and Artillery gain increased range and damage. | All Tanks, Gun Turrets and Artillery gain increased range and damage. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1743` | `FluentContinuation` | td_nod_gunturret Turret, Ix Combat Tanks and Duelist Tanks: 10% higher range and 25% more damage. | Gun Turret, Ix Combat Tanks and Duelist Tanks: 10% higher range and 25% more damage. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1845` | `FluentContinuation` | Replaces ra1_soviet_hindattackhelicopter with Kamov | Replaces Hind with Kamov | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1864` | `FluentContinuation` | Unlocks ra1_soviet_kotinnucleartank Nuclear Tank | Unlocks Kotin Nuclear Tank | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1918` | `FluentContinuation` | Equips ra1_soviet_volkov with arcing Tesla Bombs. | Equips Volkov with arcing Tesla Bombs. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1922` | `FluentContinuation` | Heavy Rockets such as of the Mammoth Tank, Kamov, ra1_soviet_migattackbomber and V2 Launcher | Heavy Rockets such as of the Mammoth Tank, Kamov, Mig and V2 Launcher | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1936` | `FluentContinuation` | Heavy Rockets such as of the Siege Mammoth Tank, ra1_soviet_hindattackhelicopter, Su-57, Grad and V2 Launcher | Heavy Rockets such as of the Siege Mammoth Tank, Hind, Su-57, Grad and V2 Launcher | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1946` | `FluentContinuation` | Increases Speed of ra1_soviet_kotinnucleartank Nuclear Tanks by 40%. | Increases Speed of Kotin Nuclear Tanks by 40%. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1950` | `FluentContinuation` | Heavy Rockets such as of the Mammoth Tank, ra1_soviet_hindattackhelicopter, ra1_soviet_migattackbomber and Nuclear V2 Launcher | Heavy Rockets such as of the Mammoth Tank, Hind, Mig and Nuclear V2 Launcher | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1958` | `FluentContinuation` | Equips ra1_soviet_volkov with a Nuclear Cannon. | Equips Volkov with a Nuclear Cannon. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1959` | `FluentContinuation` | Increases Spread and Radiation Damage of the ra1_soviet_kotinnucleartank Nuclear Tank. | Increases Spread and Radiation Damage of the Kotin Nuclear Tank. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:1972` | `FluentContinuation` | Doubles the amount of Missiles that ra1_soviet_hindattackhelicopter and Kamov can fire. | Doubles the amount of Missiles that Hind and Kamov can fire. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:2004` | `FluentContinuation` | Increases Damage and Range of Enforcers, Pitbulls, Hover td_gdi_mlrs and td_nod_samsite Towers by 20% | Increases Damage and Range of Enforcers, Pitbulls, Hover MLRS and SAM Towers by 20% | `90158ee2e8`, `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:2007` | `FluentValue` | ra1_allies_mechanic Engineering | Mech Engineering | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:2057` | `FluentValue` | td_nod_handofnod of Nod | Hand of Nod | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:2201` | `FluentContinuation` | Support powers: Parabombs, ra1_soviet_ironcurtain Curtain, Atomic Bomb | Support powers: Parabombs, Iron Curtain, Atomic Bomb | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/en.ftl:2246` | `FluentContinuation` | Support powers: ra1_soviet_ironcurtain Curtain, Nuclear Missile | Support powers: Iron Curtain, Nuclear Missile | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/ftech_en.ftl:45` | `FluentValue` | Large walking ra1_allies_mechanic armed with autoguns. | Large walking mech armed with autoguns. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/ftech_en.ftl:51` | `FluentValue` | Large walking ra1_allies_mechanic armed with twin plasma cannons. | Large walking mech armed with twin plasma cannons. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/outpost2_en.ftl:231` | `FluentValue` | Fast scout armed with a machine td_nod_gunturret | Fast scout armed with a machine gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/fluent/rules/outpost2_en.ftl:280` | `FluentValue` | Fast scout armed with a machine td_nod_gunturret | Fast scout armed with a machine gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/music.yaml:115` | `MusicTitle` | TD CO ra1_soviet_ironcurtain Fist | TD CO Iron Fist | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/music.yaml:203` | `MusicTitle` | RA Counterstrike -  The Second td_nod_handofnod | RA Counterstrike -  The Second Hand | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/music.yaml:405` | `MusicTitle` | Renegade - ra1_allies_alliedsniper | Renegade - Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/music.yaml:419` | `MusicTitle` | Renegade - Packing ra1_soviet_ironcurtain | Renegade - Packing Iron | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/defaults.yaml:1253` | `Description` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:22` | `Name` | td_gdi_apc (Destroyed) | APC (Destroyed) | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:58` | `Name` | Recon td_nod_reconbike (Destroyed) | Recon Bike (Destroyed) | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:276` | `Name` | ra1_soviet_migattackbomber Attack Plane | MiG Attack Plane | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:322` | `Name` | ra1_soviet_yakscoutplane Attack Plane | Yak Attack Plane | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:419` | `Name` | ra1_soviet_hindattackhelicopter | Hind | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/husks.yaml:440` | `Name` | ra1_soviet_hindattackhelicopter | Hind | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:1324` | `Name` | Dragunov Anti Material ra1_allies_alliedsniper | Dragunov Anti Material Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:1855` | `Name` | Allied ra1_allies_alliedsniper | Allied Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:2946` | `Name` | ra1_soviet_kotinnucleartank Nuclear Tank | Kotin Nuclear Tank | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:3701` | `Name` | Allied td_gdi_apc | Allied APC | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:4523` | `Name` | ra1_soviet_yakscoutplane Scout Plane | Yak Scout Plane | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:4622` | `Name` | Tesla ra1_soviet_yakscoutplane | Tesla Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:4749` | `Name` | Armored ra1_soviet_yakscoutplane | Armored Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:4840` | `Name` | Nuclear ra1_soviet_yakscoutplane | Nuclear Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:5163` | `Name` | ra1_soviet_migattackbomber Attack Bomber | Mig Attack Bomber | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:5403` | `Name` | ra1_soviet_hindattackhelicopter Attack Helicopter | Hind Attack Helicopter | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8460` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Tesla Tech) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Tesla Tech) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8461` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Heavy Armor) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Heavy Armor) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8462` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Nuclear War) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Nuclear War) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8463` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Tesla Tech) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Tesla Tech) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8464` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Heavy Armor) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Heavy Armor) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8465` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Nuclear War) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Nuclear War) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8466` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Tesla Tech) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Tesla Tech) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8467` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Heavy Armor) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Heavy Armor) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:8468` | `Names[]` | Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Nuclear War) | Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Nuclear War) | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:9156` | `Name` | ra1_soviet_ironcurtain Curtain | Iron Curtain | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:9459` | `Name` | Allied td_nod_gunturret Turret | Allied Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:9507` | `Name` | Allied AA td_nod_gunturret | Allied AA Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:9688` | `Name` | Soviet td_nod_samsite Site | Soviet SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:10090` | `Name` | Unlock ra1_allies_sheridanassaulttank | Unlock Sheridan | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:10094` | `Description` | Allows construction of the ra1_allies_sheridanassaulttank Light Tank. | Allows construction of the Sheridan Light Tank. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:10230` | `Name` | Unlock ra1_allies_gapgenerator Generator and Radar Jammer | Unlock Gap Generator and Radar Jammer | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:10234` | `Description` | Allows construction of the ra1_allies_gapgenerator Generator and Mobile Radar Jammer. | Allows construction of the Gap Generator and Mobile Radar Jammer. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:10317` | `Name` | ra1_allies_sheridanassaulttank Assault Tank | Sheridan Assault Tank | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:11247` | `Name` | ra1_allies_gapgenerator Generator | Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:11324` | `Name` | Mobile ra1_allies_gapgenerator Generator | Mobile Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12085` | `Name` | ra1_soviet_kotinnucleartank Nuclear Tank Upgrade | Kotin Nuclear Tank Upgrade | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12087` | `Description` | Upgrades the Hammer Tank to the ra1_soviet_kotinnucleartank Nuclear Tank | Upgrades the Hammer Tank to the Kotin Nuclear Tank | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12115` | `Name` | Unlock Tesla ra1_soviet_yakscoutplane | Unlock Tesla Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12117` | `Description` | Upgrades the ra1_soviet_yakscoutplane into the Tesla Yak. | Upgrades the Yak into the Tesla Yak. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12125` | `Name` | Unlock Armored ra1_soviet_yakscoutplane | Unlock Armored Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12127` | `Description` | Upgrades the ra1_soviet_yakscoutplane into the Armored Yak. | Upgrades the Yak into the Armored Yak. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12135` | `Name` | Unlock Nuclear ra1_soviet_yakscoutplane | Unlock Nuclear Yak | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12137` | `Description` | Upgrades the ra1_soviet_yakscoutplane into the Nuclear Yak. | Upgrades the Yak into the Nuclear Yak. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12314` | `Name` | Unlock ra1_soviet_cyberdog | Unlock Cyberdog | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12328` | `Name` | Unlock ra1_soviet_volkov | Unlock Volkov | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12471` | `Description` | Cybernetically modified ra1_soviet_attackdog that is far more durable and can attack vehicles. | Cybernetically modified dog that is far more durable and can attack vehicles. | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12475` | `Name` | ra1_soviet_cyberdog | Cyberdog | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert.yaml:12589` | `Name` | ra1_soviet_volkov | Volkov | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:990` | `Name` | ra1_allies_gapgenerator Generator | Gap Generator | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:2003` | `Name` | ra1_soviet_ironcurtain Curtain | Iron Curtain | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:2121` | `Name` | Sentry td_nod_gunturret | Sentry Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:3265` | `Name` | Attack ra1_soviet_attackdog | Attack Dog | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:3723` | `Name` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:4028` | `Name` | Attack ra1_soviet_attackdog | Attack Dog | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:5879` | `Name` | Machine td_nod_gunturret IFV | Machine Gun IFV | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:5882` | `Name` | Heavy Machine td_nod_gunturret IFV | Heavy Machine Gun IFV | `c9b73aeb4c` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:5891` | `Name` | ra1_allies_alliedsniper IFV | Sniper IFV | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:8824` | `Name` | ra1_soviet_migattackbomber Bomber | MiG Bomber | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:8928` | `Name` | ra1_soviet_migattackbomber Bomber | MiG Bomber | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:11842` | `Name` | Hot ra1_soviet_attackdog Cart | Hot Dog Cart | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:12399` | `Name` | ra1_soviet_migattackbomber Bomber | MiG Bomber | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/redalert2.yaml:14461` | `Description` | Adds a powerful corrosive effect to the Virus ra1_allies_alliedsniper that slows down enemy vehicles and deals damage over time. Increases Firepower by 33%. | Adds a powerful corrosive effect to the Virus Sniper that slows down enemy vehicles and deals damage over time. Increases Firepower by 33%. | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/tkm.yaml:1340` | `Name` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/tkm.yaml:2517` | `Name` | ra1_soviet_hindattackhelicopter | Hind | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/tkm.yaml:2652` | `Name` | TKM ra1_soviet_migattackbomber | TKM Mig | `53fb107252` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/tkm.yaml:3897` | `Name` | Unlock tkm_t30 | Unlock T30 | `bbb9bd132a` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/warcraft2.yaml:38` | `Description` | Orc\nLeaders of the Horde\nBrutish and crafty.\nSupport Powers: td_gdi_advancedcommunicationscenter of Kilrogg, Death and Decay | Orc\nLeaders of the Horde\nBrutish and crafty.\nSupport Powers: Eye of Kilrogg, Death and Decay | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/warcraft2.yaml:2903` | `Name` | ixian_concretewall | Wall | `d763966177` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/warcraft2.yaml:6577` | `Name` | td_gdi_advancedcommunicationscenter of Kilrogg | Eye of Kilrogg | `90158ee2e8` | exact pre-migration display value recovered |
+| yes | `mods/cameo/rules/warcraft2.yaml:6618` | `Name` | td_gdi_advancedcommunicationscenter of Kilrogg | Eye of Kilrogg | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:4866` | `Name` | ixian_concretewall Pipe | Wall Pipe | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:4994` | `Name` | Talon td_nod_gunturret | Talon Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:7743` | `Name` | td_nod_reconbike | Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:7880` | `Name` | Attack td_gdi_apc | Attack APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:9959` | `Name` | ra1_allies_mechanic Infantry | Mech Infantry | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/advancewars.yaml:12071` | `Name` | Durable ixian_concretewall Research | Durable Wall Research | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/classicdoom.yaml:1045` | `Name` | Attack ra1_soviet_attackdog | Attack Dog | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/classicdoom.yaml:1883` | `Name` | ra1_soviet_attackdog Food | Dog Food | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:860` | `Name` | Concrete ixian_concretewall | Concrete Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:885` | `Name` | Concrete ixian_concretewall | Concrete Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:3705` | `Description` | Recruited from outside the Freedom Guard ranks, these paid guns carry a massive shoulder mounted rail gun.\nHighly trained and ruthless, the Mercenary is tougher and deadlier than the Raider. The Mercenary can phase\nonce the Phasing Facility has been built\n\nType: Walker\nSpeed: SLow\nWeapon: Rail td_nod_gunturret\nRange: Short\nArmor: Medium | Recruited from outside the Freedom Guard ranks, these paid guns carry a massive shoulder mounted rail gun.\nHighly trained and ruthless, the Mercenary is tougher and deadlier than the Raider. The Mercenary can phase\nonce the Phasing Facility has been built\n\nType: Walker\nSpeed: SLow\nWeapon: Rail Gun\nRange: Short\nArmor: Medium | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:3754` | `Name` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:3761` | `Description` | With a long range electro-magnetic needle td_nod_gunturret, the ra1_allies_alliedsniper is lethal against\ninfantry targets. Like the Scout, the ra1_allies_alliedsniper can morph into objects for camouflage.\n\nType: Walker\nSpeed: Medium\nWeapon: ra1_allies_alliedsniper Rail\nRange: Long\nArmor: Light | With a long range electro-magnetic needle gun, the Sniper is lethal against\ninfantry targets. Like the Scout, the Sniper can morph into objects for camouflage.\n\nType: Walker\nSpeed: Medium\nWeapon: Sniper Rail\nRange: Long\nArmor: Light | `c9b73aeb4c`, `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4024` | `Name` | Spider td_nod_reconbike | Spider Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4031` | `Description` | This all terrain vehicle is the cornerstone of\nthe Freedom Guard ground force. Fast and inexpensive, it\nis able to tackle all types of terrain. Armed with a double\nrail td_nod_gunturret, it is fairly effective against armour but somewhat\nvulnerable to infantry\n\nType: Special Wheeled\nSpeed: Fast\nWeapon: Rail td_nod_gunturret\nRange: Medium\nArmor: Medium | This all terrain vehicle is the cornerstone of\nthe Freedom Guard ground force. Fast and inexpensive, it\nis able to tackle all types of terrain. Armed with a double\nrail gun, it is fairly effective against armour but somewhat\nvulnerable to infantry\n\nType: Special Wheeled\nSpeed: Fast\nWeapon: Rail Gun\nRange: Medium\nArmor: Medium | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4171` | `Description` | The pinnacle of Freedom Guard\narmour, the Triple Rail uses hover technology stolen from\nthe Imperium to allow movement over a broader range\nof terrain types. Hauling three electro-magnetic projectile\naccelerator cannons, or rail guns, this tank is a savage\nconsumer of Imperium armour.\n\nType: Hover\nSpeed: Medium\nWeapon: Triple Rail td_nod_gunturret\nRange: Long\nArmor: Heavy | The pinnacle of Freedom Guard\narmour, the Triple Rail uses hover technology stolen from\nthe Imperium to allow movement over a broader range\nof terrain types. Hauling three electro-magnetic projectile\naccelerator cannons, or rail guns, this tank is a savage\nconsumer of Imperium armour.\n\nType: Hover\nSpeed: Medium\nWeapon: Triple Rail Gun\nRange: Long\nArmor: Heavy | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4588` | `Name` | Sky td_nod_reconbike | Sky Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4595` | `Description` | Using a modified Spider td_nod_reconbike chassis, the\nFreedom Guard were able to produce cheap, fast aerial\nunits which could attack enemy ground troops and other\nflyers. Although quicker than the Imperium Cyclone, the\nSky td_nod_reconbike is not as heavily armoured and is outgunned in\neven combat. The speed of the Sky td_nod_reconbike, however, allows\nit to dictate the circumstance of conflict. This unit fires\nhigh-velocity mini-missiles and, like the Outrider, must rearm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Mini Missiles\nRange: Short\nArmor: Light | Using a modified Spider Bike chassis, the\nFreedom Guard were able to produce cheap, fast aerial\nunits which could attack enemy ground troops and other\nflyers. Although quicker than the Imperium Cyclone, the\nSky Bike is not as heavily armoured and is outgunned in\neven combat. The speed of the Sky Bike, however, allows\nit to dictate the circumstance of conflict. This unit fires\nhigh-velocity mini-missiles and, like the Outrider, must rearm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Mini Missiles\nRange: Short\nArmor: Light | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:4648` | `Description` | This ground attack aerial unit is slower and less\nmanoeuvrable than the Sky td_nod_reconbike, but considerably tougher\nand fires air to ground missiles. Deadly effective against\nImperium armour, it cannot engage other air units and\nshould be escorted by air defence units. The Outrider has\nlimited ammunition and must re-arm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Guided Missile\nRange: Long\nArmor: Heavy | This ground attack aerial unit is slower and less\nmanoeuvrable than the Sky Bike, but considerably tougher\nand fires air to ground missiles. Deadly effective against\nImperium armour, it cannot engage other air units and\nshould be escorted by air defence units. The Outrider has\nlimited ammunition and must re-arm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Guided Missile\nRange: Long\nArmor: Heavy | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:5189` | `Description` | Shock ra1_allies_alliedsniper Infantry.\n  Strong vs Light Vehicles and Creatures \n  Weak vs Infantry | Shock Sniper Infantry.\n  Strong vs Light Vehicles and Creatures \n  Weak vs Infantry | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:6763` | `Name` | ra1_soviet_shocktrooper Trooper | Shok Trooper | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:7872` | `Description` | The Low Rank Infantry\nThe Second Veterancy adquire Grenade Launcher\nThe Next Veterancy adquire Better Laser td_nod_gunturret\nThe Ultimate Veterancy transform into Jail Breaker\nThe Jail Breaker with veterancy can sabotage and attach C4 in vehicles.\n\nType: Infantry\nSpeed: Slow\nWeapon: Small Laser, Gremades, C4s\nRange: Medium\nArmor: None | The Low Rank Infantry\nThe Second Veterancy adquire Grenade Launcher\nThe Next Veterancy adquire Better Laser Gun\nThe Ultimate Veterancy transform into Jail Breaker\nThe Jail Breaker with veterancy can sabotage and attach C4 in vehicles.\n\nType: Infantry\nSpeed: Slow\nWeapon: Small Laser, Gremades, C4s\nRange: Medium\nArmor: None | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/darkreign.yaml:10572` | `Name` | Support ra1_allies_alliedbarracks | Support Tent | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2008` | `Description` | Spawns a ixian_autonomouscarryall with Vehicles. | Spawns a Carryall with Vehicles. | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2063` | `Name` | Death td_nod_handofnod | Death Hand | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2152` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2184` | `Name` | Autonomous ixian_autonomouscarryall | Autonomous Carryall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2274` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/dune2.yaml:2291` | `Name` | ixian_autonomouscarryall | Carryall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:8695` | `Name` | ra1_soviet_migattackbomber Armor | MiG Armor | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:8747` | `Name` | Tactical Nuke ra1_soviet_migattackbomber | Tactical Nuke MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:8807` | `Name` | ra1_soviet_migattackbomber | MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:8916` | `Name` | Tactical Nuke ra1_soviet_migattackbomber | Tactical Nuke MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:8998` | `Name` | ra1_soviet_migattackbomber | MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:9827` | `Description` | Stealthed ra1_allies_alliedsniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles | Stealthed sniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:12984` | `Name` | Sentry Drone td_nod_gunturret | Sentry Drone Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/generals.yaml:13496` | `Description` | Transports cash other players.\n Armed with self-defense machine td_nod_gunturret | Transports cash other players.\n Armed with self-defense machine gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/halloween.yaml:267` | `Name` | Clown ra1_allies_alliedbarracks | Clown Tent | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:640` | `Description` | Controls and provides ra1_soviet_volkov\nBuilding must be sold and rebuilt for another ra1_soviet_volkov to appear | Controls and provides Volkov\nBuilding must be sold and rebuilt for another Volkov to appear | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:646` | `Name` | ra1_soviet_volkov Control Center | Volkov Control Center | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:682` | `Name` | ra1_soviet_volkov | Volkov | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:977` | `Description` | Permanently Stealthed until her weapon is fully charged up\nCan call Nod td_nod_reconbike | Permanently Stealthed until her weapon is fully charged up\nCan call Nod Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:1078` | `Description` | Autonomous td_nod_reconbike that helps Nashwa get over long distances\nShoots flame rockets | Autonomous Bike that helps Nashwa get over long distances\nShoots flame rockets | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:1094` | `Name` | Nod td_nod_reconbike | Nod Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:1141` | `Name` | Nod td_nod_reconbike (Destroyed) | Nod Bike (Destroyed) | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:1332` | `Description` | Unable to use his left td_nod_handofnod and full of hatred - he is equipped with Tiberium Flachette SMG and\npowerful aura that spreads radiation which hurts enemies but heals allies | Unable to use his left hand and full of hatred - he is equipped with Tiberium Flachette SMG and\npowerful aura that spreads radiation which hurts enemies but heals allies | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:1419` | `Description` | Unable to use his left td_nod_handofnod and full of hatred - he is equipped with Super Shotgun and\npowerful aura that spreads radiation which hurts enemies but heals allies | Unable to use his left hand and full of hatred - he is equipped with Super Shotgun and\npowerful aura that spreads radiation which hurts enemies but heals allies | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:2857` | `Name` | Multi-direction photon td_nod_gunturret | Multi-direction photon gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:2921` | `Name` | Machine td_nod_gunturret firing remote | Machine gun firing remote | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:2925` | `Description` | Machine td_nod_gunturret firing remote.\n Increases attack range by 1 tile. | Machine gun firing remote.\n Increases attack range by 1 tile. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:3120` | `Name` | Mortar ra1_allies_alliedsniper | Mortar Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:3124` | `Description` | Kurt uses Mortar aganist buildings in ra1_allies_alliedsniper Mode | Kurt uses Mortar aganist buildings in Sniper Mode | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:3135` | `Name` | Mortar ra1_allies_alliedsniper | Mortar Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/heroes.yaml:3139` | `Description` | Kurt uses Missiles aganist vehicles in ra1_allies_alliedsniper Mode | Kurt uses Missiles aganist vehicles in Sniper Mode | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/keeper.yaml:8` | `Name` | Carvable Dirt ixian_concretewall | Carvable Dirt Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/keeper.yaml:33` | `Name` | Dungeon ixian_concretewall | Dungeon Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/keeper.yaml:58` | `Name` | Rock ixian_concretewall | Rock Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:4` | `Name` | Black td_nod_handofnod Factory | Black Hand Factory | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:75` | `Name` | Nod td_gdi_apc (Destroyed) | Nod APC (Destroyed) | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:143` | `Name` | Black td_nod_handofnod Biological Lab | Black Hand Biological Lab | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:163` | `Name` | Black td_nod_handofnod Biological Lab (Destroyed) | Black Hand Biological Lab (Destroyed) | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:347` | `Name` | GDI Pistol td_gdi_orca | GDI Pistol Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:858` | `Name` | td_nod_gunturret | gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:989` | `Name` | Black td_nod_reconbike | Black Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/lostunits.yaml:1007` | `Name` | Nod td_gdi_apc | Nod APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mcvmarket.yaml:507` | `Name` | Construction Rig (Shadow td_nod_handofnod) | Construction Rig (Shadow Hand) | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mcvmarket.yaml:552` | `Name` | Construction Rig (Shadow td_nod_handofnod) | Construction Rig (Shadow Hand) | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:197` | `Description` | Twin td_nod_gunturret defense.\n  Uses stone munition | Twin gun defense.\n  Uses stone munition | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:264` | `Description` | Basic cheap defense.\n  Uses ra1_soviet_ironcurtain munition | Basic cheap defense.\n  Uses iron munition | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:331` | `Description` | Twin td_nod_gunturret defense.\n  Uses ra1_soviet_ironcurtain munition | Twin gun defense.\n  Uses iron munition | `c9b73aeb4c`, `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:398` | `Description` | Twin td_nod_gunturret defense.\n  Uses coal munition | Twin gun defense.\n  Uses coal munition | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:462` | `Description` | Twin td_nod_gunturret defense.\n  Uses steel munition | Twin gun defense.\n  Uses steel munition | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:708` | `Name` | ra1_soviet_ironcurtain Drill | Iron Drill | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:713` | `Description` | Produces Resources and ra1_soviet_ironcurtain | Produces Resources and Iron | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/mindustry.yaml:882` | `Description` | Produces Resources and Steel .\n Requires Coal and ra1_soviet_ironcurtain connection to work | Produces Resources and Steel .\n Requires Coal and Iron connection to work | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/n64.yaml:542` | `Name` | td_nod_handofnod of Nod | Hand of Nod | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/n64.yaml:1408` | `Name` | td_nod_samsite site | SAM site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/n64.yaml:2125` | `Name` | Recon td_nod_reconbike | Recon Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/n64.yaml:2314` | `Name` | td_gdi_apc | APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/n64.yaml:2730` | `Name` | td_gdi_orca | Orca | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:1388` | `Description` | Calls ra1_soviet_ironcurtain Dragon Squadron to bombard an area with Napalm rockets | Calls Iron Dragon Squadron to bombard an area with Napalm rockets | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:2401` | `Description` | Burton gets HE Ammunition for ra1_allies_alliedsniper Rifle\nBurton's rifle will be able to hit multiple targets | Burton gets HE Ammunition for Sniper Rifle\nBurton's rifle will be able to hit multiple targets | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:2665` | `Description` | Stealthed ra1_allies_alliedsniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles | Stealthed sniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:2757` | `Description` | Elite commando equipped with ra1_allies_alliedsniper Rifle.\nCan switch between close and long range modes\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Air | Elite commando equipped with Sniper Rifle.\nCan switch between close and long range modes\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Air | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:3891` | `Name` | Lockdown td_gdi_mlrs | Lockdown MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:4912` | `Name` | ra1_allies_sheridanassaulttank | Sheridan | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:4999` | `Description` | Equips ra1_allies_sheridanassaulttank Tanks with Anti-Tank Rockets | Equips Sheridan Tanks with Anti-Tank Rockets | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:8072` | `Name` | Quad td_nod_reconbike | Quad Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:8524` | `Name` | SA2 td_nod_samsite Site | SA2 SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:8915` | `Description` | td_gdi_apc armed with toxin td_nod_gunturret and phosphorus rockets.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles | APC armed with toxin gun and phosphorus rockets.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles | `90158ee2e8`, `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:10985` | `Name` | Tarantula td_gdi_apc | Tarantula APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:10992` | `Description` | td_gdi_apc armed with toxins.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles | APC armed with toxins.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:11329` | `Description` | ra1_allies_alliedsniper infantry.\nStealthed when not attacking\n  Strong vs Infantry\n  Weak vs Vehicles | Sniper infantry.\nStealthed when not attacking\n  Strong vs Infantry\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:11676` | `Name` | ra1_allies_alliedsniper Quad Cannon | Sniper Quad Cannon | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:12300` | `Description` | td_gdi_humvee GLA Variant.\nDelete carry because has a grenadier in the back.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft | Jeep GLA Variant.\nDelete carry because has a grenadier in the back.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:12750` | `Description` | Calls squadron of ra1_soviet_ironcurtain Dragons to bombard an area with napalm rockets | Calls squadron of Iron Dragons to bombard an area with napalm rockets | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:13215` | `Name` | EMP ra1_soviet_migattackbomber | EMP MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:13291` | `Name` | EMP ra1_soviet_migattackbomber | EMP MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:13418` | `Name` | ra1_soviet_migattackbomber Afterburner | MiG Afterburner | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:13422` | `Description` | ra1_soviet_migattackbomber fighters gain more fuel efficient engines gaining up to 25% movement speed | MiG fighters gain more fuel efficient engines gaining up to 25% movement speed | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:14754` | `Name` | Berzerker td_gdi_mlrs | Berzerker MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:14836` | `Name` | Berzerker td_gdi_mlrs | Berzerker MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:14840` | `Description` | Allows production of the Berzerker td_gdi_mlrs | Allows production of the Berzerker MLRS | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:14860` | `Name` | Gattling td_gdi_apc | Gattling APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:14867` | `Description` | td_gdi_apc armed with Gattling gun.\nCan be mounted with infantry\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks | APC armed with Gattling gun.\nCan be mounted with infantry\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/shockwave.yaml:15917` | `Name` | Nuclear ra1_soviet_migattackbomber | Nuclear MiG | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/simcity.yaml:1402` | `Description` | Provides Railway td_nod_gunturret support power. | Provides Railway Gun support power. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/simcity.yaml:1431` | `Name` | Railway td_nod_gunturret | Railway Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/simcity.yaml:1709` | `Description` | Law enforcement armed with a pistol.\nCan be upgraded to have pistol replaced with Submachine td_nod_gunturret\n Strong vs Infantry\n Weak vs Vehicles, Aircraft | Law enforcement armed with a pistol.\nCan be upgraded to have pistol replaced with Submachine gun\n Strong vs Infantry\n Weak vs Vehicles, Aircraft | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/simcity.yaml:2126` | `Description` | Stealth Elite law enforcement equipped with silenced ra1_allies_alliedsniper Rifle\nCan he upgraded to get Grenade Launcher\nStrong vs Infantry, Air | Stealth Elite law enforcement equipped with silenced Sniper Rifle\nCan he upgraded to get Grenade Launcher\nStrong vs Infantry, Air | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/sow.yaml:1529` | `Name` | td_nod_gunturret Turret | Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:3871` | `Name` | td_nod_samsite Site | SAM Site | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:5201` | `Description` | Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:5224` | `Description` | Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:5256` | `Name` | Speeder td_nod_reconbike | Speeder Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:5728` | `Description` | Aircraft Gunship with AG Laser.\n  Strong vs Tanks, Walker ra1_allies_mechanic\n  Weak vs Infantry | Aircraft Gunship with AG Laser.\n  Strong vs Tanks, Walker Mech\n  Weak vs Infantry | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:8063` | `Name` | Loaded Lambda (td_gdi_grenadier) | Loaded Lambda (E2) | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/starwars.yaml:8441` | `Description` | Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/test.yaml:415` | `Description` | A Bio ra1_allies_mechanic unit that\n electrifies its victims with a Shock Shell\nStrong vs Infantry, Buildings\nWeak vs Vehicles | A Bio Mech unit that\n electrifies its victims with a Shock Shell\nStrong vs Infantry, Buildings\nWeak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/test.yaml:694` | `Name` | Mobile ra1_allies_alliedbarracks | Mobile Tent | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:253` | `Name` | Black td_nod_handofnod | Black Hand | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:258` | `Description` | The Black td_nod_handofnod is a step up from the Rocket Squad, being a better-armoured anti-tank unit. Equipped with flamethrowers, they will cook a tank until it bursts, allowing the rest of your units to pass. | The Black Hand is a step up from the Rocket Squad, being a better-armoured anti-tank unit. Equipped with flamethrowers, they will cook a tank until it bursts, allowing the rest of your units to pass. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:281` | `Description` | Similar to the GDI ra1_allies_alliedsniper Team, the Nod Confessors are a lightly-armoured infantry unit capable of eliminating enemy infantry quickly and efficiently while maintaining a safe distance. Unfortunately, they’re pretty much weak against anything else. | Similar to the GDI Sniper Team, the Nod Confessors are a lightly-armoured infantry unit capable of eliminating enemy infantry quickly and efficiently while maintaining a safe distance. Unfortunately, they’re pretty much weak against anything else. | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:347` | `Name` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:395` | `Name` | Mutant ra1_allies_alliedsniper | Mutant Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:460` | `Name` | Guardian td_gdi_apc | Guardian APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:1665` | `Description` | Increase ra1_allies_alliedsniper Shoot Range | Increase Sniper Shoot Range | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:1824` | `Description` | Upgrade the Armor of Attack td_nod_reconbike | Upgrade the Armor of Attack Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:1966` | `Description` | Adds Chemical Rockets to ra1_soviet_ironcurtain Fist | Adds Chemical Rockets to Iron Fist | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:1985` | `Description` | GDI Flak Bunker, adds a little td_nod_samsite Launcher | GDI Flak Bunker, adds a little SAM Launcher | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:3100` | `Name` | td_nod_samsite lvl 5 | SAM lvl 5 | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:3119` | `Name` | td_nod_samsite lvl 10 | SAM lvl 10 | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:3138` | `Name` | td_nod_samsite lvl 20 | SAM lvl 20 | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:3955` | `Name` | Nod td_nod_handofnod | Nod Hand | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:4966` | `Name` | td_gdi_advancedcommunicationscenter of Kane | Eye of Kane | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:5006` | `Name` | td_gdi_advancedcommunicationscenter of Kane AA Launcher | Eye of Kane AA Launcher | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:5377` | `Name` | Machine td_nod_gunturret Nest | Machine Gun Nest | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:5567` | `Name` | Shredder Machine td_nod_gunturret | Shredder Machine Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tiberiaalliances.yaml:5819` | `Name` | Reaper Machine td_nod_gunturret | Reaper Machine Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:2618` | `Name` | Living ixian_concretewall | Living Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:2818` | `Description` | Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:2869` | `Name` | Rocket td_gdi_apc | Rocket APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:3376` | `Name` | ra1_soviet_hindattackhelicopter | Hind | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:3595` | `Name` | Tear Gas td_gdi_apc | Tear Gas APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/tomorrow.yaml:3738` | `Name` | Flame td_nod_reconbike | Flame Bike | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wh40k.yaml:5800` | `Name` | ra1_allies_alliedsniper Scout | Sniper Scout | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wh40k.yaml:6084` | `Name` | Assault td_nod_gunturret Terminator Marine | Assault Gun Terminator Marine | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wh40k.yaml:6528` | `Name` | Rhino td_gdi_apc | Rhino APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wh40k.yaml:10916` | `Name` | Rhino td_gdi_apc | Rhino APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wh40k.yaml:11439` | `Name` | Plasma td_nod_gunturret Cultist | Plasma Gun Cultist | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/win98.yaml:671` | `Name` | CRT ixian_concretewall | CRT Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/worms.yaml:1299` | `Description` | Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:1105` | `Name` | ixian_concretewall | Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:1198` | `Name` | ixian_concretewall with Machinegun | Wall with Machinegun | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:1219` | `Name` | ixian_concretewall with Light Cannon | Wall with Light Cannon | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:1237` | `Name` | ixian_concretewall with Medium Cannon | Wall with Medium Cannon | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:1257` | `Name` | ixian_concretewall with Heavy Cannon | Wall with Heavy Cannon | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:2092` | `Description` | td_nod_gunturret Choppers attack enemies along a line\nwith chainguns. | Gun Choppers attack enemies along a line\nwith chainguns. | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:2250` | `Name` | ixian_concretewall | Wall | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:4403` | `Name` | Needle td_nod_gunturret Cobra Half-tracks | Needle Gun Cobra Half-tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:4476` | `Name` | Twin Assault td_nod_gunturret Python Tracks | Twin Assault Gun Python Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:4488` | `Name` | Assault td_nod_gunturret Python Tracks | Assault Gun Python Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:4610` | `Name` | Twin Assault td_nod_gunturret Python Hovercraft | Twin Assault Gun Python Hovercraft | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5117` | `Name` | Needle td_nod_gunturret Scorpion Half-tracks | Needle Gun Scorpion Half-tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5154` | `Name` | Twin Assault td_nod_gunturret Mantis Tracks | Twin Assault Gun Mantis Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5166` | `Name` | Assault td_nod_gunturret Mantis Tracks | Assault Gun Mantis Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5277` | `Name` | Twin Assault td_nod_gunturret Mantis Hovercraft | Twin Assault Gun Mantis Hovercraft | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5338` | `Name` | BabaMG td_gdi_humvee Wheels | BabaMG Jeep Wheels | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5357` | `Name` | BabaRK td_gdi_humvee Wheels | BabaRK Jeep Wheels | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5669` | `Name` | Needle td_nod_gunturret Panther Half-tracks | Needle Gun Panther Half-tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5706` | `Name` | Twin Assault td_nod_gunturret Tiger Tracks | Twin Assault Gun Tiger Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5718` | `Name` | Assault td_nod_gunturret Tiger Tracks | Assault Gun Tiger Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:5816` | `Name` | Twin Assault td_nod_gunturret Tiger Hovercraft | Twin Assault Gun Tiger Hovercraft | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:6104` | `Name` | Needle td_nod_gunturret Retribution Half-tracks | Needle Gun Retribution Half-tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:6129` | `Name` | Twin Assault td_nod_gunturret Vengeance Tracks | Twin Assault Gun Vengeance Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:6141` | `Name` | Assault td_nod_gunturret Vengeance Tracks | Assault Gun Vengeance Tracks | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:6264` | `Name` | Twin Assault td_nod_gunturret Vengeance Hovercraft | Twin Assault Gun Vengeance Hovercraft | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:6987` | `Name` | PK-105 td_gdi_humvee Barbarian MG | PK-105 Jeep Barbarian MG | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:7012` | `Name` | PK-105 td_gdi_humvee Rocket Array | PK-105 Jeep Rocket Array | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:7121` | `Name` | B-155 Camper Needle td_nod_gunturret | B-155 Camper Needle Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:7633` | `Description` | Transports tins of ra1_soviet_attackdog food to other players.\n Armed with self-defense cannon | Transports tins of dog food to other players.\n Armed with self-defense cannon | `53fb107252` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:7864` | `Name` | Bp-200 td_nod_gunturret Chopper | Bp-200 Gun Chopper | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:7947` | `Name` | td_nod_gunturret | gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:8099` | `Name` | td_nod_gunturret | gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:9109` | `Name` | ixian_concretewall Research | Wall Research | `d763966177` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:9427` | `Name` | Needle td_nod_gunturret Research | Needle Gun Research | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/wz2100.yaml:9431` | `Description` | Unlock Needle td_nod_gunturret Weapon | Unlock Needle Gun Weapon | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:200` | `Name` | Shard td_nod_gunturret Upgrade | Shard Gun Upgrade | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:205` | `Description` | Upgrades the Shotgun to the Shard td_nod_gunturret | Upgrades the Shotgun to the Shard Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:222` | `Names[]` | Shard td_nod_gunturret Upgrade | Shard Gun Upgrade | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:224` | `Descriptions[]` | Upgrades the Shotgun to the Shard td_nod_gunturret | Upgrades the Shotgun to the Shard Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:552` | `Name` | Auto ra1_allies_alliedsniper Upgrade | Auto Sniper Upgrade | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:557` | `Description` | Gives the ra1_allies_alliedsniper an automatic ra1_allies_alliedsniper Rifle | Gives the Sniper an automatic Sniper Rifle | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:574` | `Names[]` | Auto ra1_allies_alliedsniper Upgrade | Auto Sniper Upgrade | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:576` | `Descriptions[]` | Gives the ra1_allies_alliedsniper an automatic ra1_allies_alliedsniper Rifle | Gives the Sniper an automatic Sniper Rifle | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xcom.yaml:883` | `Name` | td_nod_gunturret Turret | Gun Turret | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/xmas.yaml:792` | `Description` | Light infantry equipped with td_nod_gunturret | Light infantry equipped with gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:216` | `Name` | ra1_allies_alliedsniper | Sniper | `703cfd08e2` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:317` | `Name` | td_gdi_humvee | Jeep | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:551` | `Name` | td_gdi_apc | APC | `90158ee2e8` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:760` | `Name` | td_nod_gunturret Cannon | Gun Cannon | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:858` | `Name` | Missile td_nod_gunturret | Missile Gun | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:1247` | `Name` | td_nod_gunturret Lascannon | Gun Lascannon | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:1252` | `Description` | Adds Gattling td_nod_gunturret to Fort | Adds Gattling Gun to Fort | `c9b73aeb4c` | exact pre-migration display value recovered |
+| no | `mods/cameo/rules/z.yaml:1281` | `Name` | Missiles td_nod_gunturret | Missiles Gun | `c9b73aeb4c` | exact pre-migration display value recovered |

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
@@ -549,7 +549,7 @@ ixian_machinegunturret:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: Machine td_nod_gunturret Turret
+		Name: Machine Gun Turret
 	Health:
 		HP: 75000
 	BodyOrientation:
@@ -614,7 +614,7 @@ ixian_gunturret:
 	Inherits@Armor: ^D2K_GeneralPurposeArmor
 	Inherits@Barrel: ^D2K_ReinforcedBarrel
 	Tooltip:
-		Name: td_nod_gunturret Turret
+		Name: Gun Turret
 	Valued:
 		Cost: 1000
 	Buildable:

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml
@@ -163,7 +163,7 @@ ordos_eyeinthesky:
 	Inherits@VehicleShieldsUpgradeOrdos: ^VehicleShieldsUpgradeOrdos
 	Inherits@ContrabandUpgradeOrdos: ^ContrabandUpgradeOrdos
 	Tooltip:
-		Name: td_gdi_advancedcommunicationscenter In The Sky
+		Name: Eye In The Sky
 	Valued:
 		Cost: 2500
 	Buildable:
@@ -551,7 +551,7 @@ banshee_husk.ordos:
 eye_husk.ordos:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: td_gdi_advancedcommunicationscenter on the Sky
+		Name: Eye on the Sky
 	Aircraft:
 		TurnSpeed: 8
 		Speed: 65
@@ -774,7 +774,7 @@ carryall_reinforce.ordos:
 	Inherits@LaserGuns: ^Ordos_LaserGuns
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Tooltip:
-		Name: Advanced ixian_autonomouscarryall
+		Name: Advanced Carryall
 	SpawnActorOnDeath@CRUISING:
 		Actor: carryall_husk.ordos
 		RequiresCondition: cruising
@@ -805,7 +805,7 @@ ordos_advancedcarryall:
 		BuildPaletteOrder: 120
 		Prerequisites: ~ordos_hightechfactory
 	Tooltip:
-		Name: Advanced ixian_autonomouscarryall
+		Name: Advanced Carryall
 	SpawnActorOnDeath@CRUISING:
 		Actor: carryall_husk.ordos
 		RequiresCondition: cruising
@@ -830,7 +830,7 @@ ordos_advancedcarryall:
 carryall_husk.ordos:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: Advanced ixian_autonomouscarryall
+		Name: Advanced Carryall
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 144
@@ -845,7 +845,7 @@ carryall_husk.ordos:
 carryall_huskvtol.ordos:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: Advanced ixian_autonomouscarryall
+		Name: Advanced Carryall
 	FallsToEarth:
 		Moves: False
 		Velocity: 0c128

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
@@ -19,7 +19,7 @@ ordos_apc:
 	Valued:
 		Cost: 2100
 	Tooltip:
-		Name: Ordos td_gdi_apc
+		Name: Ordos APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml
@@ -4,7 +4,7 @@ carryall.reinforce:
 	Inherits@D2KSprite: ^D2KPaletteRender
 	Inherits@selection: ^SelectableEconomicUnit
 	Tooltip:
-		Name: Autonomous ixian_autonomouscarryall
+		Name: Autonomous Carryall
 	Valued:
 		Cost: 5000
 	Health:
@@ -152,7 +152,7 @@ frigate.paradrop:
 carryall.husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 144
@@ -167,7 +167,7 @@ carryall.husk:
 carryall.huskVTOL:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	FallsToEarth:
 		Moves: False
 		Velocity: 0c128

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/buildings.yaml
@@ -242,7 +242,7 @@ ixian_concretewall:
 	UpdatesPlayerStatistics:
 		AddToAssetsValue: false
 	Tooltip:
-		Name: Concrete ixian_concretewall
+		Name: Concrete Wall
 		GenericName: Structure
 	AppearsOnRadar:
 	D2kActorPreviewPlaceBuildingPreview:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/naval.yaml
@@ -146,7 +146,7 @@ gunb.asian:
 	Valued:
 		Cost: 1400
 	Tooltip:
-		Name: Asian td_nod_gunturret Boat
+		Name: Asian Gun Boat
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/promotions.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/promotions.yaml
@@ -69,7 +69,7 @@ asian_alliance_promotion_unlockfanatic:
 asian_alliance_promotion_unlockmlrs:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock td_gdi_mlrs
+		Name: Unlock MLRS
 	Buildable:
 		BuildPaletteOrder: 101
 		Queue: Promotions

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/vehicles.yaml
@@ -554,7 +554,7 @@ asian_alliance_type89mlrs:
 	Valued:
 		Cost: 1200
 	Tooltip:
-		Name: Type 89 td_gdi_mlrs
+		Name: Type 89 MLRS
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/vehicles.yaml
@@ -36,7 +36,7 @@ futuretech_gunstrider:
 	Inherits@RobotControllable: ^RobotControllable
 	Inherits@FutureTechEqualizerUpgrades: ^FutureTechEqualizerUpgrades
 	Tooltip:
-		Name: td_nod_gunturret Strider
+		Name: Gun Strider
 	Valued:
 		Cost: 2500
 	Selectable:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/translations/en.ftl
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/translations/en.ftl
@@ -42,7 +42,7 @@ actor_nax_hetzer =
    .description = Light tank destroyer.
 
 actor_nax_hmg =
-   .description = Machine td_nod_gunturret crew.
+   .description = Machine gun crew.
       Needs to deploy to attack.
 
 actor_nax_jagdpanzer =
@@ -53,11 +53,11 @@ actor_nax_kubel =
       Can attack air.
 
 actor_nax_litt =
-   .description = Commando armed with a td_nod_gunturret that creates black holes.
+   .description = Commando armed with a gun that creates black holes.
       Black holes damage nearby enemies and can be targeted
 
 actor_nax_merc =
-   .description = ra1_allies_alliedsniper Infantry with long range.
+   .description = Sniper Infantry with long range.
 
 actor_nax_mp40 =
    .description = Elite assault infantry.

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/infantry.yaml
@@ -227,7 +227,7 @@ naxis_naximercenarysniper:
 	Valued:
 		Cost: 250
 	Tooltip:
-		Name: Naxi Mercenary ra1_allies_alliedsniper
+		Name: Naxi Mercenary Sniper
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: ~naxis_barracks, naxis_academy
@@ -1033,7 +1033,7 @@ naxis_bmwbike:
 	Valued:
 		Cost: 450
 	Tooltip:
-		Name: BMW td_nod_reconbike
+		Name: BMW Bike
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: ~naxis_barracks, naxis_warfactory

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/promotions.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/promotions.yaml
@@ -44,7 +44,7 @@ naxis_promotion_bossestanks:
 	Buildable:
 		BuildPaletteOrder: 119
 		Queue: Promotions
-		Description: Enables construction of the ra1_soviet_ironcurtain Nokana.
+		Description: Enables construction of the Iron Nokana.
 		Prerequisites: ~naxis_constructionyard, naxis_promotion_shoekarnandking, !naxis_promotion_bossestanks, rank1
 	RenderSprites:
 		Image: naxis_nokana

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/translations/en.ftl
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/translations/en.ftl
@@ -63,8 +63,8 @@ actor_latin_yakovlev =
    .description = Attack aircraft armed with machine guns.
 
 actor_ra2hind =
-   .name = ra1_soviet_hindattackhelicopter Transport
-   .description = ixian_autonomouscarryall helicopter armed with a machine gun.
+   .name = Hind Transport
+   .description = Carryall helicopter armed with a machine gun.
 
 actor_terror =
    .name = Terrorist

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/aircraft.yaml
@@ -9,7 +9,7 @@ latin_syndicate_hindtransport:
 	Valued:
 		Cost: 2500
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter Transport
+		Name: Hind Transport
 	Buildable:
 		BuildPaletteOrder: 97
 		Prerequisites: ~latin_syndicate_airstation
@@ -73,7 +73,7 @@ latin_syndicate_hindtransport:
 ra2hind_husk.latin:
 	Inherits: ^LargeHelicopterHusk
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter Transport
+		Name: Hind Transport
 	Aircraft:
 		TurnSpeed: 17
 		Speed: 85
@@ -201,7 +201,7 @@ latin_syndicate_mig21:
 	Inherits@flamerup: ^LatinFlameUpgrades
 	Selectable:
 	Tooltip:
-		Name: ra1_soviet_migattackbomber-21
+		Name: MiG-21
 	Valued:
 		Cost: 1000
 	Buildable:
@@ -282,7 +282,7 @@ latin_syndicate_mig21:
 mig_husk.latin:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ra1_soviet_migattackbomber-21
+		Name: MiG-21
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 185

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
@@ -558,7 +558,7 @@ latin_syndicate_latinsentrygun:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: Latin Sentry td_nod_gunturret
+		Name: Latin Sentry Gun
 	Building:
 		Footprint: x
 		Dimensions: 1,1

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
@@ -15,7 +15,7 @@ latin_syndicate_mortarbike:
 		Prerequisites: ~latin_syndicate_syndicatefactory, latin_syndicate_promotion_unlockmortarbikes
 		Description: actor_latin_mortarbike.description
 	Tooltip:
-		Name: Mortar td_nod_reconbike
+		Name: Mortar Bike
 	Valued:
 		Cost: 500
 	Health:
@@ -646,7 +646,7 @@ latin_syndicate_latinapc:
 	Inherits@bot: ^BotAutoDeployTransport
 	Inherits@uprecover: ^LatinCashrecover
 	Tooltip:
-		Name: Latin td_gdi_apc
+		Name: Latin APC
 	Valued:
 		Cost: 2400
 	Buildable:

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/translations/en.ftl
@@ -6,8 +6,8 @@ actor_e2 =
 actor_apc =
    .description = Armed infantry transport.
         Can attack Aircraft.
-   .tdname = GDI td_gdi_apc
-   .raname = Allied td_gdi_apc
+   .tdname = GDI APC
+   .raname = Allied APC
 
 actor_jeep =
    .description = Scout vehicle armed with a machine gun.
@@ -41,7 +41,7 @@ actor_mlrs =
 actor_orca =
    .description = Aircraft armed with missiles.
       Strong vs Buildings, Vehicles
-   .name = td_gdi_orca
+   .name = Orca
 
 actor_hq_gdi =
    .description = Provides radar, advanced technologies,
@@ -67,8 +67,8 @@ actor_empgrenadier =
         Strong vs Ground
 
 actor_gdisniper =
-   .name = GDI ra1_allies_alliedsniper
-   .description = ra1_allies_alliedsniper armed with an anti-materiel rifle.
+   .name = GDI Sniper
+   .description = Sniper armed with an anti-materiel rifle.
       Can attack air.
         Strong vs Infantry, Air
 
@@ -128,8 +128,8 @@ upgrade_armorpiercingbullets =
    .description = Increases damage of all bullet based weapons by 33%.
       while also making them more effective against tank armor.
       Increases Minigunner and Shotgunner damage by 100%.
-      Increases GDI ra1_allies_alliedsniper and A10 damage by 10%.
-      Also adds a machine td_nod_gunturret to the Battle and Predator Tank and increases damage by 5%.
+      Increases GDI Sniper and A10 damage by 10%.
+      Also adds a machine gun to the Battle and Predator Tank and increases damage by 5%.
 
 upgrade_heavyaircraftarmorplating =
    .description = Increases armor of Orcas, Firehawks, Chinooks and A10s by 50%.

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml
@@ -43,7 +43,7 @@ td_gdi_orca:
 	Valued:
 		Cost: 1700
 	Tooltip:
-		Name: td_gdi_orca
+		Name: Orca
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: ~td_gdi_helipad
@@ -119,7 +119,7 @@ A10:
 		Armaments: td_nod_gunturret, bombs
 		FacingTolerance: 32
 	Armament@GUNS:
-		Name: td_nod_gunturret
+		Name: gun
 		Weapon: Vulcan
 		LocalOffset: 1024,0,-85
 	WithMuzzleOverlay:
@@ -144,7 +144,7 @@ A10:
 ORCA.Husk:
 	Inherits: ^HelicopterHusk
 	Tooltip:
-		Name: td_gdi_orca
+		Name: Orca
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 186

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/infantry.yaml
@@ -274,7 +274,7 @@ td_gdi_heavysniper:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: GDI Heavy ra1_allies_alliedsniper
+		Name: GDI Heavy Sniper
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~td_gdi_barracks, td_gdi_communicationscenter, td_gdi_promotion_unlocksniper

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/promotions.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/promotions.yaml
@@ -33,7 +33,7 @@ td_gdi_promotion_unlockmissilesoldier:
 td_gdi_promotion_unlocksniper:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock ra1_allies_alliedsniper
+		Name: Unlock Sniper
 	Buildable:
 		BuildPaletteOrder: 19
 		Queue: Promotions
@@ -47,7 +47,7 @@ td_gdi_promotion_unlocksniper:
 td_gdi_promotion_unlockassaultapc:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock Assault td_gdi_apc
+		Name: Unlock Assault APC
 	Buildable:
 		BuildPaletteOrder: 22
 		Queue: Promotions

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
@@ -42,7 +42,7 @@ td_gdi_apc:
 	Inherits@LightWeightArmorPlating: ^LightWeightArmorPlating
 	Inherits@decoration: ^GDIRankDecoration
 	Tooltip:
-		Name: GDI td_gdi_apc
+		Name: GDI APC
 		OverrideActor: td_gdi_apc
 	Valued:
 		Cost: 1200
@@ -412,7 +412,7 @@ td_gdi_mlrs:
 	Inherits@CuttingEdge: ^CuttingEdgeEquipment
 	Inherits@decoration: ^GDIRankDecoration
 	Tooltip:
-		Name: GDI td_gdi_mlrs
+		Name: GDI MLRS
 	Valued:
 		Cost: 1000
 	Buildable:
@@ -546,7 +546,7 @@ td_gdi_assaultapc:
 	Valued:
 		Cost: 4500
 	Tooltip:
-		Name: Assault td_gdi_apc
+		Name: Assault APC
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 40

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/translations/en.ftl
@@ -32,7 +32,7 @@ actor_bike =
    .description = Scout vehicle armed with rockets.
       Can attack aircraft.
         Strong vs Vehicles
-   .name = Recon td_nod_reconbike
+   .name = Recon Bike
 
 actor_ltnk =
    .description = Fast, light tank.
@@ -82,8 +82,8 @@ actor_tmpl =
    .nuke-name = Nuclear Missile Silo
 
 actor_gun =
-   .tdname = Nod td_nod_gunturret Turret
-   .raname = Allied td_nod_gunturret Turret
+   .tdname = Nod Gun Turret
+   .raname = Allied Gun Turret
    .description = Anti-tank base defense.
         Strong vs Vehicles
 
@@ -94,8 +94,8 @@ actor_nalasr =
         Strong vs Infantry
 
 actor_sam =
-   .tdname = Nod td_nod_samsite Site
-   .raname = Soviet td_nod_samsite Site
+   .tdname = Nod SAM Site
+   .raname = Soviet SAM Site
    .ra2name = Patriot Missile System
    .description = Anti-aircraft defense.
       Requires power to operate.
@@ -133,7 +133,7 @@ actor_blackhandlaser =
         Strong vs ground targets
 
 actor_blackhandflamer =
-   .name = Black td_nod_handofnod Flamer
+   .name = Black Hand Flamer
    .description = Elite stealth flamethrower.
         Strong vs Infantry, Buildings
 
@@ -192,7 +192,7 @@ upgrade_tiberiuminfusion =
 
 upgrade_improvedartilleries =
    .description = Increases Firepower and Range of all Artilleries by 25%.
-      Increases Range of td_nod_gunturret Turrets and the SSM by 10%.
+      Increases Range of Gun Turrets and the SSM by 10%.
 
 upgrade_elementalwarfare =
    .description = Increases damage of all flame and chemical weapons by 25%.
@@ -212,11 +212,11 @@ upgrade_blackmarketupgrades =
    .description = Gives certain units new or additional weapons:
       Minigunner: Gets a Laser Rifle.
       Buggy Mk1 and Mk2: Adds a Flamethrower.
-      Recon td_nod_reconbike: Adds a Point Defense Laser.
+      Recon Bike: Adds a Point Defense Laser.
       Light Tank Mk1 and Mk2: Adds a Missile Launcher.
       Apache: Adds Missile Launchers.
       Artillery and Specter: Increases damage and spread of the warhead makes it more effective against vehicles.
-      td_nod_gunturret Turret and Attack Submarine: Increases damage and spread of the warhead.
+      Gun Turret and Attack Submarine: Increases damage and spread of the warhead.
 
 upgrade_advancedguerillatactics =
    .description = TEAM UPGRADE

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
@@ -43,7 +43,7 @@ td_nod_handofnod:
 	Inherits@sell: ^TDNodSpawnActorsOnSell
 	Inherits@ra1_soviet_barracks: ^IsBarrack
 	Tooltip:
-		Name: td_nod_handofnod of Nod
+		Name: Hand of Nod
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
@@ -392,7 +392,7 @@ td_nod_gunturret:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: Nod td_nod_gunturret Turret
+		Name: Nod Gun Turret
 	Buildable:
 		BuildPaletteOrder: 45
 		Prerequisites: ~td_nod_constructionyard, td_nod_handofnod
@@ -494,7 +494,7 @@ td_nod_samsite:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: Nod td_nod_samsite Site
+		Name: Nod SAM Site
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: ~td_nod_constructionyard, td_nod_handofnod, td_nod_communicationscenter

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/infantry.yaml
@@ -318,7 +318,7 @@ td_nod_blackhandflamer:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: Black td_nod_handofnod Flamer
+		Name: Black Hand Flamer
 	Health:
 		HP: 36000
 	ChangesHealth@SelfHealing:

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/promotions.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/promotions.yaml
@@ -19,7 +19,7 @@ td_nod_promotion_unlockchemicalrocketsoldier:
 td_nod_promotion_unlockchemicalattackbike:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock Chemical Attack td_nod_reconbike
+		Name: Unlock Chemical Attack Bike
 	Buildable:
 		BuildPaletteOrder: 4
 		Queue: Promotions
@@ -117,11 +117,11 @@ td_nod_promotion_unlocklasertrooper:
 td_nod_promotion_unlockblackhandflamer:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock Black td_nod_handofnod Flamer
+		Name: Unlock Black Hand Flamer
 	Buildable:
 		BuildPaletteOrder: 3
 		Queue: Promotions
-		Description: Allows training of Black td_nod_handofnod Flamers.
+		Description: Allows training of Black Hand Flamers.
 		Prerequisites: ~td_nod_constructionyard, !td_nod_promotion_unlockblackhandflamer, rank1
 	RenderSprites:
 		Image: td_nod_blackhandflamer

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml
@@ -271,7 +271,7 @@ td_nod_reconbike:
 	Inherits@BlackMarketUpgrades: ^BlackMarketUpgrades
 	Inherits@decoration: ^NodRankDecoration
 	Tooltip:
-		Name: Recon td_nod_reconbike
+		Name: Recon Bike
 	Valued:
 		Cost: 500
 	Buildable:
@@ -552,7 +552,7 @@ td_nod_chemicalattackbike:
 	Inherits@BlackMarketUpgrades: ^BlackMarketUpgrades
 	Inherits@decoration: ^NodRankDecoration
 	Tooltip:
-		Name: Chemical Attack td_nod_reconbike
+		Name: Chemical Attack Bike
 	Valued:
 		Cost: 750
 	Buildable:

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/translations/en.ftl
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/translations/en.ftl
@@ -63,7 +63,7 @@ actor_cabal_cyborgcommandov2 =
 
 actor_cabal_eliminator800 =
    .name = Eliminator 800
-   .description = Heavy cybernetic infantry armed with a gatling td_nod_gunturret and anti-air missiles.
+   .description = Heavy cybernetic infantry armed with a gatling gun and anti-air missiles.
       Can detect cloaked and hijacker units.
       Strong vs Infantry, Light armor, Aircraft
       Weak vs Vehicles
@@ -131,7 +131,7 @@ actor_cabal_tarantula =
       Weak vs Infantry, Aircraft
 
 actor_cabal_scarabapc =
-   .name = Scarab td_gdi_apc
+   .name = Scarab APC
    .description = Hover troop transport that comes pre-loaded with infantry.
       Can move over water.
       Unarmed.
@@ -247,7 +247,7 @@ actor_cabal_upgrade_backupsystems =
       The husk reactivates if it is not destroyed.
 
 actor_cabal_upgrade_handof =
-   .name = td_nod_handofnod of CABAL
+   .name = Hand of CABAL
    .description = Tech Upgrade (Only affects units of own faction)
       Periodically spawns free Hacker Cyborgs from the Tech Center.
       Increases Hacker Cyborg speed by 25%.

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/upgrades.yaml
@@ -92,7 +92,7 @@ cabal_upgrade_backupsystems:
 cabal_upgrade_handof:
 	Inherits: ^researched_upgrade.template
 	Tooltip:
-		Name: td_nod_handofnod of CABAL
+		Name: Hand of CABAL
 	Valued:
 		Cost: 12500
 	Buildable:

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
@@ -541,7 +541,7 @@ cabal_scarabapc:
 	Valued:
 		Cost: 4775
 	Tooltip:
-		Name: Scarab td_gdi_apc
+		Name: Scarab APC
 	UpdatesPlayerStatistics:
 		OverrideActor: ts_nod_subterraneanapc
 	Buildable:

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/aircraft.yaml
@@ -10,7 +10,7 @@ ts_gdi_orcafighter:
 	Inherits@MechanicalReliability: ^MechanicalReliability
 	Inherits@SonicWeaponry: ^SonicWeaponry
 	Tooltip:
-		Name: td_gdi_orca Fighter
+		Name: Orca Fighter
 	Valued:
 		Cost: 2200
 	UpdatesPlayerStatistics:
@@ -84,7 +84,7 @@ ts_gdi_zoneorcafighter:
 	Inherits@SonicWeaponry: ^SonicWeaponry
 	Inherits@PromotionUnitBuff: ^PromotionUnitBuff
 	Tooltip:
-		Name: Zone td_gdi_orca Fighter
+		Name: Zone Orca Fighter
 	Valued:
 		Cost: 3000
 	UpdatesPlayerStatistics:
@@ -256,7 +256,7 @@ ts_gdi_orcabomber:
 	Valued:
 		Cost: 1900
 	Tooltip:
-		Name: td_gdi_orca Bomber
+		Name: Orca Bomber
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -329,7 +329,7 @@ ts_gdi_carryall:
 	Valued:
 		Cost: 750
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Selectable:
 		Bounds: 1280, 1024
 	UpdatesPlayerStatistics:

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/defenses.yaml
@@ -219,7 +219,7 @@ ts_gdi_samtower:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: td_nod_samsite Tower
+		Name: SAM Tower
 	Buildable:
 		BuildPaletteOrder: 140
 		Prerequisites: ~ts_gdi_constructionyard, ts_gdi_radar

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/husks.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/husks.yaml
@@ -2,7 +2,7 @@ ts_gdi_orcafighter_husk:
 	Inherits: ^PlaneHusk
 	Inherits@Voxel: ^TSRenderVoxel
 	Tooltip:
-		Name: td_gdi_orca Fighter
+		Name: Orca Fighter
 	Aircraft:
 		TurnSpeed: 80
 		Speed: 186
@@ -18,7 +18,7 @@ ts_gdi_orcabomber_husk:
 	Inherits: ^PlaneHusk
 	Inherits@Voxel: ^TSRenderVoxel
 	Tooltip:
-		Name: td_gdi_orca Bomber
+		Name: Orca Bomber
 	Aircraft:
 		TurnSpeed: 40
 		Speed: 96
@@ -38,7 +38,7 @@ ts_gdi_carryall_husk:
 	Inherits: ^PlaneHusk
 	Inherits@Voxel: ^TSRenderVoxel
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Aircraft:
 		TurnSpeed: 80
 		Speed: 149

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/promotions.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/promotions.yaml
@@ -57,7 +57,7 @@ ts_gdi_promotion_unlockmammothmkii:
 ts_gdi_promotion_unlockzoneorca:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock Zone td_gdi_orca
+		Name: Unlock Zone Orca
 	Buildable:
 		BuildPaletteOrder: 2
 		Queue: Promotions

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/upgrades.yaml
@@ -61,7 +61,7 @@ ts_gdi_upgrade_ceramicarmor:
 ts_gdi_upgrade_mechengineering:
 	Inherits: ^researched_upgrade.template
 	Tooltip:
-		Name: ra1_allies_mechanic Engineering
+		Name: Mech Engineering
 	Valued:
 		Cost: 7500
 	Buildable:

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml
@@ -119,7 +119,7 @@ ts_gdi_amphibiousapc:
 	Valued:
 		Cost: 1640
 	Tooltip:
-		Name: Amphibious td_gdi_apc
+		Name: Amphibious APC
 	UpdatesPlayerStatistics:
 		OverrideActor: ts_gdi_amphibiousapc
 	Buildable:
@@ -561,7 +561,7 @@ ts_gdi_hovermlrs:
 	Valued:
 		Cost: 900
 	Tooltip:
-		Name: Hover td_gdi_mlrs
+		Name: Hover MLRS
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~ts_gdi_warfactory, ts_gdi_radar

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/buildings.yaml
@@ -241,7 +241,7 @@ ts_nod_handof:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: td_nod_handofnod of Nod
+		Name: Hand of Nod
 	ProvidesPrerequisite@buildingname:
 	Buildable:
 		BuildPaletteOrder: 30

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
@@ -216,7 +216,7 @@ ts_nod_samsite:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: td_nod_samsite Site
+		Name: SAM Site
 	Buildable:
 		BuildPaletteOrder: 140
 		Prerequisites: ~ts_nod_constructionyard, ts_nod_radar

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/upgrades.yaml
@@ -82,7 +82,7 @@ ts_nod_upgrade_tiberiumcoremissiles:
 	Buildable:
 		BuildPaletteOrder: 100
 		Queue: Research
-		Description: Procure tiberium core missile technology to Rocket Soldier, td_nod_samsite Site, Attack Cycle and Stealth Tank, increasing their firepower.
+		Description: Procure tiberium core missile technology to Rocket Soldier, SAM Site, Attack Cycle and Stealth Tank, increasing their firepower.
 		Prerequisites: ~ts_nod_techcenter, !ts_nod_upgrade_tiberiumcoremissiles
 	RenderSprites:
 		Image: tstiberiumcoremissilesicon

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/vehicles.yaml
@@ -71,7 +71,7 @@ ts_nod_subterraneanapc:
 	Valued:
 		Cost: 1410
 	Tooltip:
-		Name: Subterranean td_gdi_apc
+		Name: Subterranean APC
 	UpdatesPlayerStatistics:
 		OverrideActor: ts_nod_subterraneanapc
 	Buildable:

--- a/mods/cameo/fluent/rules/en.ftl
+++ b/mods/cameo/fluent/rules/en.ftl
@@ -26,12 +26,12 @@ actor_gtwr =
    .name = Guard Tower
 
 actor_dog =
-   .name = Attack ra1_soviet_attackdog
+   .name = Attack Dog
    .description = Can detect cloaked and disguised units.
       Strong vs Infantry
 
 actor_rasniper =
-   .name = Allied ra1_allies_alliedsniper
+   .name = Allied Sniper
    .description = Camouflaged soldier that can detect cloaked units.
         Strong vs Infantry
 
@@ -126,7 +126,7 @@ actor_mgg =
    .description = Regenerates the shroud nearby,
     obscuring the area.
         Unarmed
-   .name = Mobile ra1_allies_gapgenerator Generator
+   .name = Mobile Gap Generator
 
 actor_mrj =
    .name = Mobile Radar Jammer
@@ -155,7 +155,7 @@ actor_sheridan =
    .description = General-purpose light tank.
       Can attack air with missiles.
         Strong vs Infantry, vehicles
-   .name = ra1_allies_sheridanassaulttank
+   .name = Sheridan
 
 actor_rapierjumpjet =
    .description = Fast multirole fighter-bomber.
@@ -163,9 +163,9 @@ actor_rapierjumpjet =
    .name = Rapier Jumpjet
 
 upgrade_gapgen =
-   .description = Allows construction of the ra1_allies_gapgenerator Generator
-      and the Mobile ra1_allies_gapgenerator Generator and the Phase Transport.
-   .name = Unlock ra1_allies_gapgenerator Generator Technology
+   .description = Allows construction of the Gap Generator
+      and the Mobile Gap Generator and the Phase Transport.
+   .name = Unlock Gap Generator Technology
 
 actor_mortarsoldier =
    .name = Mortar Soldier
@@ -184,7 +184,7 @@ actor_volkov =
    armed with a magnetic pistol and exploding bullets.
         Strong vs Infantry, Vehicles
         Weak vs Aircraft
-   .name = ra1_soviet_volkov
+   .name = Volkov
 
 actor_gtnk =
    .description = Mobile unit with mounted gatling cannon.
@@ -215,7 +215,7 @@ actor_kotin =
    .description = Tank armed with nuclear shells.
       Attacks leave radiation.
         Strong vs Vehicles
-   .name = ra1_soviet_kotinnucleartank Nuclear Tank
+   .name = Kotin Nuclear Tank
 
 actor_mignuke =
    .description = Fast nuclear bomber.
@@ -226,14 +226,14 @@ actor_mig =
    .description = Multirole fighter.
       Strong vs Vehicles, Aircraft
       Weak vs air defenses
-   .name = ra1_soviet_migattackbomber
+   .name = MiG
 
 actor_yak =
    .description = Attack plane armed with
     dual machine guns.
       Strong vs infantry, Light armor
       Weak vs air defenses
-   .name = ra1_soviet_yakscoutplane
+   .name = Yak
 
 actor_su57 =
    .description = Multirole fighter-bomber.
@@ -252,7 +252,7 @@ actor_hind =
     with dual chainguns.
       Strong vs infantry, Light armor
       Weak vs air defenses
-   .name = ra1_soviet_hindattackhelicopter
+   .name = Hind
 
 actor_mh60 =
    .description = Helicopter gunship armed
@@ -303,7 +303,7 @@ actor_mslo =
 actor_iron =
    .description = Makes vehicles temporarily invincible.
       Requires power to operate.
-   .name = ra1_soviet_ironcurtain Curtain
+   .name = Iron Curtain
 
 power_ironcurtain =
    .description = Makes a group of units temporarily invulnerable.
@@ -332,10 +332,10 @@ actor_hbox =
 actor_agun =
    .description = Anti-air base defense.
     Requires power to operate.
-   .name = AA td_nod_gunturret
+   .name = AA Gun
 
 actor_gap =
-   .name = ra1_allies_gapgenerator Generator
+   .name = Gap Generator
    .description = Obscures the enemy's view with shroud.
     Requires power to operate.
 
@@ -539,7 +539,7 @@ actor_cleg =
         Weak vs Aircraft
 
 actor_ra2snipe =
-   .name = ra1_allies_alliedsniper
+   .name = Sniper
    .description = Strong vs Infantry
 
 actor_seal =
@@ -695,7 +695,7 @@ actor_zep =
         Weak vs Air
 
 actor_bpln =
-   .name = ra1_soviet_migattackbomber Bomber
+   .name = MiG Bomber
    .description = Fast multirole fighter-bomber.
         Strong vs Ground, Aircraft
         Weak vs Air Defense
@@ -977,7 +977,7 @@ actor_forgotten_zombiemutant =
       Weak vs Aircraft
 
 actor_forgotten_mutantsniper =
-   .name = Mutant ra1_allies_alliedsniper
+   .name = Mutant Sniper
    .description = Long-range marksman.
       Can only target infantry, and picks them out of garrisoned structures.
       Strong vs Infantry
@@ -999,7 +999,7 @@ actor_forgotten_mutantmortarman =
 
 actor_forgotten_mutantsergeant =
    .name = Mutant Sergeant
-   .description = Elite mutant officer whose td_nod_gunturret also reaches aircraft.
+   .description = Elite mutant officer whose gun also reaches aircraft.
       Propaganda aura: nearby friendly units gain 10% firepower and speed, take 10% less damage, reload 10% faster, slowly heal and cannot be mind-controlled.
       Strong vs Infantry
       Weak vs Tanks
@@ -1053,7 +1053,7 @@ actor_forgotten_ghoststalker =
 
 actor_forgotten_raidercar =
    .name = Raider Car
-   .description = Fast scout car whose machine td_nod_gunturret can also strafe aircraft.
+   .description = Fast scout car whose machine gun can also strafe aircraft.
       Replaced by the Bowler after that promotion.
       Strong vs Infantry
       Weak vs Tanks
@@ -1106,7 +1106,7 @@ actor_forgotten_tiberiumharvester =
       Unarmed
 
 actor_forgotten_apctruck =
-   .name = td_gdi_apc Truck
+   .name = APC Truck
    .description = Armored transport truck for six infantry.
       Its cannon reaches ground and air targets.
       Strong vs Infantry
@@ -1116,7 +1116,7 @@ actor_forgotten_missilevan =
    .name = Missile Van
    .description = Fragile van hurling missiles from extreme range.
       Chemical Weapons research loads chemical missiles.
-      Replaced by the td_gdi_mlrs after that promotion.
+      Replaced by the MLRS after that promotion.
       Strong vs Infantry, Buildings
       Weak vs Tanks, Aircraft
 
@@ -1145,10 +1145,10 @@ actor_forgotten_scoopertank =
       Weak vs Aircraft
 
 actor_forgotten_mlrs =
-   .name = Forgotten td_gdi_mlrs
+   .name = Forgotten MLRS
    .description = Mutant rocket artillery.
       Chemical Weapons research loads chemical rockets.
-      Requires the td_gdi_mlrs promotion and replaces the Missile Van.
+      Requires the MLRS promotion and replaces the Missile Van.
       Strong vs Infantry, Buildings
       Weak vs Tanks, Aircraft
 
@@ -1179,7 +1179,7 @@ actor_forgotten_thumperbus =
 actor_forgotten_nomadbarracks =
    .name = Nomad Barracks
    .description = Rolling barracks that trains infantry anywhere on the map.
-      Nine garrisoned infantry fire from inside; its own td_nod_gunturret covers the approaches.
+      Nine garrisoned infantry fire from inside; its own gun covers the approaches.
       Maximum 1 can be built.
 
 actor_forgotten_mobileconstructionvehicle =
@@ -1188,7 +1188,7 @@ actor_forgotten_mobileconstructionvehicle =
       Unarmed
 
 actor_forgotten_carryall =
-   .name = ixian_autonomouscarryall
+   .name = Carryall
    .description = VTOL crane that lifts and ferries vehicles.
       Unarmed
 
@@ -1297,7 +1297,7 @@ actor_forgotten_veinhole =
 
 actor_forgotten_machineguntower =
    .name = Machinegun Tower
-   .description = Scrap-built machine td_nod_gunturret tower.
+   .description = Scrap-built machine gun tower.
       Detects nearby cloaked enemies.
       Strong vs Infantry, Light vehicles
       Weak vs Tanks, Aircraft
@@ -1312,8 +1312,8 @@ actor_forgotten_brokenrattytankturret =
       Weak vs Infantry, Aircraft
 
 actor_forgotten_juggerflakwall =
-   .name = Juggerflak ixian_concretewall
-   .description = ixian_concretewall-mounted Juggernaut flak battery.
+   .name = Juggerflak Wall
+   .description = Wall-mounted Juggernaut flak battery.
       Cannot engage ground targets.
       Strong vs Aircraft
 
@@ -1434,16 +1434,16 @@ actor_forgotten_promotion_scoopertank =
       Follows the Warrior Tank promotion.
 
 actor_forgotten_promotion_mlrs =
-   .name = Unlock td_gdi_mlrs
+   .name = Unlock MLRS
    .description = Promotion Upgrade (Only affects units of own faction)
-      Allows construction of the Forgotten td_gdi_mlrs rocket artillery, replacing the Missile Van.
+      Allows construction of the Forgotten MLRS rocket artillery, replacing the Missile Van.
       Follows the Scooper Tank promotion.
 
 actor_forgotten_promotion_experimentalmammothtank =
    .name = Unlock Experimental Mammoth Tank
    .description = Promotion Upgrade (Only affects units of own faction)
       Allows construction of the Experimental Mammoth Tank, a colossal mammoth prototype.
-      Follows the td_gdi_mlrs promotion.
+      Follows the MLRS promotion.
 
 actor_ts_nod_missilesilo =
    .name = Missile Silo
@@ -1460,7 +1460,7 @@ actor_ts_nod_laserturret =
    Cannot attack Aircraft.
 
 actor_ts_nod_samsite =
-   .name = td_nod_samsite Site
+   .name = SAM Site
    .description = Anti-aircraft missile battery.
    Requires power to operate.
    Strong vs Aircraft.
@@ -1631,15 +1631,15 @@ upgrade_rocketenhancements =
    .description = Increases weapon and vision range and damage of all ballistic rockets:
    V1 Truck: 25%
    V2 Launcher: 20%
-   Nuclear V2 Launcher, ra1_soviet_migattackbomber and Su-57: 15%
-   Missile Submarine, td_nod_samsite Site and ra1_soviet_hindattackhelicopter: 10%
-   Mammoth Tank, Monster Tank and ra1_soviet_volkov: 5%
+   Nuclear V2 Launcher, Mig and Su-57: 15%
+   Missile Submarine, SAM Site and Hind: 10%
+   Mammoth Tank, Monster Tank and Volkov: 5%
 
 upgrade_advancedthermobarics =
    .description = Increases damage of all fire and nuclear weapons by 25%.
-   Adds Napalm Warheads to the V1 Truck, ra1_soviet_migattackbomber, Su-57 and all tanks.
+   Adds Napalm Warheads to the V1 Truck, Mig, Su-57 and all tanks.
    V2 Launcher and Nuclear V2 Launcher increase damage by 100%.
-   Adds Incendiary Bullets to the Rifle Infantry, ra1_soviet_yakscoutplane, ra1_soviet_hindattackhelicopter and Gatling Tank.
+   Adds Incendiary Bullets to the Rifle Infantry, Yak, Hind and Gatling Tank.
    Increases Armor of Grenadiers, Flamethrowers, Fire Rocket Soldiers and Mortar Soldiers by 50%
 
 upgrade_experimentalteslaweaponry =
@@ -1648,7 +1648,7 @@ upgrade_experimentalteslaweaponry =
    Unlocks the "Parabombs" Support power from the Soviet Airfield.
 
 upgrade_sovietautoloaders =
-   .description = Reduces the Reload Delay of Tanks, Hinds and ra1_soviet_volkov by 40%.
+   .description = Reduces the Reload Delay of Tanks, Hinds and Volkov by 40%.
 
 upgrade_sovietsteel =
    .description = TEAM UPGRADE
@@ -1739,8 +1739,8 @@ upgrade_personal_shield =
    .description = Gives personal shield generators to all infantry units.
 
 upgrade_d2k_siege_range_upgrade =
-   .description = All Tanks, td_nod_gunturret Turrets and Artillery gain increased range and damage.
-   td_nod_gunturret Turret, Ix Combat Tanks and Duelist Tanks: 10% higher range and 25% more damage.
+   .description = All Tanks, Gun Turrets and Artillery gain increased range and damage.
+   Gun Turret, Ix Combat Tanks and Duelist Tanks: 10% higher range and 25% more damage.
    Ix Siege Tank: 25% higher range and 50% more damage.
    Ix Combat Siege: 50% higher range and 100% more damage.
 
@@ -1842,7 +1842,7 @@ ra1_soviet_doctrine_teslaandexperimentaltech =
       Focuses on Experimental Tesla Technology
       All Tesla Weapons deal additional EMP Damage.
       Replaces Shock Troopers with Zappers
-      Replaces ra1_soviet_hindattackhelicopter with Kamov
+      Replaces Hind with Kamov
       Unlocks Heavy Tesla Tank
       Unlocks Tesla Arcing, Tesla Rockets and Reactor Overload Upgrades
 
@@ -1861,7 +1861,7 @@ ra1_soviet_doctrine_nuclearwar =
       Focuses on High Damage and Speed.
       All Vehicles have 10% higher Firepower and Speed
       Replaces V2 Rocket Launcher with Nuclear V2 Rocket Launcher
-      Unlocks ra1_soviet_kotinnucleartank Nuclear Tank
+      Unlocks Kotin Nuclear Tank
       Unlocks Unstable Isotopes, Thermonuclear Rockets and Nuclear Tank Shells Upgrades
 
 ra1_soviet_upgrade_hazmatsuits =
@@ -1915,11 +1915,11 @@ ra1_soviet_upgrade_teslaarcing =
       Adds arcing effects to all Tesla Weapons.
       Can arc up to 2 extra times for extra damage.
       Reduces recharge delay for the Heavy Tesla Tank by 25%
-      Equips ra1_soviet_volkov with arcing Tesla Bombs.
+      Equips Volkov with arcing Tesla Bombs.
 
 ra1_soviet_upgrade_teslarockets =
    .description = Tech Upgrade (Only affects units of own faction)
-      Heavy Rockets such as of the Mammoth Tank, Kamov, ra1_soviet_migattackbomber and V2 Launcher
+      Heavy Rockets such as of the Mammoth Tank, Kamov, Mig and V2 Launcher
       are replaced with Tesla Rockets that can arc over to other targets on explosion.
 
 ra1_soviet_upgrade_reactoroverload =
@@ -1933,7 +1933,7 @@ ra1_soviet_upgrade_autoloaders =
 
 ra1_soviet_upgrade_highexplosiverockets =
    .description = Tech Upgrade (Only affects units of own faction)
-      Heavy Rockets such as of the Siege Mammoth Tank, ra1_soviet_hindattackhelicopter, Su-57, Grad and V2 Launcher
+      Heavy Rockets such as of the Siege Mammoth Tank, Hind, Su-57, Grad and V2 Launcher
       are replaced with High Explosive Rockets that deal 20% more damage and have higher area of effect.
 
 ra1_soviet_upgrade_stalinium =
@@ -1943,11 +1943,11 @@ ra1_soviet_upgrade_stalinium =
 ra1_soviet_upgrade_unstableisotopes =
    .description = Tech Upgrade (Only affects units of own faction)
       Increases Speed of all Vehicles by 20%.
-      Increases Speed of ra1_soviet_kotinnucleartank Nuclear Tanks by 40%.
+      Increases Speed of Kotin Nuclear Tanks by 40%.
 
 ra1_soviet_upgrade_thermonuclearrockets =
    .description = Tech Upgrade (Only affects units of own faction)
-      Heavy Rockets such as of the Mammoth Tank, ra1_soviet_hindattackhelicopter, ra1_soviet_migattackbomber and Nuclear V2 Launcher
+      Heavy Rockets such as of the Mammoth Tank, Hind, Mig and Nuclear V2 Launcher
       are replaced with Thermonuclear Rockets that deal increased damage to heavier armor types
       and have massively higher area of effect.
 
@@ -1955,8 +1955,8 @@ ra1_soviet_upgrade_nucleartankshells =
    .description = Team Upgrade (Also affects units of your teammates)
       Increases Firepower of all Tanks in your team by 20%.
       Equips Soviet Tanks with special shells that explode in a higher radius.
-      Equips ra1_soviet_volkov with a Nuclear Cannon.
-      Increases Spread and Radiation Damage of the ra1_soviet_kotinnucleartank Nuclear Tank.
+      Equips Volkov with a Nuclear Cannon.
+      Increases Spread and Radiation Damage of the Kotin Nuclear Tank.
 
 ra1_soviet_promotion_infantrysuperoptics =
    .description = Promotion Upgrade (Only affects units of own faction)
@@ -1969,7 +1969,7 @@ ra1_soviet_promotion_mammothtanktargetingcomputer =
 
 ra1_soviet_promotion_hurricanerocketpods =
    .description = Promotion Upgrade (Only affects units of own faction)
-      Doubles the amount of Missiles that ra1_soviet_hindattackhelicopter and Kamov can fire.
+      Doubles the amount of Missiles that Hind and Kamov can fire.
 
 ordos_upgrade_shield =
    .description = Tech Upgrade (Only affects units of own faction)
@@ -2001,10 +2001,10 @@ upgrade_sonicweaponry =
 upgrade_tsprojectileimprovements =
    .name = Projectile Improvements
    .description = Tech Upgrade (Only affects units of own faction)
-      Increases Damage and Range of Enforcers, Pitbulls, Hover td_gdi_mlrs and td_nod_samsite Towers by 20%
+      Increases Damage and Range of Enforcers, Pitbulls, Hover MLRS and SAM Towers by 20%
 
 upgrade_mechengineering =
-   .name = ra1_allies_mechanic Engineering
+   .name = Mech Engineering
    .description = Tech Upgrade (Only affects units of own faction)
       Increases Damage Resistance of walkers by 20%.
       Increases Speed by 25%.
@@ -2054,7 +2054,7 @@ template_advpower =
 template_barracks =
    .description = Trains infantry.
    .td-gdi = GDI Barracks
-   .td-nod = td_nod_handofnod of Nod
+   .td-nod = Hand of Nod
    .ra-soviet = Soviet Barracks
    .ra-allies = Allied Barracks
    .ra-japan = Japanese Barracks
@@ -2198,7 +2198,7 @@ faction_ra_allies =
 faction_ra_soviets =
    .name = Soviets RA
    .description = Soviets from Red Alert
-      Support powers: Parabombs, ra1_soviet_ironcurtain Curtain, Atomic Bomb
+      Support powers: Parabombs, Iron Curtain, Atomic Bomb
 
 faction_ra_japan =
    .name = Japan RA
@@ -2243,7 +2243,7 @@ faction_ra2_allies =
 faction_ra2_soviets =
    .name = Soviets RA2
    .description = Soviets from Red Alert 2
-      Support powers: ra1_soviet_ironcurtain Curtain, Nuclear Missile
+      Support powers: Iron Curtain, Nuclear Missile
 
 faction_ra2_yuri =
    .name = Yuri

--- a/mods/cameo/fluent/rules/ftech_en.ftl
+++ b/mods/cameo/fluent/rules/ftech_en.ftl
@@ -42,13 +42,13 @@ actor_future_robot_cannon =
       Weak vs Infantry, Aircraft
 
 actor_future_mech_machinegun =
-   .description = Large walking ra1_allies_mechanic armed with autoguns.
+   .description = Large walking mech armed with autoguns.
       Can attack air.
       Strong vs Infantry, Aircraft
       Weak vs Vehicles
 
 actor_future_mech_plasma =
-   .description = Large walking ra1_allies_mechanic armed with twin plasma cannons.
+   .description = Large walking mech armed with twin plasma cannons.
       Strong vs Vehicles, Buildings
       Weak vs Infantry, Aircraft
 

--- a/mods/cameo/fluent/rules/outpost2_en.ftl
+++ b/mods/cameo/fluent/rules/outpost2_en.ftl
@@ -228,7 +228,7 @@ plymouth_convec_structure_factory =
    Unarmed
 
 plymouth_scout =
-  .description = Fast scout armed with a machine td_nod_gunturret
+  .description = Fast scout armed with a machine gun
 
 plymouth_lynx_microwave =
   .description = Fast microwave vehicle
@@ -277,7 +277,7 @@ eden_convec_structure_factory =
    Unarmed
 
 eden_scout =
-  .description = Fast scout armed with a machine td_nod_gunturret
+  .description = Fast scout armed with a machine gun
 
 eden_lynx_laser =
   .description = Fast laser vehicle

--- a/mods/cameo/music.yaml
+++ b/mods/cameo/music.yaml
@@ -112,7 +112,7 @@ dron226m: TD CO Drone
 heart: TD CO Heartbreak
 	Extension: mp3
 iam: TD CO I Am - Times (Credits)
-fist226m: TD CO ra1_soviet_ironcurtain Fist
+fist226m: TD CO Iron Fist
 	Extension: mp3
 rout: TD CO Reaching Out
 	Extension: mp3
@@ -200,7 +200,7 @@ chaos2: RA Counterstrike -  Chaos
 	Extension: mp3
 shut_it: RA Counterstrike -  Shut It
 	Extension: mp3
-2nd_hand: RA Counterstrike -  The Second td_nod_handofnod
+2nd_hand: RA Counterstrike -  The Second Hand
 	Extension: mp3
 twinmix1: RA Counterstrike -  Twin Cannon (Remix)
 under3: RA Counterstrike -  Underlying Thoughts
@@ -402,7 +402,7 @@ cncrcnc: Renegade - Command & Conquer
 	Extension: mp3
 cncrpfy: Renegade - Got a Present for Ya
 	Extension: mp3
-cncrsnipe: Renegade - ra1_allies_alliedsniper
+cncrsnipe: Renegade - Sniper
 	Extension: mp3
 cncracton: Renegade - Act on Instinct (Renegade)
 	Extension: mp3
@@ -416,7 +416,7 @@ cncrmovit: Renegade - Move It
 	Extension: mp3
 cncdogfig: Renegade - Dogfight
 	Extension: mp3
-cncrpctir: Renegade - Packing ra1_soviet_ironcurtain
+cncrpctir: Renegade - Packing Iron
 	Extension: mp3
 cncrindam: Renegade - Industrial Ambient
 	Extension: mp3

--- a/mods/cameo/rules/advancewars.yaml
+++ b/mods/cameo/rules/advancewars.yaml
@@ -4863,7 +4863,7 @@ awpipe:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: ixian_concretewall Pipe
+		Name: Wall Pipe
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: vehicleproduction
@@ -4991,7 +4991,7 @@ awtalon:
 	Valued:
 		Cost: 3000
 	Tooltip:
-		Name: Talon td_nod_gunturret
+		Name: Talon Gun
 	Buildable:
 		BuildPaletteOrder: 45
 		Prerequisites: awlab
@@ -7740,7 +7740,7 @@ awbike:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: td_nod_reconbike
+		Name: Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: True
 	Buildable:
@@ -7877,7 +7877,7 @@ awapc2:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: Attack td_gdi_apc
+		Name: Attack APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: True
 	Buildable:
@@ -9956,7 +9956,7 @@ awe3:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: ra1_allies_mechanic Infantry
+		Name: Mech Infantry
 	UpdatesPlayerStatistics:
 		AddToArmyValue: True
 	Buildable:
@@ -12068,7 +12068,7 @@ awuptiberium:
 awupwall:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Durable ixian_concretewall Research
+		Name: Durable Wall Research
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research

--- a/mods/cameo/rules/classicdoom.yaml
+++ b/mods/cameo/rules/classicdoom.yaml
@@ -1042,7 +1042,7 @@ wolfdog:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: Attack ra1_soviet_attackdog
+		Name: Attack Dog
 		GenericName: ra1_soviet_attackdog
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
@@ -1880,7 +1880,7 @@ wolfrobot:
 wolfupdogfood:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: ra1_soviet_attackdog Food
+		Name: Dog Food
 	Buildable:
 		BuildPaletteOrder: 250
 		Queue: Research

--- a/mods/cameo/rules/darkreign.yaml
+++ b/mods/cameo/rules/darkreign.yaml
@@ -857,7 +857,7 @@ drwall1:
 	Valued:
 		Cost: 50
 	Tooltip:
-		Name: Concrete ixian_concretewall
+		Name: Concrete Wall
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Defence, RADefence
@@ -882,7 +882,7 @@ drwall2:
 	Valued:
 		Cost: 50
 	Tooltip:
-		Name: Concrete ixian_concretewall
+		Name: Concrete Wall
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Defence, RADefence
@@ -3702,7 +3702,7 @@ drmercenary:
 		BuildPaletteOrder: 25
 		Prerequisites: barracks
 		Queue: Infantry, RAInfantry
-		Description: Recruited from outside the Freedom Guard ranks, these paid guns carry a massive shoulder mounted rail gun.\nHighly trained and ruthless, the Mercenary is tougher and deadlier than the Raider. The Mercenary can phase\nonce the Phasing Facility has been built\n\nType: Walker\nSpeed: SLow\nWeapon: Rail td_nod_gunturret\nRange: Short\nArmor: Medium
+		Description: Recruited from outside the Freedom Guard ranks, these paid guns carry a massive shoulder mounted rail gun.\nHighly trained and ruthless, the Mercenary is tougher and deadlier than the Raider. The Mercenary can phase\nonce the Phasing Facility has been built\n\nType: Walker\nSpeed: SLow\nWeapon: Rail Gun\nRange: Short\nArmor: Medium
 		BuildDuration: 300
 		BuildDurationModifier: 100
 	Mobile:
@@ -3751,14 +3751,14 @@ drsnipe:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: ra1_allies_alliedsniper
+		Name: Sniper
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: drfgbarr2
 		Queue: Infantry, RAInfantry
-		Description: With a long range electro-magnetic needle td_nod_gunturret, the ra1_allies_alliedsniper is lethal against\ninfantry targets. Like the Scout, the ra1_allies_alliedsniper can morph into objects for camouflage.\n\nType: Walker\nSpeed: Medium\nWeapon: ra1_allies_alliedsniper Rail\nRange: Long\nArmor: Light
+		Description: With a long range electro-magnetic needle gun, the Sniper is lethal against\ninfantry targets. Like the Scout, the Sniper can morph into objects for camouflage.\n\nType: Walker\nSpeed: Medium\nWeapon: Sniper Rail\nRange: Long\nArmor: Light
 	Mobile:
 		Speed: 80
 	Health:
@@ -4021,14 +4021,14 @@ drspid:
 	Valued:
 		Cost: 550
 	Tooltip:
-		Name: Spider td_nod_reconbike
+		Name: Spider Bike
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: vehicleproduction
 		Queue: Vehicle, RAVehicle
 		BuildDuration: 1020
 		BuildDurationModifier: 40
-		Description: This all terrain vehicle is the cornerstone of\nthe Freedom Guard ground force. Fast and inexpensive, it\nis able to tackle all types of terrain. Armed with a double\nrail td_nod_gunturret, it is fairly effective against armour but somewhat\nvulnerable to infantry\n\nType: Special Wheeled\nSpeed: Fast\nWeapon: Rail td_nod_gunturret\nRange: Medium\nArmor: Medium
+		Description: This all terrain vehicle is the cornerstone of\nthe Freedom Guard ground force. Fast and inexpensive, it\nis able to tackle all types of terrain. Armed with a double\nrail gun, it is fairly effective against armour but somewhat\nvulnerable to infantry\n\nType: Special Wheeled\nSpeed: Fast\nWeapon: Rail Gun\nRange: Medium\nArmor: Medium
 	Mobile:
 		Speed: 174
 		TurnSpeed: 48
@@ -4168,7 +4168,7 @@ drrtnk:
 		Queue: Vehicle, RAVehicle
 		BuildDurationModifier: 100
 		BuildDuration: 1500
-		Description: The pinnacle of Freedom Guard\narmour, the Triple Rail uses hover technology stolen from\nthe Imperium to allow movement over a broader range\nof terrain types. Hauling three electro-magnetic projectile\naccelerator cannons, or rail guns, this tank is a savage\nconsumer of Imperium armour.\n\nType: Hover\nSpeed: Medium\nWeapon: Triple Rail td_nod_gunturret\nRange: Long\nArmor: Heavy
+		Description: The pinnacle of Freedom Guard\narmour, the Triple Rail uses hover technology stolen from\nthe Imperium to allow movement over a broader range\nof terrain types. Hauling three electro-magnetic projectile\naccelerator cannons, or rail guns, this tank is a savage\nconsumer of Imperium armour.\n\nType: Hover\nSpeed: Medium\nWeapon: Triple Rail Gun\nRange: Long\nArmor: Heavy
 	Mobile:
 		Locomotor: hover
 		TurnSpeed: 32
@@ -4585,14 +4585,14 @@ drskybike:
 	Valued:
 		Cost: 850
 	Tooltip:
-		Name: Sky td_nod_reconbike
+		Name: Sky Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: drfgweap2, drfghelipad, ~techlevel.medium
 		Queue: Vehicle, RAVehicle
-		Description: Using a modified Spider td_nod_reconbike chassis, the\nFreedom Guard were able to produce cheap, fast aerial\nunits which could attack enemy ground troops and other\nflyers. Although quicker than the Imperium Cyclone, the\nSky td_nod_reconbike is not as heavily armoured and is outgunned in\neven combat. The speed of the Sky td_nod_reconbike, however, allows\nit to dictate the circumstance of conflict. This unit fires\nhigh-velocity mini-missiles and, like the Outrider, must rearm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Mini Missiles\nRange: Short\nArmor: Light
+		Description: Using a modified Spider Bike chassis, the\nFreedom Guard were able to produce cheap, fast aerial\nunits which could attack enemy ground troops and other\nflyers. Although quicker than the Imperium Cyclone, the\nSky Bike is not as heavily armoured and is outgunned in\neven combat. The speed of the Sky Bike, however, allows\nit to dictate the circumstance of conflict. This unit fires\nhigh-velocity mini-missiles and, like the Outrider, must rearm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Mini Missiles\nRange: Short\nArmor: Light
 	Aircraft:
 		TurnSpeed: 36
 		Speed: 210
@@ -4645,7 +4645,7 @@ droutrider:
 		BuildPaletteOrder: 20
 		Prerequisites: drfgweap2, drfghelipad, ~techlevel.medium
 		Queue: Vehicle, RAVehicle
-		Description: This ground attack aerial unit is slower and less\nmanoeuvrable than the Sky td_nod_reconbike, but considerably tougher\nand fires air to ground missiles. Deadly effective against\nImperium armour, it cannot engage other air units and\nshould be escorted by air defence units. The Outrider has\nlimited ammunition and must re-arm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Guided Missile\nRange: Long\nArmor: Heavy
+		Description: This ground attack aerial unit is slower and less\nmanoeuvrable than the Sky Bike, but considerably tougher\nand fires air to ground missiles. Deadly effective against\nImperium armour, it cannot engage other air units and\nshould be escorted by air defence units. The Outrider has\nlimited ammunition and must re-arm at the Re-Arming Deck\n\nType: Flyer\nSpeed: Fast\nWeapon: Guided Missile\nRange: Long\nArmor: Heavy
 	Aircraft:
 		TurnSpeed: 36
 		Speed: 210
@@ -5186,7 +5186,7 @@ drreaper:
 		BuildPaletteOrder: 30
 		Prerequisites: barracks, drmadrix.shadowhand
 		Queue: Infantry, RAInfantry
-		Description: Shock ra1_allies_alliedsniper Infantry.\n  Strong vs Light Vehicles and Creatures \n  Weak vs Infantry
+		Description: Shock Sniper Infantry.\n  Strong vs Light Vehicles and Creatures \n  Weak vs Infantry
 	Mobile:
 		Speed: 50
 	Health:
@@ -6760,7 +6760,7 @@ drshok:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: ra1_soviet_shocktrooper Trooper
+		Name: Shok Trooper
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -7869,7 +7869,7 @@ drrasta:
 		BuildPaletteOrder: 10
 		Prerequisites: anypower
 		Queue: Infantry, RAInfantry
-		Description: The Low Rank Infantry\nThe Second Veterancy adquire Grenade Launcher\nThe Next Veterancy adquire Better Laser td_nod_gunturret\nThe Ultimate Veterancy transform into Jail Breaker\nThe Jail Breaker with veterancy can sabotage and attach C4 in vehicles.\n\nType: Infantry\nSpeed: Slow\nWeapon: Small Laser, Gremades, C4s\nRange: Medium\nArmor: None
+		Description: The Low Rank Infantry\nThe Second Veterancy adquire Grenade Launcher\nThe Next Veterancy adquire Better Laser Gun\nThe Ultimate Veterancy transform into Jail Breaker\nThe Jail Breaker with veterancy can sabotage and attach C4 in vehicles.\n\nType: Infantry\nSpeed: Slow\nWeapon: Small Laser, Gremades, C4s\nRange: Medium\nArmor: None
 	Mobile:
 		Speed: 80
 	Health:
@@ -10569,7 +10569,7 @@ drdsupport:
 	Valued:
 		Cost: 500 #300
 	Tooltip:
-		Name: Support ra1_allies_alliedbarracks
+		Name: Support Tent
 	Building:
 		Footprint: xx xx ==
 		Dimensions: 2,3

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -1250,7 +1250,7 @@
 	KeepsDistance:
 		Distance: 10
 	TooltipExtras@ra1_allies_alliedsniper:
-		Description: ra1_allies_alliedsniper
+		Description: Sniper
 	GrantExternalConditionToTransport:
 		Condition: ifv-ra1_allies_alliedsniper
 

--- a/mods/cameo/rules/dune2.yaml
+++ b/mods/cameo/rules/dune2.yaml
@@ -2005,7 +2005,7 @@ dunespaceport:
 		Icon: dune2carry
 		ChargeInterval: 3000
 		Name: Reinforcement
-		Description: Spawns a ixian_autonomouscarryall with Vehicles.
+		Description: Spawns a Carryall with Vehicles.
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		EndChargeSpeechNotification: SpyPlaneReady
@@ -2060,7 +2060,7 @@ dunepalace:
 		RequiresCondition: harkonnen
 		Prerequisites: ~techlevel.superweapons
 		ChargeInterval: 7500
-		Name: Death td_nod_handofnod
+		Name: Death Hand
 		Description: Launches an atomic missile at a target location
 		BeginChargeSpeechNotification: DeathHandCharging
 		InsufficientPowerSpeechNotification: InsufficientPower
@@ -2149,7 +2149,7 @@ dunepalace:
 dunecarryall.starport:
 	Inherits: ^Plane
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 326
@@ -2181,7 +2181,7 @@ dunecarryall.reinforce:
 	Valued:
 		Cost: 1500
 	Tooltip:
-		Name: Autonomous ixian_autonomouscarryall
+		Name: Autonomous Carryall
 	Health:
 		HP: 160000
 	Armor:
@@ -2271,7 +2271,7 @@ dunecarryall.buy:
 dunecarryall.husk:
 	Inherits: ^HelicopterHusk
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 149
@@ -2288,7 +2288,7 @@ dunecarryall.husk:
 dunecarryall.huskair:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ixian_autonomouscarryall
+		Name: Carryall
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 186

--- a/mods/cameo/rules/generals.yaml
+++ b/mods/cameo/rules/generals.yaml
@@ -8692,7 +8692,7 @@ upneutronshell:
 upmigarmor:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Armor
+		Name: MiG Armor
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
@@ -8744,7 +8744,7 @@ upsubliminal:
 upmignuke:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Tactical Nuke ra1_soviet_migattackbomber
+		Name: Tactical Nuke MiG
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
@@ -8804,7 +8804,7 @@ CHMIG:
 	Valued:
 		Cost: 1200
 	Tooltip:
-		Name: ra1_soviet_migattackbomber
+		Name: MiG
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -8913,7 +8913,7 @@ CHMIG2:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: Tactical Nuke ra1_soviet_migattackbomber
+		Name: Tactical Nuke MiG
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -8995,7 +8995,7 @@ CHMIG2:
 chmig.husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ra1_soviet_migattackbomber
+		Name: MiG
 	Contrail@1:
 		Offset: -598,-683,0
 	Contrail@2:
@@ -9824,7 +9824,7 @@ usapath:
 	Buildable:
 		BuildPaletteOrder: 20
 		Queue: Infantry, RAInfantry
-		Description: Stealthed ra1_allies_alliedsniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: Stealthed sniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
 		Prerequisites: barracks, upusapath, ~!anysusa
 	Valued:
 		Cost: 600
@@ -12981,7 +12981,7 @@ usauptowmiss:
 usaupdronegun:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Sentry Drone td_nod_gunturret
+		Name: Sentry Drone Gun
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
@@ -13493,7 +13493,7 @@ usauwusupply:
 		Queue: Vehicle, RAVehicle
 		Prerequisites: usasupply
 		BuildPaletteOrder: 120
-		Description: Transports cash other players.\n Armed with self-defense machine td_nod_gunturret
+		Description: Transports cash other players.\n Armed with self-defense machine gun
 	Turreted:
 		Offset: -10,0,150
 	Armament:

--- a/mods/cameo/rules/halloween.yaml
+++ b/mods/cameo/rules/halloween.yaml
@@ -264,7 +264,7 @@ halloween_clowntent:
 	Valued:
 		Cost: 750
 	Tooltip:
-		Name: Clown ra1_allies_alliedbarracks
+		Name: Clown Tent
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:

--- a/mods/cameo/rules/heroes.yaml
+++ b/mods/cameo/rules/heroes.yaml
@@ -637,13 +637,13 @@ volkovcc:
 		Queue: Heroes
 		BuildPaletteOrder: 140
 		Prerequisites: ra2_soviets_warfactory, ra2_soviets_battlelab, ~techlevel.high, ~anysovietsallra, !1hero
-		Description: Controls and provides ra1_soviet_volkov\nBuilding must be sold and rebuilt for another ra1_soviet_volkov to appear
+		Description: Controls and provides Volkov\nBuilding must be sold and rebuilt for another Volkov to appear
 		IconPalette: ra2
 		BuildLimit: 1
 	Valued:
 		Cost: 3000
 	Tooltip:
-		Name: ra1_soviet_volkov Control Center
+		Name: Volkov Control Center
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -679,7 +679,7 @@ ra1_soviet_volkov:
 	Inherits: GNRL
 	-Buildable:
 	Tooltip:
-		Name: ra1_soviet_volkov
+		Name: Volkov
 	Armament:
 		Weapon: RA2VolkovGun
 	Health:
@@ -974,7 +974,7 @@ TSNASHWA:
 		Queue: Heroes
 		BuildPaletteOrder: 120
 		Prerequisites: !1hero, ~anynod
-		Description: Permanently Stealthed until her weapon is fully charged up\nCan call Nod td_nod_reconbike
+		Description: Permanently Stealthed until her weapon is fully charged up\nCan call Nod Bike
 		IconPalette: ra2
 		BuildDuration: 500
 		BuildDurationModifier: 100
@@ -1075,7 +1075,7 @@ TSNASHWABIKE:
 	Buildable:
 		BuildPaletteOrder: 30
 		Queue: NashwaBike.TSNod
-		Description: Autonomous td_nod_reconbike that helps Nashwa get over long distances\nShoots flame rockets
+		Description: Autonomous Bike that helps Nashwa get over long distances\nShoots flame rockets
 		Prerequisites: ~!TSNASHWABIKE
 		BuildLimit: 1
 		IconPalette: ra2
@@ -1091,7 +1091,7 @@ TSNASHWABIKE:
 	Health:
 		HP: 40000
 	Tooltip:
-		Name: Nod td_nod_reconbike
+		Name: Nod Bike
 	RenderSprites:
 		Image: tsnashwabike
 	WithFacingSpriteBody:
@@ -1138,7 +1138,7 @@ TSNASHWABIKE.cd:
 	ProvidesPrerequisite@nashwabike:
 		Prerequisite: TSNASHWABIKE
 	Tooltip:
-		Name: Nod td_nod_reconbike (Destroyed)
+		Name: Nod Bike (Destroyed)
 	RenderSprites:
 		Image: TSNASHWABIKE
 	KillsSelf:
@@ -1329,7 +1329,7 @@ mutantseverus:
 		Queue: Heroes
 		BuildPaletteOrder: 120
 		Prerequisites: !1hero, ~faction.forgotten
-		Description: Unable to use his left td_nod_handofnod and full of hatred - he is equipped with Tiberium Flachette SMG and\npowerful aura that spreads radiation which hurts enemies but heals allies
+		Description: Unable to use his left hand and full of hatred - he is equipped with Tiberium Flachette SMG and\npowerful aura that spreads radiation which hurts enemies but heals allies
 		IconPalette: ra2
 		BuildDuration: 500
 		BuildDurationModifier: 100
@@ -1416,7 +1416,7 @@ severuscabal:
 		Queue: Heroes
 		BuildPaletteOrder: 120
 		Prerequisites: !1hero, ~faction.cabal
-		Description: Unable to use his left td_nod_handofnod and full of hatred - he is equipped with Super Shotgun and\npowerful aura that spreads radiation which hurts enemies but heals allies
+		Description: Unable to use his left hand and full of hatred - he is equipped with Super Shotgun and\npowerful aura that spreads radiation which hurts enemies but heals allies
 		BuildDuration: 500
 		BuildDurationModifier: 100
 	Valued:
@@ -2854,7 +2854,7 @@ Rockets:
 Spreader:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Multi-direction photon td_nod_gunturret
+		Name: Multi-direction photon gun
 	Buildable:
 		BuildPaletteOrder: 20
 		Queue: Upgrade.Contestant
@@ -2918,11 +2918,11 @@ Speedboost:
 Orb:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Machine td_nod_gunturret firing remote
+		Name: Machine gun firing remote
 	Buildable:
 		BuildPaletteOrder: 60
 		Queue: Upgrade.Contestant
-		Description: Machine td_nod_gunturret firing remote.\n Increases attack range by 1 tile.
+		Description: Machine gun firing remote.\n Increases attack range by 1 tile.
 		Prerequisites: ~1hero
 	Valued:
 		Cost: 1000
@@ -3117,11 +3117,11 @@ mdkchaingun:
 mdkmortar:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Mortar ra1_allies_alliedsniper
+		Name: Mortar Sniper
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Upgrade.Kurt
-		Description: Kurt uses Mortar aganist buildings in ra1_allies_alliedsniper Mode
+		Description: Kurt uses Mortar aganist buildings in Sniper Mode
 		Prerequisites: ~1hero
 	Valued:
 		Cost: 1000
@@ -3132,11 +3132,11 @@ mdkmortar:
 mdkmissile:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Mortar ra1_allies_alliedsniper
+		Name: Mortar Sniper
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Upgrade.Kurt
-		Description: Kurt uses Missiles aganist vehicles in ra1_allies_alliedsniper Mode
+		Description: Kurt uses Missiles aganist vehicles in Sniper Mode
 		Prerequisites: ~1hero
 	Valued:
 		Cost: 1000

--- a/mods/cameo/rules/husks.yaml
+++ b/mods/cameo/rules/husks.yaml
@@ -19,7 +19,7 @@ HARV.Husk:
 APC.Husk:
 	Inherits: ^LightHusk
 	Tooltip:
-		Name: td_gdi_apc (Destroyed)
+		Name: APC (Destroyed)
 	TransformOnCapture:
 		IntoActor: td_gdi_apc
 	RenderSprites:
@@ -55,7 +55,7 @@ BGGY.Husk:
 BIKE.Husk:
 	Inherits: ^LightHusk
 	Tooltip:
-		Name: Recon td_nod_reconbike (Destroyed)
+		Name: Recon Bike (Destroyed)
 	TransformOnCapture:
 		IntoActor: td_nod_reconbike
 	RenderSprites:
@@ -273,7 +273,7 @@ jsuperbomber.Husk:
 MIG.Husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Attack Plane
+		Name: MiG Attack Plane
 	Contrail@1:
 		Offset: -598,-683,0
 	Contrail@2:
@@ -319,7 +319,7 @@ su57.Husk:
 YAK.Husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ra1_soviet_yakscoutplane Attack Plane
+		Name: Yak Attack Plane
 	Contrail:
 		Offset: -853,0,0
 	Aircraft:
@@ -416,7 +416,7 @@ HELI.Husk:
 HIND.Husk:
 	Inherits: ^LargeHelicopterHusk
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter
+		Name: Hind
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 112
@@ -437,7 +437,7 @@ HIND.Husk:
 ra_kamov.Husk:
 	Inherits: ^LargeHelicopterHusk
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter
+		Name: Hind
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 112

--- a/mods/cameo/rules/keeper.yaml
+++ b/mods/cameo/rules/keeper.yaml
@@ -5,7 +5,7 @@ keeperdirt:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: Carvable Dirt ixian_concretewall
+		Name: Carvable Dirt Wall
 	Health:
 		HP: 12000
 	Armor:
@@ -30,7 +30,7 @@ keeperwall:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: Dungeon ixian_concretewall
+		Name: Dungeon Wall
 	Health:
 		HP: 44000
 	Armor:
@@ -55,7 +55,7 @@ keeperbedrock:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: Rock ixian_concretewall
+		Name: Rock Wall
 	Health:
 		HP: 9999999
 	Armor:

--- a/mods/cameo/rules/lostunits.yaml
+++ b/mods/cameo/rules/lostunits.yaml
@@ -1,7 +1,7 @@
 NODWEAP:
 	Inherits: td_gdi_weaponsfactory
 	Tooltip:
-		Name: Black td_nod_handofnod Factory
+		Name: Black Hand Factory
 	-Buildable:
 	Production@NORMAL:
 		Produces: Vehicle
@@ -72,7 +72,7 @@ RNV2RL:
 RNAPC.Husk:
 	Inherits: ^LightHusk
 	Tooltip:
-		Name: Nod td_gdi_apc (Destroyed)
+		Name: Nod APC (Destroyed)
 	TransformOnCapture:
 		IntoActor: rnapc
 	RenderSprites:
@@ -140,7 +140,7 @@ RNFTNK.Husk:
 NODBIO:
 	Inherits: bio
 	Tooltip:
-		Name: Black td_nod_handofnod Biological Lab
+		Name: Black Hand Biological Lab
 	TooltipDescription@ally:
 		Description: Produces special infantry units.
 	TooltipDescription@other:
@@ -160,7 +160,7 @@ NODBIO:
 NODBIO.Husk:
 	Inherits: bio.Husk
 	Tooltip:
-		Name: Black td_nod_handofnod Biological Lab (Destroyed)
+		Name: Black Hand Biological Lab (Destroyed)
 
 RNE4:
 	Inherits: td_nod_flamethrower
@@ -344,7 +344,7 @@ techgdrone:
 	Valued:
 		Cost: 100
 	Tooltip:
-		Name: GDI Pistol td_gdi_orca
+		Name: GDI Pistol Orca
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -855,7 +855,7 @@ BHMIG:
 	Tooltip:
 		Name: Black Plane
 	Armament@GUNS:
-		Name: td_nod_gunturret
+		Name: gun
 		Weapon: TSTurretLaserFire
 		LocalOffset: 1024,0,-85
 	Armament@BOMBS:
@@ -986,7 +986,7 @@ BHBRIK:
 BHBIKE:
 	Inherits: td_nod_reconbike
 	Tooltip:
-		Name: Black td_nod_reconbike
+		Name: Black Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -1004,7 +1004,7 @@ BHAPC:
 	Valued:
 		Cost: 550
 	Tooltip:
-		Name: Nod td_gdi_apc
+		Name: Nod APC
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 40

--- a/mods/cameo/rules/mcvmarket.yaml
+++ b/mods/cameo/rules/mcvmarket.yaml
@@ -504,7 +504,7 @@ mmmcv.imperium:
 mmmcv.shadowhand:
 	Inherits@MCV: mcv.shadowhand
 	Tooltip:
-		Name: Construction Rig (Shadow td_nod_handofnod)
+		Name: Construction Rig (Shadow Hand)
 	Buildable:
 		BuildPaletteOrder: 310
 		-Description:
@@ -549,7 +549,7 @@ mmmcv.xenite:
 mmmcv.togran:
 	Inherits@MCV: mcv.togran
 	Tooltip:
-		Name: Construction Rig (Shadow td_nod_handofnod)
+		Name: Construction Rig (Shadow Hand)
 	Buildable:
 		BuildPaletteOrder: 310
 		-Description:

--- a/mods/cameo/rules/mindustry.yaml
+++ b/mods/cameo/rules/mindustry.yaml
@@ -194,7 +194,7 @@ mindclass_turret_2:
 		Prerequisites: mindclass_drill1
 		Queue: Defence.MindustryClassic, RADefence.MindustryClassic
 		BuildDurationModifier: 40
-		Description: Twin td_nod_gunturret defense.\n  Uses stone munition
+		Description: Twin gun defense.\n  Uses stone munition
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 8
@@ -261,7 +261,7 @@ mindclass_turret_3:
 		Prerequisites: mindclass_drill2
 		Queue: Defence.MindustryClassic, RADefence.MindustryClassic
 		BuildDurationModifier: 40
-		Description: Basic cheap defense.\n  Uses ra1_soviet_ironcurtain munition
+		Description: Basic cheap defense.\n  Uses iron munition
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 8
@@ -328,7 +328,7 @@ mindclass_turret_4:
 		Prerequisites: mindclass_drill2
 		Queue: Defence.MindustryClassic, RADefence.MindustryClassic
 		BuildDurationModifier: 40
-		Description: Twin td_nod_gunturret defense.\n  Uses ra1_soviet_ironcurtain munition
+		Description: Twin gun defense.\n  Uses iron munition
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 8
@@ -395,7 +395,7 @@ mindclass_turret_5:
 		Prerequisites: mindclass_drill3, mindclass_furnace
 		Queue: Defence.MindustryClassic, RADefence.MindustryClassic
 		BuildDurationModifier: 40
-		Description: Twin td_nod_gunturret defense.\n  Uses coal munition
+		Description: Twin gun defense.\n  Uses coal munition
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 8
@@ -459,7 +459,7 @@ mindclass_turret_6:
 		Prerequisites: mindclass_furnace
 		Queue: Defence.MindustryClassic, RADefence.MindustryClassic
 		BuildDurationModifier: 40
-		Description: Twin td_nod_gunturret defense.\n  Uses steel munition
+		Description: Twin gun defense.\n  Uses steel munition
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 8
@@ -705,12 +705,12 @@ mindclass_drill2:
 	Valued:
 		Cost: 400
 	Tooltip:
-		Name: ra1_soviet_ironcurtain Drill
+		Name: Iron Drill
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: mindclass_drill1
 		Queue: Building.MindustryClassic, RABuilding.MindustryClassic
-		Description: Produces Resources and ra1_soviet_ironcurtain
+		Description: Produces Resources and Iron
 	Building:
 		Footprint: x
 		Dimensions: 1,1
@@ -879,7 +879,7 @@ mindclass_furnace:
 		BuildPaletteOrder: 10
 		Prerequisites: mindclass_drill2
 		Queue: Building.MindustryClassic, RABuilding.MindustryClassic
-		Description: Produces Resources and Steel .\n Requires Coal and ra1_soviet_ironcurtain connection to work
+		Description: Produces Resources and Steel .\n Requires Coal and Iron connection to work
 	Building:
 		Footprint: x
 		Dimensions: 1,1

--- a/mods/cameo/rules/n64.yaml
+++ b/mods/cameo/rules/n64.yaml
@@ -539,7 +539,7 @@ N64HAND:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: td_nod_handofnod of Nod
+		Name: Hand of Nod
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
@@ -1405,7 +1405,7 @@ N64SAM:
 	Valued:
 		Cost: 650
 	Tooltip:
-		Name: td_nod_samsite site
+		Name: SAM site
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Defence, RADefence
@@ -2122,7 +2122,7 @@ N64BIKE:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Recon td_nod_reconbike
+		Name: Recon Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -2311,7 +2311,7 @@ N64APC:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: td_gdi_apc
+		Name: APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 		OverrideActor: td_gdi_apc
@@ -2727,7 +2727,7 @@ N64ORCA:
 	Valued:
 		Cost: 1200
 	Tooltip:
-		Name: td_gdi_orca
+		Name: Orca
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:

--- a/mods/cameo/rules/redalert.yaml
+++ b/mods/cameo/rules/redalert.yaml
@@ -1321,7 +1321,7 @@ ra1_soviet_dragunovantimaterialsniper:
 	Inherits@AntiTank: ^PrioritizeTank
 	Inherits@SuperOpticsPromotionRA1: ^SuperOpticsPromotionRA1
 	Tooltip:
-		Name: Dragunov Anti Material ra1_allies_alliedsniper
+		Name: Dragunov Anti Material Sniper
 	Valued:
 		Cost: 400
 	UpdatesPlayerStatistics:
@@ -1852,7 +1852,7 @@ ra1_allies_alliedsniper:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Allied ra1_allies_alliedsniper
+		Name: Allied Sniper
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -2943,7 +2943,7 @@ ra1_soviet_kotinnucleartank:
 	Valued:
 		Cost: 1800
 	Tooltip:
-		Name: ra1_soviet_kotinnucleartank Nuclear Tank
+		Name: Kotin Nuclear Tank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -3698,7 +3698,7 @@ RAAPC:
 	Valued:
 		Cost: 1300
 	Tooltip:
-		Name: Allied td_gdi_apc
+		Name: Allied APC
 	Buildable:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 120
@@ -4520,7 +4520,7 @@ ra1_soviet_yakscoutplane:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: ra1_soviet_yakscoutplane Scout Plane
+		Name: Yak Scout Plane
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -4619,7 +4619,7 @@ ra1_soviet_teslayak:
 	Inherits@StaliniumTeamUpgradeRA1: ^StaliniumTeamUpgradeRA1
 	Inherits@eject: ^AircraftEjectOnDeath
 	Tooltip:
-		Name: Tesla ra1_soviet_yakscoutplane
+		Name: Tesla Yak
 	Valued:
 		Cost: 2000
 	Buildable:
@@ -4746,7 +4746,7 @@ ra1_soviet_armoredyak:
 	Valued:
 		Cost: 1600
 	Tooltip:
-		Name: Armored ra1_soviet_yakscoutplane
+		Name: Armored Yak
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -4837,7 +4837,7 @@ ra1_soviet_nuclearyak:
 	Inherits@StaliniumTeamUpgradeRA1: ^StaliniumTeamUpgradeRA1
 	Inherits@eject: ^AircraftEjectOnDeath
 	Tooltip:
-		Name: Nuclear ra1_soviet_yakscoutplane
+		Name: Nuclear Yak
 	Valued:
 		Cost: 2000
 	Buildable:
@@ -5160,7 +5160,7 @@ ra1_soviet_migattackbomber:
 	Valued:
 		Cost: 1400
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Attack Bomber
+		Name: Mig Attack Bomber
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -5400,7 +5400,7 @@ ra1_soviet_hindattackhelicopter:
 	Valued:
 		Cost: 1800
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter Attack Helicopter
+		Name: Hind Attack Helicopter
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -8457,15 +8457,15 @@ ra1_soviet_airfield:
 			20: Soviet Paratroopers (Mortar Soldier, Inferno, Tesla Tech)
 			21: Soviet Paratroopers (Mortar Soldier, Inferno, Heavy Armor)
 			22: Soviet Paratroopers (Mortar Soldier, Inferno, Nuclear War)
-			23: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Tesla Tech)
-			24: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Heavy Armor)
-			25: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Conscription, Nuclear War)
-			26: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Tesla Tech)
-			27: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Heavy Armor)
-			28: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Industrial, Nuclear War)
-			29: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Tesla Tech)
-			30: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Heavy Armor)
-			31: Soviet Paratroopers (Mortar Soldier, ra1_soviet_cyberdog, Inferno, Nuclear War)
+			23: Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Tesla Tech)
+			24: Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Heavy Armor)
+			25: Soviet Paratroopers (Mortar Soldier, Cyberdog, Conscription, Nuclear War)
+			26: Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Tesla Tech)
+			27: Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Heavy Armor)
+			28: Soviet Paratroopers (Mortar Soldier, Cyberdog, Industrial, Nuclear War)
+			29: Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Tesla Tech)
+			30: Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Heavy Armor)
+			31: Soviet Paratroopers (Mortar Soldier, Cyberdog, Inferno, Nuclear War)
 		Descriptions:
 			1: power_paratroopers.description
 			2: power_paratroopers.description
@@ -9153,7 +9153,7 @@ ra1_soviet_ironcurtain:
 		Prerequisites: ~ra1_soviet_techcenter, ~techlevel.superweapons
 		Description: actor_iron.description
 	Tooltip:
-		Name: ra1_soviet_ironcurtain Curtain
+		Name: Iron Curtain
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -9456,7 +9456,7 @@ ra1_allies_alliedgunturret:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: Allied td_nod_gunturret Turret
+		Name: Allied Gun Turret
 	Building:
 		BuildSounds: placbldg.aud, build5.aud
 	Health:
@@ -9504,7 +9504,7 @@ ra1_allies_alliedaagun:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Allied AA td_nod_gunturret
+		Name: Allied AA Gun
 	Selectable:
 		Bounds: 1024, 1440, 0, -240
 	SelectionDecorations:
@@ -9685,7 +9685,7 @@ ra1_soviet_samsite:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: Soviet td_nod_samsite Site
+		Name: Soviet SAM Site
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
@@ -10087,11 +10087,11 @@ ra1_allies_promotion_unlockmachinegunner:
 ra1_allies_promotion_unlocksheridan:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock ra1_allies_sheridanassaulttank
+		Name: Unlock Sheridan
 	Buildable:
 		BuildPaletteOrder: 28
 		Queue: Promotions
-		Description: Allows construction of the ra1_allies_sheridanassaulttank Light Tank.
+		Description: Allows construction of the Sheridan Light Tank.
 		Prerequisites: ~ra1_allies_alliedconstructionyard, !ra1_allies_promotion_unlocksheridan, ra1_allies_promotion_unlockmachinegunner, rank1
 	RenderSprites:
 		Image: ra1_allies_sheridanassaulttank
@@ -10227,11 +10227,11 @@ ra1_allies_promotion_unlockbastion:
 ra1_allies_promotion_unlockgapgeneratorandradarjammer:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock ra1_allies_gapgenerator Generator and Radar Jammer
+		Name: Unlock Gap Generator and Radar Jammer
 	Buildable:
 		BuildPaletteOrder: 36
 		Queue: Promotions
-		Description: Allows construction of the ra1_allies_gapgenerator Generator and Mobile Radar Jammer.
+		Description: Allows construction of the Gap Generator and Mobile Radar Jammer.
 		Prerequisites: ~ra1_allies_alliedconstructionyard, !ra1_allies_promotion_unlockgapgeneratorandradarjammer, ra1_allies_promotion_unlockbastion, rank1
 	RenderSprites:
 		Image: gapgeneratorradarjammer
@@ -10314,7 +10314,7 @@ ra1_allies_sheridanassaulttank:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: ra1_allies_sheridanassaulttank Assault Tank
+		Name: Sheridan Assault Tank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -11244,7 +11244,7 @@ ra1_allies_gapgenerator:
 	Valued:
 		Cost: 5000
 	Tooltip:
-		Name: ra1_allies_gapgenerator Generator
+		Name: Gap Generator
 	Building:
 		BuildSounds: placbldg.aud, build5.aud
 	Buildable:
@@ -11321,7 +11321,7 @@ ra1_allies_mobilegapgenerator:
 		Prerequisites: ~ra1_allies_alliedwarfactory, ra1_allies_alliedtechcenter, ra1_allies_promotion_unlockgapgeneratorandradarjammer
 		Description: actor_mgg.description
 	Tooltip:
-		Name: Mobile ra1_allies_gapgenerator Generator
+		Name: Mobile Gap Generator
 	Valued:
 		Cost: 5000
 	UpdatesPlayerStatistics:
@@ -12082,9 +12082,9 @@ ra1_soviet_upgrade_shtoradefensesystem:
 ra1_soviet_upgrade_kotinnucleartank:
 	Inherits: ^unit_upgrade_template
 	Tooltip:
-		Name: ra1_soviet_kotinnucleartank Nuclear Tank Upgrade
+		Name: Kotin Nuclear Tank Upgrade
 	Buildable:
-		Description: Upgrades the Hammer Tank to the ra1_soviet_kotinnucleartank Nuclear Tank
+		Description: Upgrades the Hammer Tank to the Kotin Nuclear Tank
 		Prerequisites: ~ra1_soviet_techcenter, ~ra1_soviet_doctrine_nuclearwar, ra1_soviet_upgrade_hammertank, !ra1_soviet_upgrade_kotinnucleartank
 	RenderSprites:
 		Image: ra1_soviet_kotinnucleartank
@@ -12112,9 +12112,9 @@ ra1_soviet_upgrade_unlockheatraytank:
 ra1_soviet_upgrade_unlockteslayak:
 	Inherits: ^unit_upgrade_template
 	Tooltip:
-		Name: Unlock Tesla ra1_soviet_yakscoutplane
+		Name: Unlock Tesla Yak
 	Buildable:
-		Description: Upgrades the ra1_soviet_yakscoutplane into the Tesla Yak.
+		Description: Upgrades the Yak into the Tesla Yak.
 		Prerequisites: ~ra1_soviet_radardome, ~ra1_soviet_doctrine_teslaandexperimentaltech, !ra1_soviet_upgrade_unlockteslayak
 	RenderSprites:
 		Image: ra1_soviet_teslayak
@@ -12122,9 +12122,9 @@ ra1_soviet_upgrade_unlockteslayak:
 ra1_soviet_upgrade_unlockarmoredyak:
 	Inherits: ^unit_upgrade_template
 	Tooltip:
-		Name: Unlock Armored ra1_soviet_yakscoutplane
+		Name: Unlock Armored Yak
 	Buildable:
-		Description: Upgrades the ra1_soviet_yakscoutplane into the Armored Yak.
+		Description: Upgrades the Yak into the Armored Yak.
 		Prerequisites: ~ra1_soviet_radardome, ~ra1_soviet_doctrine_heavyarmor, !ra1_soviet_upgrade_unlockarmoredyak
 	RenderSprites:
 		Image: ra1_soviet_armoredyak
@@ -12132,9 +12132,9 @@ ra1_soviet_upgrade_unlockarmoredyak:
 ra1_soviet_upgrade_unlocknuclearyak:
 	Inherits: ^unit_upgrade_template
 	Tooltip:
-		Name: Unlock Nuclear ra1_soviet_yakscoutplane
+		Name: Unlock Nuclear Yak
 	Buildable:
-		Description: Upgrades the ra1_soviet_yakscoutplane into the Nuclear Yak.
+		Description: Upgrades the Yak into the Nuclear Yak.
 		Prerequisites: ~ra1_soviet_radardome, ~ra1_soviet_doctrine_nuclearwar, !ra1_soviet_upgrade_unlocknuclearyak
 	RenderSprites:
 		Image: ra1_soviet_nuclearyak
@@ -12311,7 +12311,7 @@ ra1_soviet_promotion_unlockmortarsoldier:
 ra1_soviet_promotion_unlockcyberdog:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock ra1_soviet_cyberdog
+		Name: Unlock Cyberdog
 	Buildable:
 		BuildPaletteOrder: 43
 		Queue: Promotions
@@ -12325,7 +12325,7 @@ ra1_soviet_promotion_unlockcyberdog:
 ra1_soviet_promotion_unlockvolkov:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock ra1_soviet_volkov
+		Name: Unlock Volkov
 	Buildable:
 		BuildPaletteOrder: 46
 		Queue: Promotions
@@ -12468,11 +12468,11 @@ ra1_soviet_cyberdog:
 		Queue: Infantry, RAInfantry
 		BuildPaletteOrder: 29
 		Prerequisites: ~ra1_soviet_promotion_unlockcyberdog, ~ra1_soviet_barracks
-		Description: Cybernetically modified ra1_soviet_attackdog that is far more durable and can attack vehicles.
+		Description: Cybernetically modified dog that is far more durable and can attack vehicles.
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: ra1_soviet_cyberdog
+		Name: Cyberdog
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Selectable:
@@ -12586,7 +12586,7 @@ ra1_soviet_volkov:
 		Prerequisites: ~ra1_soviet_barracks, ra1_soviet_techcenter, ra1_soviet_promotion_unlockvolkov
 		Description: actor_volkov.description
 	Tooltip:
-		Name: ra1_soviet_volkov
+		Name: Volkov
 	Valued:
 		Cost: 10000
 	Armament:

--- a/mods/cameo/rules/redalert2.yaml
+++ b/mods/cameo/rules/redalert2.yaml
@@ -987,7 +987,7 @@ ra2_allies_gapgenerator:
 	Valued:
 		Cost: 5000
 	Tooltip:
-		Name: ra1_allies_gapgenerator Generator
+		Name: Gap Generator
 	Buildable:
 		BuildLimit: 1
 		BuildDuration: 1500
@@ -2000,7 +2000,7 @@ ra2_soviets_ironcurtain:
 		Prerequisites: ~ra2_soviets_constructionyard, ra2_soviets_battlelab, ~techlevel.superweapons
 		Description: actor_iron.description
 	Tooltip:
-		Name: ra1_soviet_ironcurtain Curtain
+		Name: Iron Curtain
 	Building:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3
@@ -2118,7 +2118,7 @@ ra2_soviets_sentrygun:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Sentry td_nod_gunturret
+		Name: Sentry Gun
 	Building:
 		Footprint: x
 		Dimensions: 1,1
@@ -3262,7 +3262,7 @@ ra2_allies_attackdog:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: Attack ra1_soviet_attackdog
+		Name: Attack Dog
 		GenericName: ra1_soviet_attackdog
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
@@ -3720,7 +3720,7 @@ ra2_allies_sniper:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: ra1_allies_alliedsniper
+		Name: Sniper
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~ra2_allies_alliedbarracks, ra2_allies_alliedbattlelab
@@ -4025,7 +4025,7 @@ ra2_soviets_attackdog:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: Attack ra1_soviet_attackdog
+		Name: Attack Dog
 		GenericName: ra1_soviet_attackdog
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
@@ -5876,10 +5876,10 @@ ra2_allies_ifv:
 		RequiresCondition: ifv-demo
 	###############
 	Tooltip@MG:
-		Name: Machine td_nod_gunturret IFV
+		Name: Machine Gun IFV
 		RequiresCondition: ifv-mg || ifv-thief
 	Tooltip@HMG:
-		Name: Heavy Machine td_nod_gunturret IFV
+		Name: Heavy Machine Gun IFV
 		RequiresCondition: ifv-hmg
 	Tooltip@MISS:
 		Name: Missile IFV
@@ -5888,7 +5888,7 @@ ra2_allies_ifv:
 		Name: Repair IFV
 		RequiresCondition: ifv-repair
 	Tooltip@SNIPE:
-		Name: ra1_allies_alliedsniper IFV
+		Name: Sniper IFV
 		RequiresCondition: ifv-ra1_allies_alliedsniper
 	Tooltip@HERO:
 		Name: Hero IFV
@@ -8821,7 +8821,7 @@ yrbpln:
 	Inherits@RA2SovietTeslaDischargeArmor: ^RA2SovietTeslaDischargeArmor
 	Selectable:
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Bomber
+		Name: MiG Bomber
 	Buildable:
 		Description: template_airstrike_slave.description
 	Valued:
@@ -8925,7 +8925,7 @@ ra2_soviets_migbomber:
 	Inherits@RA2SovietTeslaDischargeArmor: ^RA2SovietTeslaDischargeArmor
 	Selectable:
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Bomber
+		Name: MiG Bomber
 	Valued:
 		Cost: 2000
 	Buildable:
@@ -11839,7 +11839,7 @@ ra2_ctmsc01:
 		Footprint: x
 		Dimensions: 1,1
 	Tooltip:
-		Name: Hot ra1_soviet_attackdog Cart
+		Name: Hot Dog Cart
 	Crushable:
 		CrushClasses: ixian_concretewall
 ra2_ctmsc02:
@@ -12396,7 +12396,7 @@ ra2shad.Husk:
 yrbpln.husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Bomber
+		Name: MiG Bomber
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 176
@@ -14458,7 +14458,7 @@ yuri_upgrade_corrosiveammo:
 		Name: Corrosive Ammo
 	Buildable:
 		Queue: Research
-		Description: Adds a powerful corrosive effect to the Virus ra1_allies_alliedsniper that slows down enemy vehicles and deals damage over time. Increases Firepower by 33%.
+		Description: Adds a powerful corrosive effect to the Virus Sniper that slows down enemy vehicles and deals damage over time. Increases Firepower by 33%.
 		Prerequisites: ~yuri_battlelab, yuri_lunarcommandcenter, yuri_upgrade_meltingvirus, !yuri_upgrade_corrosiveammo
 	RenderSprites:
 		Image: yuri_upgrade_corrosiveammo

--- a/mods/cameo/rules/shockwave.yaml
+++ b/mods/cameo/rules/shockwave.yaml
@@ -1385,7 +1385,7 @@ Player:
 		IconPalette: ra2
 		ChargeInterval: 6000
 		Name: Napalm Strike
-		Description: Calls ra1_soviet_ironcurtain Dragon Squadron to bombard an area with Napalm rockets
+		Description: Calls Iron Dragon Squadron to bombard an area with Napalm rockets
 		SelectTargetSpeechNotification: SelectTarget
 		CameraActor: camera
 		CameraRemoveDelay: 150
@@ -2398,7 +2398,7 @@ susaburtonequipment:
 susaarmorburtonequipment:
 	Inherits: susaburtonequipment
 	Buildable:
-		Description: Burton gets HE Ammunition for ra1_allies_alliedsniper Rifle\nBurton's rifle will be able to hit multiple targets
+		Description: Burton gets HE Ammunition for Sniper Rifle\nBurton's rifle will be able to hit multiple targets
 		Prerequisites: ~!susaburtonequipment, susastrategy, ~susa_armor
 
 susawptargetting:
@@ -2662,7 +2662,7 @@ susapath:
 	Buildable:
 		BuildPaletteOrder: 40
 		Queue: Infantry, RAInfantry
-		Description: Stealthed ra1_allies_alliedsniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: Stealthed sniper infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
 		Prerequisites: barracks, upusapath, ~anysusa, ~!susa_armor
 	RenderSprites:
 		Image: susapathfinder
@@ -2754,7 +2754,7 @@ susaarmorburton:
 		Name: Armor Burton
 	Buildable:
 		Prerequisites: susastrategy, ~techlevel.high, ~susa_armor, ~!botplayer
-		Description: Elite commando equipped with ra1_allies_alliedsniper Rifle.\nCan switch between close and long range modes\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Air
+		Description: Elite commando equipped with Sniper Rifle.\nCan switch between close and long range modes\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Air
 	Armament@PRIMARY:
 		Weapon: SUSABurtonSniper
 		Name: primary
@@ -3888,7 +3888,7 @@ susalockdownmlrs:
 	Valued:
 		Cost: 1600
 	Tooltip:
-		Name: Lockdown td_gdi_mlrs
+		Name: Lockdown MLRS
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -4909,7 +4909,7 @@ susasheridan:
 	Valued:
 		Cost: 850
 	Tooltip:
-		Name: ra1_allies_sheridanassaulttank
+		Name: Sheridan
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -4996,7 +4996,7 @@ susashilleighat:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Vehicle, RAVehicle
-		Description: Equips ra1_allies_sheridanassaulttank Tanks with Anti-Tank Rockets
+		Description: Equips Sheridan Tanks with Anti-Tank Rockets
 		Prerequisites: ~!susashilleighat, ~susa_air
 		IconPalette: ra2
 	Valued:
@@ -8069,7 +8069,7 @@ sglaquadbike:
 	Valued:
 		Cost: 400 #1100
 	Tooltip:
-		Name: Quad td_nod_reconbike
+		Name: Quad Bike
 	Health:
 		HP: 20000
 	Armor:
@@ -8521,7 +8521,7 @@ sglsa2samsite:
 	Valued:
 		Cost: 1200
 	Tooltip:
-		Name: SA2 td_nod_samsite Site
+		Name: SA2 SAM Site
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: sglbarracks, ~techlevel.low, ~sgla_scrap
@@ -8912,7 +8912,7 @@ sglkrait:
 		BuildPaletteOrder: 30
 		Prerequisites: sglweap, ~techlevel.medium, ~sgla_scrap
 		Queue: Vehicle, RAVehicle
-		Description: td_gdi_apc armed with toxin td_nod_gunturret and phosphorus rockets.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: APC armed with toxin gun and phosphorus rockets.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles
 		IconPalette: ra2
 	Mobile:
 		Speed: 125
@@ -10982,14 +10982,14 @@ sgltarantula:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: Tarantula td_gdi_apc
+		Name: Tarantula APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: sglweap, ~techlevel.medium, ~sgla_toxin
 		Queue: Vehicle, RAVehicle
-		Description: td_gdi_apc armed with toxins.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: APC armed with toxins.\nCan carry 2 passengers.\n  Strong vs Infantry\n  Weak vs Vehicles
 		IconPalette: ra2
 	Mobile:
 		Speed: 140
@@ -11326,7 +11326,7 @@ sglassassin:
 	Buildable:
 		BuildPaletteOrder: 40
 		Queue: Infantry, RAInfantry
-		Description: ra1_allies_alliedsniper infantry.\nStealthed when not attacking\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: Sniper infantry.\nStealthed when not attacking\n  Strong vs Infantry\n  Weak vs Vehicles
 		Prerequisites: sglpalace, ~sgla_camo
 		IconPalette: ra2
 	RenderSprites:
@@ -11673,7 +11673,7 @@ sglsniperquadcannon:
 	Valued:
 		Cost: 750
 	Tooltip:
-		Name: ra1_allies_alliedsniper Quad Cannon
+		Name: Sniper Quad Cannon
 	Turreted:
 		TurnSpeed: 36
 		Offset: -370,0,225
@@ -12297,7 +12297,7 @@ eglrajeep:
 		Queue: Vehicle, RAVehicle
 		BuildPaletteOrder: 20
 		Prerequisites: sglweap, ~techlevel.low, ~eglatechnic
-		Description: td_gdi_humvee GLA Variant.\nDelete carry because has a grenadier in the back.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+		Description: Jeep GLA Variant.\nDelete carry because has a grenadier in the back.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -12747,7 +12747,7 @@ upschnapalmstrike:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Promotions.CHINA
-		Description: Calls squadron of ra1_soviet_ironcurtain Dragons to bombard an area with napalm rockets
+		Description: Calls squadron of Iron Dragons to bombard an area with napalm rockets
 		Prerequisites: !upschnapalmstrike, ~techlevel.high, ~schina_regular, rank3, rank1
 		IconPalette: ra2
 	RenderSprites:
@@ -13212,7 +13212,7 @@ schempmig:
 	Valued:
 		Cost: 1500
 	Tooltip:
-		Name: EMP ra1_soviet_migattackbomber
+		Name: EMP MiG
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -13288,7 +13288,7 @@ schempmig:
 schempmig.husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: EMP ra1_soviet_migattackbomber
+		Name: EMP MiG
 	Contrail@1:
 		Offset: -598,-683,0
 	Contrail@2:
@@ -13415,11 +13415,11 @@ schtiger.husk:
 upschmigspeed:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: ra1_soviet_migattackbomber Afterburner
+		Name: MiG Afterburner
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Aircraft, RAAircraft
-		Description: ra1_soviet_migattackbomber fighters gain more fuel efficient engines gaining up to 25% movement speed
+		Description: MiG fighters gain more fuel efficient engines gaining up to 25% movement speed
 		Prerequisites: ~!upschmigspeed, ~schina_regular
 		IconPalette: ra2
 	Valued:
@@ -14751,7 +14751,7 @@ schberzerkermlrs:
 	Valued:
 		Cost: 1600
 	Tooltip:
-		Name: Berzerker td_gdi_mlrs
+		Name: Berzerker MLRS
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -14833,11 +14833,11 @@ schberzerkermlrs:
 upschberzerkermlrs:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Berzerker td_gdi_mlrs
+		Name: Berzerker MLRS
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Promotions.CHINA
-		Description: Allows production of the Berzerker td_gdi_mlrs
+		Description: Allows production of the Berzerker MLRS
 		Prerequisites: !upschberzerkermlrs, ~techlevel.high, ~schina_inf, rank1
 		IconPalette: ra2
 	RenderSprites:
@@ -14857,14 +14857,14 @@ schgattlingapc:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: Gattling td_gdi_apc
+		Name: Gattling APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~techlevel.low, ~schina_inf
 		Queue: Vehicle, RAVehicle
-		Description: td_gdi_apc armed with Gattling gun.\nCan be mounted with infantry\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks
+		Description: APC armed with Gattling gun.\nCan be mounted with infantry\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks
 		IconPalette: ra2
 	Mobile:
 		Speed: 124
@@ -15914,7 +15914,7 @@ schnuclearmig:
 	Valued:
 		Cost: 1400
 	Tooltip:
-		Name: Nuclear ra1_soviet_migattackbomber
+		Name: Nuclear MiG
 	RenderSprites:
 		Image: chmig
 	Armament@1:

--- a/mods/cameo/rules/simcity.yaml
+++ b/mods/cameo/rules/simcity.yaml
@@ -1399,7 +1399,7 @@ CITYSTATION:
 	Buildable:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 80
-		Description: Provides Railway td_nod_gunturret support power.
+		Description: Provides Railway Gun support power.
 		Prerequisites: Fire Department, Police Department, Industrial, cityharbor, ~techlevel.superweapons
 	Building:
 		Footprint: xx xx
@@ -1428,7 +1428,7 @@ CITYSTATION:
 		Cursor: attackmove
 		Icon: emp
 		ChargeInterval: 1500
-		Name: Railway td_nod_gunturret
+		Name: Railway Gun
 		Description: An unseen underground bullet train\nfires heavy artillery at the target.
 		EndChargeSpeechNotification:
 		SelectTargetSpeechNotification:
@@ -1706,7 +1706,7 @@ CITYPOLICEOFFICER:
 		BuildDuration: 55
 		BuildDurationModifier: 100
 		Queue: Vehicle, RAVehicle
-		Description: Law enforcement armed with a pistol.\nCan be upgraded to have pistol replaced with Submachine td_nod_gunturret\n Strong vs Infantry\n Weak vs Vehicles, Aircraft
+		Description: Law enforcement armed with a pistol.\nCan be upgraded to have pistol replaced with Submachine gun\n Strong vs Infantry\n Weak vs Vehicles, Aircraft
 	Mobile:
 		Speed: 56
 	Health:
@@ -2123,7 +2123,7 @@ CITYSWATGL:
 		Prerequisites: citylibrary, citybank, cityairport, ~techlevel.high
 		BuildDurationModifier: 50
 		Queue: Vehicle, RAVehicle
-		Description: Stealth Elite law enforcement equipped with silenced ra1_allies_alliedsniper Rifle\nCan he upgraded to get Grenade Launcher\nStrong vs Infantry, Air
+		Description: Stealth Elite law enforcement equipped with silenced Sniper Rifle\nCan he upgraded to get Grenade Launcher\nStrong vs Infantry, Air
 		Icon: iconcomm
 	Tooltip:
 		Name: S.W.A.T. Specialist

--- a/mods/cameo/rules/sow.yaml
+++ b/mods/cameo/rules/sow.yaml
@@ -1526,7 +1526,7 @@ sow_gun_tower:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: td_nod_gunturret Turret
+		Name: Gun Turret
 	Buildable:
 		BuildPaletteOrder: 1
 		BuildDurationModifier: 50

--- a/mods/cameo/rules/starwars.yaml
+++ b/mods/cameo/rules/starwars.yaml
@@ -3868,7 +3868,7 @@ SWSAM:
 	Valued:
 		Cost: 650
 	Tooltip:
-		Name: td_nod_samsite Site
+		Name: SAM Site
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: barracks
@@ -5198,7 +5198,7 @@ swrmbo:
 		BuildPaletteOrder: 50
 		Prerequisites: swfort, ~techlevel.high
 		Queue: Infantry, RAInfantry
-		Description: Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Armament:
 		Weapon: ra1_allies_alliedsniper
 	Armament@GARRISONED:
@@ -5221,7 +5221,7 @@ swgreedo:
 		BuildPaletteOrder: 50
 		Prerequisites: swfort, ~techlevel.high
 		Queue: Infantry, RAInfantry
-		Description: Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Armament@PRIMARY:
 		Weapon: ra1_allies_alliedsniper
 	Armament@GARRISONED:
@@ -5253,7 +5253,7 @@ swbike:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: Speeder td_nod_reconbike
+		Name: Speeder Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -5725,7 +5725,7 @@ swltnk:
 		BuildPaletteOrder: 20
 		Prerequisites: hpad, anyhq, ~techlevel.medium
 		Queue: Aircraft, RAAircraft
-		Description: Aircraft Gunship with AG Laser.\n  Strong vs Tanks, Walker ra1_allies_mechanic\n  Weak vs Infantry
+		Description: Aircraft Gunship with AG Laser.\n  Strong vs Tanks, Walker Mech\n  Weak vs Infantry
 		BuildDurationModifier: 50
 	Aircraft:
 		CruiseAltitude: 900
@@ -8060,7 +8060,7 @@ swtran.e2:
 		RequiresCondition: !loaded && botmicro
 		Delay: 200
 	EditorOnlyTooltip:
-		Name: Loaded Lambda (td_gdi_grenadier)
+		Name: Loaded Lambda (E2)
 
 swtran.e1:
 	Inherits: swtran
@@ -8438,7 +8438,7 @@ swrmbo.hutt:
 		BuildPaletteOrder: 10
 		Prerequisites: ~techlevel.low
 		Queue: Infantry, RAInfantry
-		Description: Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Armament:
 		Weapon: SWBikeLaserSalvage
 	Armament@GARRISONED:

--- a/mods/cameo/rules/test.yaml
+++ b/mods/cameo/rules/test.yaml
@@ -412,7 +412,7 @@ EXCITER:
 		BuildAtProductionType: Vehicle
 		BuildPaletteOrder: 240
 		Prerequisites: fix, ra1_allies_alliedtechcenter, ~vehicles.allies, ~techlevel.high, ~bio
-		Description: A Bio ra1_allies_mechanic unit that\n electrifies its victims with a Shock Shell\nStrong vs Infantry, Buildings\nWeak vs Vehicles
+		Description: A Bio Mech unit that\n electrifies its victims with a Shock Shell\nStrong vs Infantry, Buildings\nWeak vs Vehicles
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -691,7 +691,7 @@ MOBILETENT:
 	Valued:
 		Cost: 2000
 	Tooltip:
-		Name: Mobile ra1_allies_alliedbarracks
+		Name: Mobile Tent
 	Selectable:
 		Priority: 4
 		DecorationBounds: 896, 896

--- a/mods/cameo/rules/tiberiaalliances.yaml
+++ b/mods/cameo/rules/tiberiaalliances.yaml
@@ -250,12 +250,12 @@ TABLACKHAND:
 	Valued:
 		Cost: 250
 	Tooltip:
-		Name: Black td_nod_handofnod
+		Name: Black Hand
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: barracks, Addonshand2
 		Queue: Infantry, RAInfantry
-		Description: The Black td_nod_handofnod is a step up from the Rocket Squad, being a better-armoured anti-tank unit. Equipped with flamethrowers, they will cook a tank until it bursts, allowing the rest of your units to pass.
+		Description: The Black Hand is a step up from the Rocket Squad, being a better-armoured anti-tank unit. Equipped with flamethrowers, they will cook a tank until it bursts, allowing the rest of your units to pass.
 	Health:
 		HP: 14000
 	Armament@PRIMARY:
@@ -278,7 +278,7 @@ TACONFESSOR:
 		BuildPaletteOrder: 30
 		Prerequisites: barracks, Addonshand3
 		Queue: Infantry, RAInfantry
-		Description: Similar to the GDI ra1_allies_alliedsniper Team, the Nod Confessors are a lightly-armoured infantry unit capable of eliminating enemy infantry quickly and efficiently while maintaining a safe distance. Unfortunately, they’re pretty much weak against anything else.
+		Description: Similar to the GDI Sniper Team, the Nod Confessors are a lightly-armoured infantry unit capable of eliminating enemy infantry quickly and efficiently while maintaining a safe distance. Unfortunately, they’re pretty much weak against anything else.
 	Health:
 		HP: 14000
 	Armament@PRIMARY:
@@ -344,7 +344,7 @@ TASNIPE:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: ra1_allies_alliedsniper
+		Name: Sniper
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: Addonsbarr3, ~techlevel.medium
@@ -392,7 +392,7 @@ TAMUTSNIPE:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Mutant ra1_allies_alliedsniper
+		Name: Mutant Sniper
 	Buildable:
 		BuildPaletteOrder: 95
 		Prerequisites: barracks, upgrade.tamutbarr2
@@ -457,7 +457,7 @@ taguardian:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: Guardian td_gdi_apc
+		Name: Guardian APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 		OverrideActor: td_gdi_apc
@@ -1662,7 +1662,7 @@ tauplaserscope:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
-		Description: Increase ra1_allies_alliedsniper Shoot Range
+		Description: Increase Sniper Shoot Range
 		Prerequisites: ~!tauplaserscope, barracks
 	Valued:
 		Cost: 1500
@@ -1821,7 +1821,7 @@ taupshield1:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
-		Description: Upgrade the Armor of Attack td_nod_reconbike
+		Description: Upgrade the Armor of Attack Bike
 		Prerequisites: ~!taupshield1, vehicleproduction
 	Valued:
 		Cost: 1500
@@ -1963,7 +1963,7 @@ taupchemical2:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
-		Description: Adds Chemical Rockets to ra1_soviet_ironcurtain Fist
+		Description: Adds Chemical Rockets to Iron Fist
 		Prerequisites: ~!taupchemical2, taupchemical1
 	Valued:
 		Cost: 1500
@@ -1982,7 +1982,7 @@ taupguidedmiss:
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
-		Description: GDI Flak Bunker, adds a little td_nod_samsite Launcher
+		Description: GDI Flak Bunker, adds a little SAM Launcher
 		Prerequisites: ~!taupguidedmiss, tagdihq2
 	Valued:
 		Cost: 2000
@@ -3097,7 +3097,7 @@ Addonssam1:
 	Interactable:
 	ScriptTriggers:
 	Tooltip:
-		Name: td_nod_samsite lvl 5
+		Name: SAM lvl 5
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: ~tanodhq2, ~!Addonssam1
@@ -3116,7 +3116,7 @@ Addonssam2:
 	Interactable:
 	ScriptTriggers:
 	Tooltip:
-		Name: td_nod_samsite lvl 10
+		Name: SAM lvl 10
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: ~Addonssam1, ~!Addonssam2
@@ -3135,7 +3135,7 @@ Addonssam3:
 	Interactable:
 	ScriptTriggers:
 	Tooltip:
-		Name: td_nod_samsite lvl 20
+		Name: SAM lvl 20
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: ~Addonssam2, ~!Addonssam3
@@ -3952,7 +3952,7 @@ tanodhand:
 	Valued:
 		Cost: 500 #500
 	Tooltip:
-		Name: Nod td_nod_handofnod
+		Name: Nod Hand
 	Production@NORMAL:
 		Produces: Infantry
 	Production@CLASSICPRODUCTIONQUEUES:
@@ -4963,7 +4963,7 @@ tanodeyeofkane:
 	Valued:
 		Cost: 1500 #500
 	Tooltip:
-		Name: td_gdi_advancedcommunicationscenter of Kane
+		Name: Eye of Kane
 	Building:
 		Footprint: xxx xxx ___
 		Dimensions: 3,3
@@ -5003,7 +5003,7 @@ tanodeyeofkane:
 		Cursor: attackmove
 		Icon: glscudstorm
 		ChargeInterval: 6000
-		Name: td_gdi_advancedcommunicationscenter of Kane AA Launcher
+		Name: Eye of Kane AA Launcher
 		Description: Fires 9 Scud Missiles at the target.
 		EndChargeSpeechNotification:
 		SelectTargetSpeechNotification:
@@ -5374,7 +5374,7 @@ tamgnest:
 		Prerequisites: barracks
 		Queue: Defence, RADefence
 	Tooltip:
-		Name: Machine td_nod_gunturret Nest
+		Name: Machine Gun Nest
 	GrantConditionOnPrerequisite@levelupgrade1:
 		Condition: levelupgrade1
 		Prerequisites: upgrade.tamgnest1
@@ -5564,7 +5564,7 @@ tamgnod:
 		Prerequisites: barracks
 		Queue: Defence, RADefence
 	Tooltip:
-		Name: Shredder Machine td_nod_gunturret
+		Name: Shredder Machine Gun
 	Armament:
 		Weapon: TSVulcanTower
 		LocalOffset: 300,60,600
@@ -5816,7 +5816,7 @@ tareapercann:
 	Valued:
 		Cost: 900
 	Tooltip:
-		Name: Reaper Machine td_nod_gunturret
+		Name: Reaper Machine Gun
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: barracks, vehicleproduction

--- a/mods/cameo/rules/tkm.yaml
+++ b/mods/cameo/rules/tkm.yaml
@@ -1337,7 +1337,7 @@ tkm_sniper:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: ra1_allies_alliedsniper
+		Name: Sniper
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~tkm_barracks, ~tkm_upgrade_berezkaarsenalupgrade, tkm_observationvan
@@ -2514,7 +2514,7 @@ tkm_iroquois:
 tkmhuey.husk:
 	Inherits: ^LargeHelicopterHusk
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter
+		Name: Hind
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 112
@@ -2649,7 +2649,7 @@ tkm_viper:
 tkmviper.husk:
 	Inherits: ^PlaneHusk
 	Tooltip:
-		Name: TKM ra1_soviet_migattackbomber
+		Name: TKM Mig
 	Contrail:
 		Offset: -853,0,0
 	Aircraft:
@@ -3894,7 +3894,7 @@ tkm_promotion_unlockdronepodtruck:
 tkm_promotion_unlockt30:
 	Inherits: ^promotion_upgrade.template
 	Tooltip:
-		Name: Unlock tkm_t30
+		Name: Unlock T30
 	Buildable:
 		BuildPaletteOrder: 8054
 		Queue: Promotions

--- a/mods/cameo/rules/tomorrow.yaml
+++ b/mods/cameo/rules/tomorrow.yaml
@@ -2615,7 +2615,7 @@ DTLWALL:
 	CustomSellValue:
 		Value: 5
 	Tooltip:
-		Name: Living ixian_concretewall
+		Name: Living Wall
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: dtbio
@@ -2815,7 +2815,7 @@ DTRMBO:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq, ~techlevel.high, dtpropaganda
 		Queue: Infantry, RAInfantry
-		Description: Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 		BuildDuration: 375
 		BuildDurationModifier: 100
 		BuildLimit: 1
@@ -2866,7 +2866,7 @@ dtapc:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: Rocket td_gdi_apc
+		Name: Rocket APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 		OverrideActor: td_gdi_apc
@@ -3373,7 +3373,7 @@ hind.dtrussia:
 	RenderSprites:
 		Image: ra1_soviet_hindattackhelicopter
 	Tooltip:
-		Name: ra1_soviet_hindattackhelicopter
+		Name: Hind
 	Buildable:
 		Queue: Aircraft, RAAircraft
 		Prerequisites: anyhq
@@ -3592,7 +3592,7 @@ dtapc2:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Tear Gas td_gdi_apc
+		Name: Tear Gas APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 		OverrideActor: td_gdi_apc
@@ -3735,7 +3735,7 @@ dtfbik:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: Flame td_nod_reconbike
+		Name: Flame Bike
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:

--- a/mods/cameo/rules/warcraft2.yaml
+++ b/mods/cameo/rules/warcraft2.yaml
@@ -35,7 +35,7 @@ World:
 		InternalName: orc2
 		Game: Warcraft 2
 		Side: Warcraft 2
-		Description: Orc\nLeaders of the Horde\nBrutish and crafty.\nSupport Powers: td_gdi_advancedcommunicationscenter of Kilrogg, Death and Decay
+		Description: Orc\nLeaders of the Horde\nBrutish and crafty.\nSupport Powers: Eye of Kilrogg, Death and Decay
 		Selectable: True
 	FactionCA@RandomWC2:
 		Name: Random WC2
@@ -2900,7 +2900,7 @@ humans_wall:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: ixian_concretewall
+		Name: Wall
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: ~humans_townhall
@@ -6574,7 +6574,7 @@ wc2_orc_eye_of_kilrogg:
 	Valued:
 		Cost: 2000
 	Tooltip:
-		Name: td_gdi_advancedcommunicationscenter of Kilrogg
+		Name: Eye of Kilrogg
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: ~disabled
@@ -6615,7 +6615,7 @@ wc2_support_orc_eye_of_kilrogg:
 	Health:
 		HP: 200000
 	Tooltip:
-		Name: td_gdi_advancedcommunicationscenter of Kilrogg
+		Name: Eye of Kilrogg
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 28

--- a/mods/cameo/rules/wh40k.yaml
+++ b/mods/cameo/rules/wh40k.yaml
@@ -5797,7 +5797,7 @@ wh40kscoutsniper:
 	Power:
 		Amount: -15
 	Tooltip:
-		Name: ra1_allies_alliedsniper Scout
+		Name: Sniper Scout
 	Buildable:
 		BuildPaletteOrder: 63
 		Prerequisites: barracks, wh40karmorym
@@ -6081,7 +6081,7 @@ wh40kterminator3:
 	Power:
 		Amount: -30
 	Tooltip:
-		Name: Assault td_nod_gunturret Terminator Marine
+		Name: Assault Gun Terminator Marine
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -6525,7 +6525,7 @@ wh40krhino:
 	Power:
 		Amount: -25
 	Tooltip:
-		Name: Rhino td_gdi_apc
+		Name: Rhino APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -10913,7 +10913,7 @@ wh40kchaosrhino:
 	Power:
 		Amount: -25
 	Tooltip:
-		Name: Rhino td_gdi_apc
+		Name: Rhino APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -11436,7 +11436,7 @@ wh40kcultistplasma:
 	Power:
 		Amount: -15
 	Tooltip:
-		Name: Plasma td_nod_gunturret Cultist
+		Name: Plasma Gun Cultist
 	Buildable:
 		BuildPaletteOrder: 64
 		Prerequisites: barracks, wh40karmoryc

--- a/mods/cameo/rules/win98.yaml
+++ b/mods/cameo/rules/win98.yaml
@@ -668,7 +668,7 @@ WIN98_CRT_WALL:
 	CustomSellValue:
 		Value: 0
 	Tooltip:
-		Name: CRT ixian_concretewall
+		Name: CRT Wall
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: WIN98_BARRACKS

--- a/mods/cameo/rules/worms.yaml
+++ b/mods/cameo/rules/worms.yaml
@@ -1296,7 +1296,7 @@ WORMDYNAMITE:
 		Queue: Infantry, RAInfantry
 		BuildDuration: 1000
 		BuildDurationModifier: 40
-		Description: Elite ra1_allies_alliedsniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Mobile:
 		Speed: 71
 	Guard:

--- a/mods/cameo/rules/wz2100.yaml
+++ b/mods/cameo/rules/wz2100.yaml
@@ -1102,7 +1102,7 @@ Player:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: ixian_concretewall
+		Name: Wall
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Defence, RADefence
@@ -1195,7 +1195,7 @@ Player:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: ixian_concretewall with Machinegun
+		Name: Wall with Machinegun
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: 2100FY1, ~up2100upwall1
@@ -1216,7 +1216,7 @@ Player:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: ixian_concretewall with Light Cannon
+		Name: Wall with Light Cannon
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: 2100FY1, ~up2100upwall1, ~up2100uplcannon1
@@ -1234,7 +1234,7 @@ Player:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: ixian_concretewall with Medium Cannon
+		Name: Wall with Medium Cannon
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: 2100FY1, ~up2100upwall1, up2100upmcannon1
@@ -1254,7 +1254,7 @@ Player:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: ixian_concretewall with Heavy Cannon
+		Name: Wall with Heavy Cannon
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: 2100FY1, ~up2100upwall1, ~up2100uphcannon1
@@ -2089,7 +2089,7 @@ psc2100factory2:
 		SquadSize: 3
 		QuantizedFacings: 8
 		Name: Air Strike
-		Description: td_nod_gunturret Choppers attack enemies along a line\nwith chainguns.
+		Description: Gun Choppers attack enemies along a line\nwith chainguns.
 		EndChargeSpeechNotification: AirstrikeReady
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
@@ -2247,7 +2247,7 @@ psc2100factory2:
 	Valued:
 		Cost: 150
 	Tooltip:
-		Name: ixian_concretewall
+		Name: Wall
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Defence, RADefence
@@ -4400,7 +4400,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1500
 	Tooltip:
-		Name: Needle td_nod_gunturret Cobra Half-tracks
+		Name: Needle Gun Cobra Half-tracks
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: 2100fy2, ~up2100upneedle, ~up2100upcobra1, ~techlevel.medium
@@ -4473,7 +4473,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1450
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Python Tracks
+		Name: Twin Assault Gun Python Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100uppython1, ~up2100uptracks1, ~up2100uptwinassaultmg1
@@ -4485,7 +4485,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1350
 	Tooltip:
-		Name: Assault td_nod_gunturret Python Tracks
+		Name: Assault Gun Python Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100uppython1, ~up2100uptracks1, ~up2100upassaultmg1
@@ -4607,7 +4607,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1650
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Python Hovercraft
+		Name: Twin Assault Gun Python Hovercraft
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100uppython1, ~up2100uphover1, ~up2100uptwinassaultmg1
@@ -5114,7 +5114,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1450
 	Tooltip:
-		Name: Needle td_nod_gunturret Scorpion Half-tracks
+		Name: Needle Gun Scorpion Half-tracks
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: 2100fy2, ~up2100upneedle, ~up2100upscorpion1, ~techlevel.medium
@@ -5151,7 +5151,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1350
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Mantis Tracks
+		Name: Twin Assault Gun Mantis Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upmantis1, ~up2100uptracks1, ~up2100uptwinassaultmg1
@@ -5163,7 +5163,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1150
 	Tooltip:
-		Name: Assault td_nod_gunturret Mantis Tracks
+		Name: Assault Gun Mantis Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upmantis1, ~up2100uptracks1, ~up2100upassaultmg1
@@ -5274,7 +5274,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1550
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Mantis Hovercraft
+		Name: Twin Assault Gun Mantis Hovercraft
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upmantis1, ~up2100uphover1, ~up2100uptwinassaultmg1
@@ -5335,7 +5335,7 @@ psc2100chopshop2:
 2100CJEEP:
 	Inherits: 2100JEEP
 	Tooltip:
-		Name: BabaMG td_gdi_humvee Wheels
+		Name: BabaMG Jeep Wheels
 	Buildable:
 		BuildPaletteOrder: 40
 		Queue: Infantry, RAInfantry
@@ -5354,7 +5354,7 @@ psc2100chopshop2:
 2100CJEEPMSL:
 	Inherits: 2100JEEPMSL
 	Tooltip:
-		Name: BabaRK td_gdi_humvee Wheels
+		Name: BabaRK Jeep Wheels
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Infantry, RAInfantry
@@ -5666,7 +5666,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1600
 	Tooltip:
-		Name: Needle td_nod_gunturret Panther Half-tracks
+		Name: Needle Gun Panther Half-tracks
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: 2100fy2, ~up2100upneedle, ~up2100uppanther1, ~techlevel.medium
@@ -5703,7 +5703,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1550
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Tiger Tracks
+		Name: Twin Assault Gun Tiger Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: 2100CRC, ~techlevel.high, ~up2100uptiger1, ~up2100uptracks1, ~up2100uptwinassaultmg1
@@ -5715,7 +5715,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1350
 	Tooltip:
-		Name: Assault td_nod_gunturret Tiger Tracks
+		Name: Assault Gun Tiger Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: 2100CRC, ~techlevel.high, ~up2100uptiger1, ~up2100uptracks1, ~up2100upassaultmg1
@@ -5813,7 +5813,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1650
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Tiger Hovercraft
+		Name: Twin Assault Gun Tiger Hovercraft
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100uptiger1, ~up2100uphover1, ~up2100uptwinassaultmg1
@@ -6101,7 +6101,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1700
 	Tooltip:
-		Name: Needle td_nod_gunturret Retribution Half-tracks
+		Name: Needle Gun Retribution Half-tracks
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: 2100fy2, ~up2100upneedle, ~up2100upretribution1, ~techlevel.medium
@@ -6126,7 +6126,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 2050
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Vengeance Tracks
+		Name: Twin Assault Gun Vengeance Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upvengeance1, ~up2100uptracks1, ~up2100uptwinassaultmg1
@@ -6138,7 +6138,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1850
 	Tooltip:
-		Name: Assault td_nod_gunturret Vengeance Tracks
+		Name: Assault Gun Vengeance Tracks
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upvengeance1, ~up2100uptracks1, ~up2100upassaultmg1
@@ -6261,7 +6261,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 2300
 	Tooltip:
-		Name: Twin Assault td_nod_gunturret Vengeance Hovercraft
+		Name: Twin Assault Gun Vengeance Hovercraft
 	Buildable:
 		BuildPaletteOrder: 80
 		Prerequisites: ~2100fy3, ~techlevel.high, ~up2100upvengeance1, ~up2100uphover1, ~up2100uptwinassaultmg1
@@ -6984,7 +6984,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: PK-105 td_gdi_humvee Barbarian MG
+		Name: PK-105 Jeep Barbarian MG
 	Buildable:
 		BuildPaletteOrder: 40
 		Queue: Vehicle, RAVehicle
@@ -7009,7 +7009,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 350
 	Tooltip:
-		Name: PK-105 td_gdi_humvee Rocket Array
+		Name: PK-105 Jeep Rocket Array
 	Buildable:
 		BuildPaletteOrder: 50
 		Queue: Vehicle, RAVehicle
@@ -7118,7 +7118,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 700
 	Tooltip:
-		Name: B-155 Camper Needle td_nod_gunturret
+		Name: B-155 Camper Needle Gun
 	Buildable:
 		BuildPaletteOrder: 60
 		Queue: Vehicle, RAVehicle
@@ -7630,7 +7630,7 @@ psc2100chopshop2:
 		Queue: Vehicle, RAVehicle
 		Prerequisites: 2100ChopShopAdv
 		BuildPaletteOrder: 120
-		Description: Transports tins of ra1_soviet_attackdog food to other players.\n Armed with self-defense cannon
+		Description: Transports tins of dog food to other players.\n Armed with self-defense cannon
 	Turreted:
 		TurnSpeed: 32
 		Offset: -10,0,150
@@ -7861,7 +7861,7 @@ psc2100chopshop2:
 	Valued:
 		Cost: 1100
 	Tooltip:
-		Name: Bp-200 td_nod_gunturret Chopper
+		Name: Bp-200 Gun Chopper
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: 2100ChopShop, 2100RF, ~techlevel.medium
@@ -7944,7 +7944,7 @@ psc2100chopshop2:
 		Armaments: td_nod_gunturret
 		FacingTolerance: 32
 	Armament@GUNS:
-		Name: td_nod_gunturret
+		Name: gun
 		Weapon: ScavVulcan
 		LocalOffset: 1024,0,-85
 	WithMuzzleOverlay:
@@ -8096,7 +8096,7 @@ psc2100chopshop2:
 		Armaments: td_nod_gunturret
 		FacingTolerance: 32
 	Armament@GUNS:
-		Name: td_nod_gunturret
+		Name: gun
 		Weapon: ScavAGM
 		LocalOffset: 1024,0,-85
 	WithMuzzleOverlay:
@@ -9106,7 +9106,7 @@ up2100upengineer2:
 up2100upwall1:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: ixian_concretewall Research
+		Name: Wall Research
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
@@ -9424,11 +9424,11 @@ up2100uphycannon:
 up2100upneedle:
 	Inherits: ^upgrade.template
 	Tooltip:
-		Name: Needle td_nod_gunturret Research
+		Name: Needle Gun Research
 	Buildable:
 		BuildPaletteOrder: 200
 		Queue: Research
-		Description: Unlock Needle td_nod_gunturret Weapon
+		Description: Unlock Needle Gun Weapon
 		Prerequisites: ~!up2100upneedle, ~up2100uplcannon6, ~up2100upsypnaticdata4
 	Valued:
 		Cost: 1000

--- a/mods/cameo/rules/xcom.yaml
+++ b/mods/cameo/rules/xcom.yaml
@@ -197,12 +197,12 @@ ShotgunUpgrade:
 		Range: 1c0
 ShardgunUpgrade:
 	Tooltip:
-		Name: Shard td_nod_gunturret Upgrade
+		Name: Shard Gun Upgrade
 	Buildable:
 		Prerequisites: ~xcomhq
 		BuildPaletteOrder: 1
 		Queue: Addons
-		Description: Upgrades the Shotgun to the Shard td_nod_gunturret
+		Description: Upgrades the Shotgun to the Shard Gun
 	Valued:
 		Cost: 2500
 	RenderSprites:
@@ -219,9 +219,9 @@ ShardgunUpgrade:
 		ChargeInterval: 0
 		StartFullyCharged: true
 		Names:
-			1: Shard td_nod_gunturret Upgrade
+			1: Shard Gun Upgrade
 		Descriptions:
-			1: Upgrades the Shotgun to the Shard td_nod_gunturret
+			1: Upgrades the Shotgun to the Shard Gun
 		Condition: ShardgunUpgrade
 		Duration: 0
 		SelectTargetSpeechNotification: SelectTarget
@@ -549,12 +549,12 @@ xcomsharpshooter:
 		Image: ra2_allies_sniper
 AutoSniperUpgrade:
 	Tooltip:
-		Name: Auto ra1_allies_alliedsniper Upgrade
+		Name: Auto Sniper Upgrade
 	Buildable:
 		Prerequisites: ~xcomhq
 		BuildPaletteOrder: 2
 		Queue: Addons
-		Description: Gives the ra1_allies_alliedsniper an automatic ra1_allies_alliedsniper Rifle
+		Description: Gives the Sniper an automatic Sniper Rifle
 	Valued:
 		Cost: 800
 	RenderSprites:
@@ -571,9 +571,9 @@ AutoSniperUpgrade:
 		ChargeInterval: 0
 		StartFullyCharged: true
 		Names:
-			1: Auto ra1_allies_alliedsniper Upgrade
+			1: Auto Sniper Upgrade
 		Descriptions:
-			1: Gives the ra1_allies_alliedsniper an automatic ra1_allies_alliedsniper Rifle
+			1: Gives the Sniper an automatic Sniper Rifle
 		Condition: AutoSniperUpgrade
 		Duration: 0
 		SelectTargetSpeechNotification: SelectTarget
@@ -880,7 +880,7 @@ medium_gun_turret.xcom:
 	Valued:
 		Cost: 2000
 	Tooltip:
-		Name: td_nod_gunturret Turret
+		Name: Gun Turret
 	Selectable:
 		Priority: 4
 		DecorationBounds: 1536, 1536

--- a/mods/cameo/rules/xmas.yaml
+++ b/mods/cameo/rules/xmas.yaml
@@ -789,7 +789,7 @@ xmas_satangoblin:
 	Buildable:
 		BuildPaletteOrder: 1
 		Queue: Infantry
-		Description: Light infantry equipped with td_nod_gunturret
+		Description: Light infantry equipped with gun
 	Mobile:
 		Speed: 90
 	Health:

--- a/mods/cameo/rules/z.yaml
+++ b/mods/cameo/rules/z.yaml
@@ -213,7 +213,7 @@ zsniper:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: ra1_allies_alliedsniper
+		Name: Sniper
 	Buildable:
 		BuildPaletteOrder: 25
 		Prerequisites: barracks
@@ -314,7 +314,7 @@ zjeep:
 	Valued:
 		Cost: 250
 	Tooltip:
-		Name: td_gdi_humvee
+		Name: Jeep
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -548,7 +548,7 @@ zapc:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: td_gdi_apc
+		Name: APC
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -757,7 +757,7 @@ zguncan:
 	Valued:
 		Cost: 600
 	Tooltip:
-		Name: td_nod_gunturret Cannon
+		Name: Gun Cannon
 	Buildable:
 		BuildPaletteOrder: 45
 		Prerequisites: barracks
@@ -855,7 +855,7 @@ zmissilecan:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: Missile td_nod_gunturret
+		Name: Missile Gun
 	Buildable:
 		BuildPaletteOrder: 45
 		Prerequisites: barracks, zhq
@@ -1244,12 +1244,12 @@ zfort.zgattlingcan:
 		RemoveInstead: true
 zfort.zguncan:
 	Tooltip:
-		Name: td_nod_gunturret Lascannon
+		Name: Gun Lascannon
 	Buildable:
 		Prerequisites: barracks
 		BuildPaletteOrder: 10
 		Queue: Addon.Zfort
-		Description: Adds Gattling td_nod_gunturret to Fort
+		Description: Adds Gattling Gun to Fort
 		BuildDurationModifier: 100
 		BuildDuration: 1000
 	Valued:
@@ -1278,7 +1278,7 @@ zfort.zhotwizer:
 		RemoveInstead: true
 zfort.zmissilecan:
 	Tooltip:
-		Name: Missiles td_nod_gunturret
+		Name: Missiles Gun
 	Buildable:
 		Prerequisites: barracks
 		BuildPaletteOrder: 10

--- a/mods/cameo/sequences/voxels.yaml
+++ b/mods/cameo/sequences/voxels.yaml
@@ -34,7 +34,7 @@ ra2hornet:
 	idle:
 
 ra2_soviets_seascorpion: #Sea Scorpion
-	idle:
+	idle: ra2hyd
 
 ra2_soviets_sentrygun:
 	turret: ra2laser
@@ -50,14 +50,14 @@ ra2pdplane: #Paradrop plane
 	idle:
 
 ra2_allies_patriotmissilesystem:
-	idle: td_nod_samsite
-	turret: td_nod_samsite
+	idle: sam
+	turret: sam
 
 ra2sapc:
 	idle:
 
 ra2_allies_nighthawk: #Nighthawk
-	idle:
+	idle: ra2shad
 
 ra2sub: #Typhoon Attack Sub
 	idle:
@@ -70,13 +70,13 @@ ra2subt: #Sub Torpedo needs voxel projectiles
 #
 
 yuri_boomersubmarine:
-	idle:
+	idle: yrbsub
 
 yrbsubmisl:
 	idle:
 
 yuri_chaosdrone:
-	idle:
+	idle: yrcaos
 
 yrschd:
 	idle:

--- a/tools/audit/audit_display_text.py
+++ b/tools/audit/audit_display_text.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Detect internal actor ids leaked into player-visible text.
+
+Actor naming migrations must update structural references without rewriting
+ordinary prose.  A case-insensitive ``HAND -> td_nod_handofnod`` replacement,
+for example, must not turn "Hand of Nod" into an internal actor id.
+
+The audit scans:
+
+* display-oriented MiniYAML scalar fields across the whole mod tree;
+* numbered values nested below ``Names`` and ``Descriptions``;
+* every value in Fluent files;
+* music titles; and
+* quoted strings passed to common player-facing Lua APIs.
+
+Comments containing internal ids are reported separately for human inspection.
+They are informational because a comment may intentionally document an actor id.
+
+Files loaded by the active manifest are blocking.  Findings in dormant files
+are reported separately so disabled content can be repaired without blocking
+the live ruleset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+from cameo_model import Model
+from report import h1, h2, table
+
+
+DISPLAY_KEYS = {
+    "briefing", "buttontext", "description", "displayname", "label",
+    "message", "menulabel", "name", "objective", "prompt", "text",
+    "title",
+}
+DISPLAY_CONTAINERS = {"names", "descriptions"}
+
+YAML_SCALAR = re.compile(r"^(?P<indent>\s*)(?P<key>[^:#][^:]*):\s*(?P<value>.*)$")
+FTL_VALUE = re.compile(r"^\s*(?:[A-Za-z0-9_.-]+|\.[A-Za-z0-9_-]+)\s*=\s*(.*)$")
+LUA_STRING = re.compile(r"(?P<quote>['\"])(?P<value>(?:\\.|(?!\1).)*)(?P=quote)")
+LUA_DISPLAY_API = re.compile(
+    r"(?:DisplayMessage(?:ToPlayer)?|Add(?:Primary|Secondary)?Objective|"
+    r"AddObjective|SetMissionText|GetFluentMessage)\s*\("
+)
+COMMENT = re.compile(r"^\s*#\s?(?P<value>.*)$")
+TECHNICAL_DESCRIPTION_REFERENCE = re.compile(
+    r",\s*[!~][A-Za-z0-9_.-]+(?:\s*,|\s*$)")
+
+
+@dataclass(frozen=True)
+class Finding:
+    active: bool
+    path: str
+    line: int
+    field: str
+    ids: tuple[str, ...]
+    value: str
+
+
+def actor_id_pattern(actor_ids: set[str]) -> re.Pattern[str]:
+    """Match migration-style actor ids without matching ordinary words."""
+    candidates = sorted(
+        (a for a in actor_ids
+         if len(a) >= 5 and ("_" in a or "." in a)),
+        key=len,
+        reverse=True,
+    )
+    if not candidates:
+        return re.compile(r"(?!)")
+    return re.compile(
+        r"(?<![A-Za-z0-9_.])(?:" +
+        "|".join(re.escape(a) for a in candidates) +
+        r")(?![A-Za-z0-9_.])",
+        re.IGNORECASE,
+    )
+
+
+def leaked_ids(value: str, pattern: re.Pattern[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(m.group(0).lower() for m in pattern.finditer(value)))
+
+
+def is_technical_reference(finding: Finding) -> bool:
+    return (
+        finding.field.lower() == "description" and
+        TECHNICAL_DESCRIPTION_REFERENCE.search(finding.value) is not None
+    )
+
+
+def yaml_display_value(path: pathlib.Path, line: str,
+                       container: tuple[int, str] | None = None) -> tuple[str, str] | None:
+    match = YAML_SCALAR.match(line)
+    if not match:
+        return None
+    key = match.group("key").strip().lstrip("-").split("@", 1)[0].lower()
+    value = match.group("value").split(" #", 1)[0].strip()
+    if not value:
+        return None
+    if path.name.lower() == "music.yaml" and not match.group("indent"):
+        return "MusicTitle", value
+    if key in DISPLAY_KEYS:
+        return match.group("key").strip(), value
+    if container and len(match.group("indent")) > container[0] and key.isdigit():
+        return f"{container[1]}[]", value
+    return None
+
+
+def scan_text_file(path: pathlib.Path, active: bool, root: pathlib.Path,
+                   pattern: re.Pattern[str], include_comments: bool = False) -> list[Finding]:
+    findings: list[Finding] = []
+    rel = path.relative_to(root).as_posix()
+    lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+    suffix = path.suffix.lower()
+    yaml_container: tuple[int, str] | None = None
+
+    for lineno, line in enumerate(lines, 1):
+        candidates: list[tuple[str, str]] = []
+        if suffix == ".yaml":
+            comment = COMMENT.match(line)
+            if comment and include_comments:
+                candidates.append(("Comment", comment.group("value")))
+
+            match = YAML_SCALAR.match(line)
+            if match:
+                indent = len(match.group("indent"))
+                if yaml_container and indent <= yaml_container[0]:
+                    yaml_container = None
+                key = match.group("key").strip().lstrip("-").split("@", 1)[0].lower()
+                if not match.group("value").strip() and key in DISPLAY_CONTAINERS:
+                    yaml_container = (indent, key.title())
+
+            item = yaml_display_value(path, line, yaml_container)
+            if item:
+                candidates.append(item)
+        elif suffix == ".ftl":
+            match = FTL_VALUE.match(line)
+            if match:
+                candidates.append(("FluentValue", match.group(1).strip()))
+            elif line[:1].isspace() and line.strip() and not line.lstrip().startswith(("#", ".")):
+                candidates.append(("FluentContinuation", line.strip()))
+        elif suffix == ".lua" and LUA_DISPLAY_API.search(line):
+            candidates.extend(("LuaString", m.group("value")) for m in LUA_STRING.finditer(line))
+
+        for field, value in candidates:
+            ids = leaked_ids(value, pattern)
+            if ids:
+                findings.append(Finding(active, rel, lineno, field, ids, value))
+    return findings
+
+
+def collect_findings(root: pathlib.Path | None = None,
+                     include_comments: bool = False) -> list[Finding]:
+    model = Model(root)
+    root = model.root
+    active_paths = {
+        p.resolve() for group in (
+            model.rs.manifest.rules,
+            model.rs.manifest.weapons,
+            model.rs.manifest.sequences,
+            model.rs.manifest.fluent,
+        ) for p in group
+    }
+    active_paths.add((root / "mods/cameo/music.yaml").resolve())
+
+    pattern = actor_id_pattern({a.lower() for a in model.rs.actors})
+    mod = root / "mods/cameo"
+    paths: set[pathlib.Path] = set()
+    for glob in ("**/*.yaml", "**/*.ftl", "**/*.lua"):
+        paths.update(p for p in mod.glob(glob) if p.is_file())
+
+    findings: list[Finding] = []
+    for path in sorted(paths):
+        findings.extend(scan_text_file(
+            path, path.resolve() in active_paths, root, pattern, include_comments))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=pathlib.Path,
+        help="repository worktree to inspect (defaults to this script's repository)",
+    )
+    parser.add_argument(
+        "--include-comments", action="store_true",
+        help="also report comments containing actor ids (informational)",
+    )
+    args = parser.parse_args()
+    findings = collect_findings(args.root, include_comments=args.include_comments)
+    comments = [f for f in findings if f.field == "Comment"]
+    references = [f for f in findings if is_technical_reference(f)]
+    display = [
+        f for f in findings
+        if f.field != "Comment" and not is_technical_reference(f)
+    ]
+    active = [f for f in display if f.active]
+    dormant = [f for f in display if not f.active]
+
+    def rows(items: list[Finding]) -> list[list[str]]:
+        return [[
+            f"{f.path}:{f.line}", f.field, ", ".join(f.ids), f.value,
+        ] for f in items]
+
+    print(h1("audit_display_text — internal ids leaked into UI prose"))
+    print(
+        f"Active findings: **{len(active)}**; dormant findings: **{len(dormant)}**; "
+        f"technical references: **{len(references)}**; "
+        f"comments for inspection: **{len(comments)}**\n"
+    )
+    print(h2(f"D1 — active display text containing actor ids ({len(active)}) — BLOCKING"))
+    print(table(["location", "field", "internal id", "value"], rows(active)))
+    print(h2(f"D2 — dormant display text containing actor ids ({len(dormant)})"))
+    print(table(["location", "field", "internal id", "value"], rows(dormant)))
+    print(h2(f"D0 — technical references in display-named fields ({len(references)}) — INFORMATIONAL"))
+    print(table(["location", "field", "internal id", "value"], rows(references)))
+    if args.include_comments:
+        print(h2(f"D3 — comments containing actor ids ({len(comments)}) — INFORMATIONAL"))
+        print(table(["location", "field", "internal id", "value"], rows(comments)))
+    return 1 if active else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/audit_rename_safety.py
+++ b/tools/audit/audit_rename_safety.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Verify that the unsafe legacy rename applicator fails closed."""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from report import h1, h2, table
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+APPLICATOR = ROOT / "tools" / "rename" / "apply.py"
+
+
+def main() -> int:
+    tree = ast.parse(APPLICATOR.read_text(encoding="utf-8"), filename=str(APPLICATOR))
+    functions = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    ]
+    safe = False
+    if len(functions) == 1 and len(functions[0].body) >= 2:
+        message, stop = functions[0].body[:2]
+        safe = (
+            isinstance(message, ast.Expr) and
+            isinstance(message.value, ast.Call) and
+            isinstance(message.value.func, ast.Name) and
+            message.value.func.id == "print" and
+            isinstance(stop, ast.Return) and
+            isinstance(stop.value, ast.Constant) and
+            stop.value.value == 2
+        )
+
+    print(h1("audit_rename_safety — legacy applicator guard"))
+    print(h2("R1 — context-blind rename applicator must fail closed"))
+    if safe:
+        print("_guard present: main prints an error and returns 2 before legacy code_\n")
+        return 0
+
+    print(table(
+        ["location", "problem"],
+        [["tools/rename/apply.py", "main is not guarded by an immediate return 2"]],
+    ))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit/classify_display_text_history.py
+++ b/tools/audit/classify_display_text_history.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Classify display-text findings against their exact Git history.
+
+This is deliberately read-only.  A finding is eligible for an exact restore
+only when every step back to clean prose is blamed on a rename commit and the
+commit changed no characters outside the leaked internal-id span.  Everything
+else is left for review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import difflib
+import functools
+import pathlib
+import re
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+from audit_display_text import Finding, actor_id_pattern, collect_findings, leaked_ids
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+REFERENCE_IN_DESCRIPTION = re.compile(r",\s*[!~][A-Za-z0-9_.-]+(?:\s*,|\s*$)")
+
+
+@dataclass(frozen=True)
+class Blame:
+    commit: str
+    original_line: int
+    summary: str
+    previous_commit: str | None
+    previous_path: str | None
+    filename: str
+    content: str
+
+
+@dataclass(frozen=True)
+class Classification:
+    finding: Finding
+    decision: str
+    historical_value: str
+    commits: tuple[str, ...]
+    reason: str
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=ROOT, check=False, text=True,
+        encoding="utf-8", errors="replace", stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+@functools.lru_cache(maxsize=None)
+def blame_line(revision: str, path: str, line: int) -> Blame:
+    output = git(
+        "blame", "--line-porcelain", "-C", "-C", "-M",
+        revision, "-L", f"{line},{line}", "--", path,
+    )
+    lines = output.splitlines()
+    header = lines[0].split()
+    metadata: dict[str, str] = {}
+    content = ""
+    for item in lines[1:]:
+        if item.startswith("\t"):
+            content = item[1:]
+            break
+        key, _, value = item.partition(" ")
+        metadata[key] = value
+
+    previous_commit = previous_path = None
+    if "previous" in metadata:
+        previous_commit, previous_path = metadata["previous"].split(" ", 1)
+
+    return Blame(
+        commit=header[0],
+        original_line=int(header[1]),
+        summary=metadata.get("summary", ""),
+        previous_commit=previous_commit,
+        previous_path=previous_path,
+        filename=metadata.get("filename", path),
+        content=content,
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def file_lines(revision: str, path: str) -> tuple[str, ...]:
+    return tuple(git("show", f"{revision}:{path}").splitlines())
+
+
+def value_frame(line: str, value: str) -> tuple[str, str] | None:
+    start = line.find(value)
+    if start < 0:
+        return None
+    return line[:start], line[start + len(value):]
+
+
+def framed_value(line: str, prefix: str, suffix: str) -> str | None:
+    if not line.startswith(prefix) or not line.endswith(suffix):
+        return None
+    end = len(line) - len(suffix) if suffix else len(line)
+    if end < len(prefix):
+        return None
+    return line[len(prefix):end]
+
+
+def rename_summary(summary: str) -> bool:
+    lowered = summary.lower()
+    return "rename" in lowered or "naming migration" in lowered
+
+
+def changes_confined_to_ids(old: str, new: str,
+                            pattern: re.Pattern[str]) -> bool:
+    spans = [(match.start(), match.end()) for match in pattern.finditer(new)]
+    if not spans or old == new:
+        return False
+
+    def inside(position: int) -> bool:
+        return any(start <= position < end for start, end in spans)
+
+    def touches(position: int) -> bool:
+        return any(start <= position <= end for start, end in spans)
+
+    matcher = difflib.SequenceMatcher(a=old, b=new, autojunk=False)
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        if j1 == j2:
+            if not touches(j1):
+                return False
+        elif not all(inside(position) for position in range(j1, j2)):
+            return False
+    return True
+
+
+def classify_one(finding: Finding, pattern: re.Pattern[str]) -> Classification:
+    current_path = ROOT / finding.path
+    current_line = current_path.read_text(
+        encoding="utf-8-sig", errors="replace").splitlines()[finding.line - 1]
+    frame = value_frame(current_line, finding.value)
+    if frame is None:
+        return Classification(finding, "REVIEW", "", (), "value is not unique on its source line")
+    prefix, suffix = frame
+
+    revision = "HEAD"
+    path = finding.path
+    line = finding.line
+    value = finding.value
+    commits: list[str] = []
+
+    for _ in range(16):
+        remaining = leaked_ids(value, pattern)
+        if not remaining:
+            if (finding.field.lower() == "description" and
+                    REFERENCE_IN_DESCRIPTION.search(finding.value)):
+                return Classification(
+                    finding, "KEEP", value, tuple(commits),
+                    "Description contains an explicit hidden prerequisite reference",
+                )
+            return Classification(
+                finding, "FIX", value, tuple(commits),
+                "exact pre-migration display value recovered",
+            )
+
+        blame = blame_line(revision, path, line)
+        if blame.content != framed_line(prefix, value, suffix):
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                "line framing changed while following history",
+            )
+        if not rename_summary(blame.summary):
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                f"last change is not a recognized rename commit: {blame.summary}",
+            )
+        if not blame.previous_commit or not blame.previous_path:
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                "rename commit has no traceable parent line",
+            )
+
+        previous_lines = file_lines(blame.previous_commit, blame.previous_path)
+        if not 1 <= blame.original_line <= len(previous_lines):
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                "parent line number is outside the historical file",
+            )
+        previous_line = previous_lines[blame.original_line - 1]
+        previous_value = framed_value(previous_line, prefix, suffix)
+        if previous_value is None:
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                "non-display characters changed in the rename commit",
+            )
+        if not changes_confined_to_ids(previous_value, value, pattern):
+            return Classification(
+                finding, "REVIEW", value, tuple(commits),
+                "rename commit changed text outside an internal-id span",
+            )
+
+        commits.append(blame.commit)
+        revision = blame.previous_commit
+        path = blame.previous_path
+        line = blame.original_line
+        value = previous_value
+
+    return Classification(
+        finding, "REVIEW", value, tuple(commits),
+        "history traversal exceeded the safety limit",
+    )
+
+
+def framed_line(prefix: str, value: str, suffix: str) -> str:
+    return f"{prefix}{value}{suffix}"
+
+
+def markdown_escape(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", "\\n")
+
+
+def render(results: list[Classification]) -> str:
+    decision_counts = Counter(result.decision for result in results)
+    active_counts = Counter(
+        result.decision for result in results if result.finding.active)
+    by_id: dict[str, Counter[str]] = defaultdict(Counter)
+    for result in results:
+        for actor_id in result.finding.ids:
+            by_id[actor_id][result.decision] += 1
+
+    output = [
+        "# Display-text migration review",
+        "",
+        "This report is read-only. `FIX` means the exact pre-migration value was "
+        "recovered through a rename-only blame chain. `KEEP` is a technical "
+        "reference inside a display-named field. `REVIEW` is never changed "
+        "automatically.",
+        "",
+        f"Findings: **{len(results)}**; FIX: **{decision_counts['FIX']}**; "
+        f"KEEP: **{decision_counts['KEEP']}**; REVIEW: **{decision_counts['REVIEW']}**.",
+        "",
+        f"Active findings — FIX: **{active_counts['FIX']}**; "
+        f"KEEP: **{active_counts['KEEP']}**; REVIEW: **{active_counts['REVIEW']}**.",
+        "",
+        "## Identifier-family separation",
+        "",
+        "| internal id | FIX | KEEP | REVIEW |",
+        "|---|---:|---:|---:|",
+    ]
+    for actor_id in sorted(by_id):
+        counts = by_id[actor_id]
+        output.append(
+            f"| `{actor_id}` | {counts['FIX']} | {counts['KEEP']} | {counts['REVIEW']} |"
+        )
+
+    for decision in ("KEEP", "REVIEW", "FIX"):
+        items = [result for result in results if result.decision == decision]
+        output.extend([
+            "",
+            f"## {decision} ({len(items)})",
+            "",
+            "| active | location | field | current value | historical value | provenance | reason |",
+            "|---|---|---|---|---|---|---|",
+        ])
+        for result in sorted(
+                items,
+                key=lambda item: (
+                    not item.finding.active, item.finding.path, item.finding.line,
+                    item.finding.field,
+                )):
+            finding = result.finding
+            commits = ", ".join(f"`{commit[:10]}`" for commit in result.commits)
+            output.append(
+                "| {active} | `{path}:{line}` | `{field}` | {current} | {historical} | "
+                "{commits} | {reason} |".format(
+                    active="yes" if finding.active else "no",
+                    path=finding.path,
+                    line=finding.line,
+                    field=markdown_escape(finding.field),
+                    current=markdown_escape(finding.value),
+                    historical=markdown_escape(result.historical_value),
+                    commits=commits,
+                    reason=markdown_escape(result.reason),
+                )
+            )
+    return "\n".join(output) + "\n"
+
+
+def main() -> int:
+    global ROOT
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=pathlib.Path, default=ROOT,
+        help="repository worktree to inspect (defaults to this script's repository)",
+    )
+    parser.add_argument("--output", type=pathlib.Path, help="write Markdown report to this path")
+    parser.add_argument("--jobs", type=int, default=8, help="parallel Git blame workers")
+    args = parser.parse_args()
+    ROOT = args.root.resolve()
+
+    findings = collect_findings(ROOT)
+    all_ids = {actor_id for finding in findings for actor_id in finding.ids}
+    pattern = actor_id_pattern(all_ids)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as executor:
+        results = list(executor.map(lambda finding: classify_one(finding, pattern), findings))
+
+    report = render(results)
+    if args.output:
+        output = args.output if args.output.is_absolute() else ROOT / args.output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(report, encoding="utf-8", newline="\n")
+    else:
+        print(report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit/repair_display_text.py
+++ b/tools/audit/repair_display_text.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Apply only Git-proven display-text restorations with exact assertions."""
+
+from __future__ import annotations
+
+import argparse
+import codecs
+import concurrent.futures
+import pathlib
+from collections import Counter, defaultdict
+
+import classify_display_text_history as history
+from audit_display_text import actor_id_pattern, collect_findings
+
+
+def classify(root: pathlib.Path, jobs: int) -> list[history.Classification]:
+    history.ROOT = root
+    history.blame_line.cache_clear()
+    history.file_lines.cache_clear()
+    findings = collect_findings(root)
+    actor_ids = {actor_id for finding in findings for actor_id in finding.ids}
+    pattern = actor_id_pattern(actor_ids)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, jobs)) as executor:
+        return list(executor.map(
+            lambda finding: history.classify_one(finding, pattern), findings))
+
+
+def apply_exact(root: pathlib.Path,
+                results: list[history.Classification], write: bool) -> int:
+    by_path: dict[str, list[history.Classification]] = defaultdict(list)
+    for result in results:
+        if result.decision == "FIX":
+            by_path[result.finding.path].append(result)
+
+    changed = 0
+    for relative_path, items in sorted(by_path.items()):
+        path = root / relative_path
+        raw = path.read_bytes()
+        bom = codecs.BOM_UTF8 if raw.startswith(codecs.BOM_UTF8) else b""
+        text = raw[len(bom):].decode("utf-8")
+        lines = text.splitlines(keepends=True)
+
+        seen_lines: set[int] = set()
+        for result in sorted(items, key=lambda item: item.finding.line):
+            finding = result.finding
+            if finding.line in seen_lines:
+                raise RuntimeError(
+                    f"multiple approved repairs target {relative_path}:{finding.line}")
+            seen_lines.add(finding.line)
+            index = finding.line - 1
+            if not 0 <= index < len(lines):
+                raise RuntimeError(f"missing target line {relative_path}:{finding.line}")
+            if lines[index].count(finding.value) != 1:
+                raise RuntimeError(
+                    f"expected current value exactly once at "
+                    f"{relative_path}:{finding.line}: {finding.value!r}")
+            if not result.historical_value:
+                raise RuntimeError(
+                    f"empty historical value at {relative_path}:{finding.line}")
+            lines[index] = lines[index].replace(
+                finding.value, result.historical_value, 1)
+            changed += 1
+
+        new_raw = bom + "".join(lines).encode("utf-8")
+
+        # Byte-for-byte reversibility proves that no character outside the
+        # approved scalar values changed, including BOMs and line endings.
+        reverse_lines = new_raw[len(bom):].decode("utf-8").splitlines(keepends=True)
+        for result in sorted(items, key=lambda item: item.finding.line):
+            index = result.finding.line - 1
+            if reverse_lines[index].count(result.historical_value) != 1:
+                raise RuntimeError(
+                    f"historical value is not uniquely reversible at "
+                    f"{relative_path}:{result.finding.line}")
+            reverse_lines[index] = reverse_lines[index].replace(
+                result.historical_value, result.finding.value, 1)
+        reconstructed = bom + "".join(reverse_lines).encode("utf-8")
+        if reconstructed != raw:
+            raise RuntimeError(
+                f"structural equivalence failed for {relative_path}")
+
+        if write:
+            path.write_bytes(new_raw)
+            if path.read_bytes() != new_raw:
+                raise RuntimeError(f"write verification failed for {relative_path}")
+
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=pathlib.Path, required=True)
+    parser.add_argument("--apply", action="store_true", help="write approved changes")
+    parser.add_argument("--jobs", type=int, default=8)
+    parser.add_argument("--expect-fix", type=int, required=True)
+    parser.add_argument("--expect-keep", type=int, required=True)
+    parser.add_argument("--expect-review", type=int, required=True)
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    results = classify(root, args.jobs)
+    counts = Counter(result.decision for result in results)
+    expected = {
+        "FIX": args.expect_fix,
+        "KEEP": args.expect_keep,
+        "REVIEW": args.expect_review,
+    }
+    actual = {key: counts[key] for key in expected}
+    if actual != expected:
+        raise RuntimeError(
+            f"classification changed; refusing repair: expected {expected}, got {actual}")
+
+    changed = apply_exact(root, results, args.apply)
+    mode = "applied" if args.apply else "verified"
+    print(f"{mode} {changed} exact display-text restorations in {root}")
+    print(f"classification: {actual}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit/run_all.sh
+++ b/tools/audit/run_all.sh
@@ -23,7 +23,7 @@ failed=0
 for a in inherits faction_leaks upgrades upgrade_coverage ai sequences \
          metadata outliers orphans assets fluent power_budget stat_formulas \
          weapon_uniqueness garrison_weapons asset_files promotion_gating min_range \
-         basebuilder_crates buildable_order; do
+         basebuilder_crates buildable_order display_text rename_safety; do
   echo "== audit_$a"
   "$PYTHON" "tools/audit/audit_$a.py" "$@" > "$OUT/$a.md" 2> "$OUT/$a.err" \
     || failed=1

--- a/tools/audit/test_audit_display_text.py
+++ b/tools/audit/test_audit_display_text.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+import pathlib
+import tempfile
+
+from audit_display_text import actor_id_pattern, leaked_ids, scan_text_file
+
+
+class DisplayTextAuditTests(unittest.TestCase):
+    def setUp(self):
+        self.pattern = actor_id_pattern({
+            "td_nod_handofnod", "td_nod_gunturret", "td_gdi_apc",
+        })
+
+    def test_internal_id_in_prose_is_detected(self):
+        self.assertEqual(
+            leaked_ids("Black td_nod_handofnod Flamer", self.pattern),
+            ("td_nod_handofnod",),
+        )
+
+    def test_ordinary_words_are_not_actor_ids(self):
+        for value in ("Hand of Nod", "Black Hand", "left hand", "machine gun", "APC Truck"):
+            self.assertEqual(leaked_ids(value, self.pattern), ())
+
+    def test_identifier_boundaries_avoid_partial_matches(self):
+        self.assertEqual(leaked_ids("x_td_nod_handofnod", self.pattern), ())
+
+    def test_nested_display_lists_and_comments_are_detected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            path = root / "rules.yaml"
+            path.write_text(
+                "Power:\n"
+                "\tNames:\n"
+                "\t\t1: Unlock td_gdi_apc\n"
+                "\tActors:\n"
+                "\t\t1: td_gdi_apc\n"
+                "# Black td_nod_handofnod infantry\n",
+                encoding="utf-8",
+            )
+            findings = scan_text_file(path, True, root, self.pattern, include_comments=True)
+
+        self.assertEqual(
+            [(f.field, f.value) for f in findings],
+            [
+                ("Names[]", "Unlock td_gdi_apc"),
+                ("Comment", "Black td_nod_handofnod infantry"),
+            ],
+        )
+
+    def test_structural_lua_strings_are_not_display_text(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            path = root / "script.lua"
+            path.write_text(
+                'Actor.Create("td_gdi_apc")\n'
+                'Media.DisplayMessage("Destroy the td_gdi_apc")\n',
+                encoding="utf-8",
+            )
+            findings = scan_text_file(path, False, root, self.pattern)
+
+        self.assertEqual(
+            [(f.field, f.value) for f in findings],
+            [("LuaString", "Destroy the td_gdi_apc")],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/audit/test_classify_display_text_history.py
+++ b/tools/audit/test_classify_display_text_history.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+from audit_display_text import actor_id_pattern
+from classify_display_text_history import changes_confined_to_ids, framed_value, value_frame
+
+
+class DisplayTextHistoryTests(unittest.TestCase):
+    def setUp(self):
+        self.pattern = actor_id_pattern({"td_nod_handofnod", "td_nod_gunturret"})
+
+    def test_exact_context_blind_rename_is_accepted(self):
+        self.assertTrue(changes_confined_to_ids(
+            "Hand of Nod", "td_nod_handofnod of Nod", self.pattern))
+        self.assertTrue(changes_confined_to_ids(
+            "Machine Gun Turret", "Machine td_nod_gunturret Turret", self.pattern))
+
+    def test_unrelated_wording_change_is_rejected(self):
+        self.assertFalse(changes_confined_to_ids(
+            "Hand of Nod", "Advanced td_nod_handofnod of Nod", self.pattern))
+
+    def test_value_frame_round_trip(self):
+        line = "\t\tName: td_nod_handofnod of Nod # barracks"
+        prefix, suffix = value_frame(line, "td_nod_handofnod of Nod")
+        self.assertEqual(prefix, "\t\tName: ")
+        self.assertEqual(suffix, " # barracks")
+        self.assertEqual(framed_value(
+            "\t\tName: Hand of Nod # barracks", prefix, suffix), "Hand of Nod")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/audit/test_rename_apply_disabled.py
+++ b/tools/audit/test_rename_apply_disabled.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import unittest
+
+
+class RenameApplySafetyTests(unittest.TestCase):
+    def test_legacy_applicator_fails_closed(self):
+        path = pathlib.Path(__file__).resolve().parents[1] / "rename" / "apply.py"
+        spec = importlib.util.spec_from_file_location("legacy_rename_apply", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            result = module.main()
+
+        self.assertEqual(result, 2)
+        self.assertIn("is disabled", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/rename/apply.py
+++ b/tools/rename/apply.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""apply.py — mechanically apply a rename map (MASTER_REPORT §9.6 step 3).
+"""Disabled legacy rename-map applicator.
+
+This script is intentionally blocked because it rewrites identifiers without
+syntax or namespace context and resolves asset renames by bare filename. It is
+kept only as a record of the failed migration and must not be used.
 
 Usage:  python tools/rename/apply.py tools/rename/rename_map_<faction>.yaml
 
@@ -83,6 +87,13 @@ def audio_voice_keys() -> set[str]:
 
 
 def main() -> int:
+    print(
+        "ERROR: tools/rename/apply.py is disabled. Its context-blind text "
+        "replacement and bare-filename asset lookup caused cross-namespace "
+        "corruption, map incompatibility, and incorrect sprite selection."
+    )
+    return 2
+
     if len(sys.argv) != 2:
         print(__doc__)
         return 2


### PR DESCRIPTION
## Summary

- restore the exact pre-migration wording for 428 player-visible fields corrupted by context-blind actor renames, including Hand of Nod
- point six RA2/Yuri voxel sequence fields at their existing asset basenames
- add active-manifest display-text detection, Git-history classification, an exact-value repair tool, regression tests, and a complete repair manifest
- disable the unsafe legacy rename applicator and audit that it remains fail-closed

## Root cause

The legacy rename-map applicator replaced actor tokens case-insensitively across YAML, Fluent, and Lua without understanding syntax or namespace. Common identifiers such as `HAND`, `GUN`, and `APC` were therefore rewritten inside ordinary UI prose. Actor renames also changed sequence keys without changing several voxel basenames, while `sam` was incorrectly rewritten to the TD Nod SAM-site actor ID.

The display repairs are limited to values whose exact pre-migration form can be recovered through a rename-only Git blame chain. One technical Ixian reference inside a display-named field is intentionally retained and documented.

## Impact

- unit, upgrade, support-power, and music text no longer exposes internal actor IDs
- TD Nod's barracks is displayed as Hand of Nod again
- Sea Scorpion, Patriot Missile System, Nighthawk, Boomer Submarine, and Chaos Drone resolve their voxel assets
- future context-blind rename runs fail closed, and similar UI leaks are detected by the audit suite

## Validation

- `python tools/audit/test_audit_display_text.py`
- `python tools/audit/test_classify_display_text_history.py`
- `python tools/audit/test_rename_apply_disabled.py`
- `python tools/audit/audit_display_text.py`
- `python tools/audit/audit_rename_safety.py`
- `python tools/audit/audit_fluent.py`
- `python tools/audit/audit_metadata.py`
- `python tools/audit/audit_asset_files.py`
- `python tools/audit/audit_ai.py`
- `python tools/audit/audit_sequences.py`
- `git diff --check`

All checks pass. The branch is based directly on current upstream `master` and contains no Volcanic Theater changes.
