### PR TITLE
Remove bibs from Obelisk and Tesla Coil

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/defenses.yaml
@@ -202,8 +202,6 @@ ra1_soviets_teslacoil:
 	SelectionDecorations:
 	Health:
 		HP: 90000
-	WithBuildingBib:
-		HasMinibib: true
 	WithTeslaChargeAnimation:
 	Armament:
 		Weapon: TeslaZap

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/sequences.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/sequences.yaml
@@ -970,7 +970,6 @@ ra1_soviets_flametower:
 		Filename: ra1_soviets_flametower_icon.png
 
 ra1_soviets_teslacoil:
-	Inherits: ^WithBuildingBibTsla
 	Defaults:
 		Filename: ra1_soviets_teslacoil.shp
 		Offset: 0,-26
@@ -989,8 +988,6 @@ ra1_soviets_teslacoil:
 		Length: 9
 		Tick: 100
 	dead:
-	bib:
-		Offset: 0,0
 	icon:
 		Filename: ra1_soviets_teslacoil_icon.png
 		Offset: 0,0

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
@@ -562,8 +562,6 @@ td_nod_obeliskoflight:
 	SelectionDecorations:
 	Health:
 		HP: 242500
-	WithBuildingBib:
-		HasMinibib: true
 	-WithSpriteBody:
 	WithChargeSpriteBody:
 		Sequence: active

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/sequences.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/sequences.yaml
@@ -289,7 +289,6 @@ td_nod_templeprime:
 		Offset: 0,0
 
 td_nod_obeliskoflight:
-	Inherits: ^WithBuildingBibTsla
 	Defaults:
 		Filename: td_nod_obeliskoflight.shp
 		Offset: 0,-24
@@ -310,8 +309,6 @@ td_nod_obeliskoflight:
 		Filename: td_nod_obeliskoflight_make.shp
 		Length: 13
 		Tick: 80
-	bib:
-		Offset: -5,-10
 	icon:
 		Filename: td_nod_obeliskoflight_icon.shp
 		Offset: 0,0


### PR DESCRIPTION
## Summary

- remove the minibib from Tiberian Dawn Nod's Obelisk of Light
- remove the minibib from Red Alert's Soviet Tesla Coil
- remove the now-unused bib sequence inheritance and overrides

## Why

These narrow defensive structures were configured with the Tesla building bib despite their artwork not needing the additional ground foundation.

## Impact

The Obelisk of Light and Tesla Coil now render without a bib. Their gameplay behavior, footprint, selection bounds, and combat statistics are unchanged.

## Validation

- `git diff --check`
- focused audit confirmed no `WithBuildingBib` trait or `bib` sequence remains in either target actor
