### PR TITLE
Fix runtime sequence crashes

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/buildings.yaml
@@ -169,6 +169,7 @@ ra1_allies_alliedtechcenter:
 	RenderDetectionCircle:
 	WithBuildingBib:
 	GpsPower:
+		DoorImage: ra1_allies_alliedtechcenter
 		Prerequisites:
 			1: ra1_allies_upgrade_gpssatellitesupport
 		Icons:

--- a/mods/cameo/ContentPacks/TKM/TKM/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TKM/TKM/yaml/infantry.yaml
@@ -135,6 +135,8 @@ tkm_marine:
 		RequiresCondition: !parachute
 	WithDeathAnimation:
 		DeathSequencePalette: raplayer
+		DeathTypes:
+			SmallExplosionDeath: 2
 	RenderSprites:
 		Image: ra2_allies_seal
 		PlayerPalette: playerra2


### PR DESCRIPTION
## Summary

- remap the TKM Marine small-explosion death to the existing `die2` sequence
- point the RA1 Allied Tech Center GPS launch at its renamed door image

## Root cause

TKM Marine renders with the RA2 SEAL image but inherited a death mapping that requested the undefined `die3` sequence.

The RA1 legacy-ID rename changed the Allied Tech Center sequence image from `atek` to `ra1_allies_alliedtechcenter`, while its GPS power still relied on the engine's `atek` default.

## Impact

Prevents runtime crashes when a TKM Marine dies from small-explosion damage and when the Allied GPS satellite support power activates.

## Validation

- `git diff upstream/master...HEAD --check`
- resolved `tkm_marine` rules map `SmallExplosionDeath` to `2`
- resolved Allied Tech Center GPS rules use `DoorImage: ra1_allies_alliedtechcenter`
- resolved Allied Tech Center `active` door sequence exists
