### PR TITLE
Fix SM and Naxis passive income buildings

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
@@ -16,8 +16,6 @@ naxis_constructionyard:
 	WithBuildingPlacedOverlay:
 	ProvidesPrerequisite@ra2swall:
 		Prerequisite: ra2swall
-	ProvidesPrerequisite@ra2oilderrick:
-		Prerequisite: ra2oilderrick
 	Exit@1:
 		SpawnOffset: 213,-128,0
 		ExitCell: 1,2

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/buildings.yaml
@@ -18,8 +18,6 @@ schwarzermond_constructionyard:
 	WithBuildingPlacedOverlay:
 	ProvidesPrerequisite@ra2ywall:
 		Prerequisite: ra2ywall
-	ProvidesPrerequisite@ra2oilderrick:
-		Prerequisite: ra2oilderrick
 	Exit@1:
 		SpawnOffset: 213,-128,0
 		ExitCell: 1,2
@@ -601,7 +599,7 @@ schwarzermond_moondairyfarm:
 	Buildable:
 		Queue: Building, RABuilding
 		Description: Produces Passive income and adds hp bonus with Infantry
-		Prerequisites: ~schwarzermond_constructionyard, schwarzermond_techcenter, ~techlevel.medium, derricklimit
+		Prerequisites: ~schwarzermond_constructionyard, schwarzermond_techcenter, derricklimit
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2


### PR DESCRIPTION
## Summary

- Remove the generic RA2 Oil Derrick prerequisite from the Schwarzer Mond construction yard.
- Remove the same prerequisite from the Naxis construction yard.
- Remove Schwarzer Mond Moon Dairy Farm's stale `techlevel.medium` hide-gate.
- Preserve the faction-specific wall prerequisites.

## Root cause

Two recent changes interacted:

1. Commit `b4061b8d3939e9f89c88e0049705c48c6d93059f` replaced Cameo's old tech-level choices with the superweapon restriction dropdown. Cameo no longer provides `techlevel.medium`, but Moon Dairy Farm still required `~techlevel.medium`, leaving it permanently hidden.
2. Commit `4c6d4bfaa39369121e7add4686298d345eb7d30c` then broadly enabled the RA2 Oil Derrick for RA2-universe factions, including Schwarzer Mond and Naxis, despite both having native passive-income structures.

## Impact

Moon Dairy Farm is visible in Schwarzer Mond's building palette and becomes buildable after constructing the Schwarzer Mond Tech Center, subject to the passive-income limit. It remains hidden from every other faction.

Naxis continues to use its Beer Factory and Sausage Factory instead of also receiving the generic RA2 Oil Derrick.

## Validation

- `git diff --check`
- Headless `--faction-report schwarzermond`:
  - before: `schwarzermond_moondairyfarm *NONE`
  - after: Moon Dairy Farm is reachable
- Headless `--tilde-audit visibility`:
  - Schwarzer Mond: `VISIBLE_LOCKED`
  - all 27 other factions: `HIDDEN`
- Confirmed the final diff contains only the two faction building files.

No build is required for this YAML-only change.
