### PR TITLE
Add charging lens flares to Obelisk defenses

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="b89ae60"
+ENGINE_VERSION="2e0783c0e482d8e853e6611f46f4cf660613a668"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
@@ -567,12 +567,20 @@ td_nod_obeliskoflight:
 		Sequence: active
 	Armament:
 		Weapon: LaserObelisk
-		LocalOffset: 0,-85,1280
+		LocalOffset: -43,-85,1259
 	AttackCharges:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: lowpower || disabled
 		ChargeLevel: 50
 		ChargingCondition: charging
+	WithChargeLensFlare:
+		RequiresCondition: !build-incomplete
+		RayColor: FF3B00D0
+		CoreColor: FFFFFFFF
+		Size: 64, 72
+		Width: 2.5
+		CoreSize: 5
+		ZOffset: 3001
 	AmbientSound:
 		RequiresCondition: charging
 		SoundFiles: obelpowr.aud

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
@@ -149,6 +149,14 @@ cabal_heavycabalobelisk:
 		PauseOnCondition: lowpower || disabled
 		ChargeLevel: 50
 		ChargingCondition: charging
+	WithChargeLensFlare:
+		RequiresCondition: !build-incomplete
+		RayColor: CC22DDE0
+		CoreColor: FFFFFFFF
+		Size: 64, 72
+		Width: 2.5
+		CoreSize: 5
+		ZOffset: 1
 	AmbientSoundCA:
 		RequiresCondition: charging
 		SoundFiles: cabal_obelisk_charge.wav
@@ -202,12 +210,20 @@ cabal_obeliskofdarkness:
 	WithSpriteBody:
 	Armament:
 		Weapon: DarkObeliskLaser
-		LocalOffset: -85,-43,1600
+		LocalOffset: -128,-43,1600
 	AttackCharges:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: lowpower || disabled
 		ChargeLevel: 30
 		ChargingCondition: charging
+	WithChargeLensFlare:
+		RequiresCondition: !build-incomplete
+		RayColor: CC22DDE0
+		CoreColor: FFFFFFFF
+		Size: 64, 72
+		Width: 2.5
+		CoreSize: 5
+		ZOffset: 1
 	AmbientSound:
 		RequiresCondition: charging
 		SoundFiles: obelpowr.aud

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
@@ -350,18 +350,27 @@ ts_nod_obeliskoflight:
 	Armament@PRIMARY:
 		Weapon: TSObeliskLaserFire
 		# LocalOffset: 0,180,1600
-		LocalOffset: 0,320,1280
+		LocalOffset: 0,277,1323
 		RequiresCondition: !ts_nod_upgrade_tiberiumlenses
 	Armament@UPGRADE:
 		Weapon: TSLaserObeliskLaserFire
 		# LocalOffset: 0,180,1600
-		LocalOffset: 0,320,1280
+		LocalOffset: 0,277,1323
 		RequiresCondition: ts_nod_upgrade_tiberiumlenses
 	AttackCharges:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: lowpower || disabled
 		ChargeLevel: 50
 		ChargingCondition: charging
+	WithChargeLensFlare:
+		RequiresCondition: !build-incomplete
+		Armaments: primary
+		RayColor: FF3B00D0
+		CoreColor: FFFFFFFF
+		Size: 64, 72
+		Width: 2.5
+		CoreSize: 5
+		ZOffset: 1
 	AmbientSound:
 		RequiresCondition: charging
 		SoundFiles: obelpowr.aud


### PR DESCRIPTION
## Summary

- pin the engine to merged [cameo-mod/OpenRA#85](https://github.com/cameo-mod/OpenRA/pull/85)
- add charge-level-driven lens flares to the TD Nod, TS Nod, CABAL Fortified, and CABAL Darkness Obelisks
- render from each active armament's real muzzle, including automatic selection between TS Nod's normal and Tiberium Lenses armaments
- preserve the existing faction flare colors and firing behavior
- include the maintainer-approved muzzle alignments for the TD, TS, and Darkness Obelisks

## Behavior

The charging flare fades with normalized `AttackCharges.ChargeLevel`, including smooth discharge after cancellation or target loss. At firing, the engine hands off to the existing projectile source flare without a gap or double-bright frame. Disabled, low-power, sell, destruction, visibility, and fog states are handled by the reusable engine trait.

## Validation

- mandatory `tools\preflight-build.ps1`: passed at `2e0783c0e482d8e853e6611f46f4cf660613a668`
- `./make all` Release build: 0 warnings, 0 errors
- runtime DLL byte markers confirmed: `WithChargeLensFlareInfo`, `LensFlareRenderable`, and `NormalizedChargeLevel`
- `--resolved-rules` passed for all four active Obelisk actors with their final muzzle offsets
- in-game visual testing completed for all four Obelisks; final positioning approved by the maintainer
- engine PR benchmark: approximately 1.51-1.56 microseconds per 100 charging actors per frame, with no steady-state allocation
- `git diff --check`

No `--check-yaml` command was run.
