### PR TITLE
Restore missing RA2 wall sequences

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/sequences.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/sequences.yaml
@@ -4985,3 +4985,44 @@ ra2zbomb:
 		Facings: 32
 		ZOffset: 1023
 
+ra2_awall:
+	Defaults:
+		Filename: ra2_awall.shp
+	idle:
+		Length: 16
+	scratched-idle:
+		Start: 16
+		Length: 16
+	damaged-idle:
+		Start: 32
+		Length: 16
+	icon:
+		Filename: ra2_awallicon.png
+
+ra2_swall:
+	Defaults:
+		Filename: ra2_swall.shp
+	idle:
+		Length: 16
+	scratched-idle:
+		Start: 16
+		Length: 16
+	damaged-idle:
+		Start: 32
+		Length: 16
+	icon:
+		Filename: ra2_swallicon.png
+
+ra2_ywall:
+	Defaults:
+		Filename: ra2_ywall.shp
+	idle:
+		Length: 16
+	scratched-idle:
+		Start: 16
+		Length: 16
+	damaged-idle:
+		Start: 32
+		Length: 16
+	icon:
+		Filename: ra2_ywallicon.png


### PR DESCRIPTION
## What changed

- Restore the `ra2_awall`, `ra2_swall`, and `ra2_ywall` sequence definitions in the active Red Alert 2 Shared content pack.

## Why

The RA2 content-pack migration copied the shared sequence file only through `ra2zbomb`, leaving the three wall definitions behind in the disabled monolithic sequence file. Opening the affected production palette therefore threw `System.InvalidOperationException` because `ra2_ywall` had no loaded sequences.

## Impact

Allied, Soviet, and Yuri wall icons and sprites can now be resolved from the active content pack, preventing the production-palette crash.

## Validation

- Confirmed all three definitions exactly match the legacy sequence blocks.
- Confirmed all referenced SHP and PNG assets exist.
- `git diff --check` passes.
- YAML-only change; no engine rebuild required.
