### PR TITLE
Add building count display toggle

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoSettings.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Cameo.Traits
 		[Desc("Enables Quota Mode: production buildings auto-requeue units to maintain alive count targets.")]
 		public bool QuotaModeEnabled = false;
 
+		[Desc("Show the number of owned buildings of each type on the production palette.")]
+		public bool ShowBuildingCounts = true;
+
 		[Desc("Selected cyberintel UI colour theme. On change, the matching baked chrome sheets are ",
 			"copied over the active ones (applies after restart). Options live in uibits/cyberintel_themes/. ",
 			"\"random\" re-picks a colour on every boot.")]

--- a/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/CameoGameplaySettingsLogic.cs
@@ -69,6 +69,14 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 				quotaManager?.SetEnabled(cameoSettings.QuotaModeEnabled);
 			};
 
+			var buildingCountsCheckbox = panel.Get<CheckboxWidget>("BUILDING_COUNTS_CHECKBOX");
+			buildingCountsCheckbox.IsChecked = () => cameoSettings.ShowBuildingCounts;
+			buildingCountsCheckbox.OnClick = () =>
+			{
+				cameoSettings.ShowBuildingCounts ^= true;
+				cameoSettings.Save();
+			};
+
 			return () => false;
 		}
 

--- a/OpenRA.Mods.Cameo/Widgets/QuotaProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Cameo/Widgets/QuotaProductionPaletteWidget.cs
@@ -32,10 +32,14 @@ namespace OpenRA.Mods.Cameo.Widgets
 		SpriteFont quotaFont;
 		SpriteFont hoverHeaderFont;
 		SpriteFont symbolFont;
+		readonly CameoSettings cameoSettings;
 
 		[ObjectCreator.UseCtor]
 		public QuotaProductionPaletteWidget(ModData modData, OrderManager orderManager, World world, WorldRenderer worldRenderer)
-			: base(modData, orderManager, world, worldRenderer) { }
+			: base(modData, orderManager, world, worldRenderer)
+		{
+			cameoSettings = modData.GetSettings<CameoSettings>();
+		}
 
 		public override void Initialize(WidgetArgs args)
 		{
@@ -103,7 +107,7 @@ namespace OpenRA.Mods.Cameo.Widgets
 			if (localPlayer == null || CurrentQueue == null)
 				return;
 
-			if (CurrentQueue.Info.Group == MainStructureProductionGroup)
+			if (cameoSettings.ShowBuildingCounts && CurrentQueue.Info.Group == MainStructureProductionGroup)
 			{
 				var structureCounts = World.ActorsHavingTrait<Building>()
 					.Where(a => a.Owner == localPlayer && !a.IsDead)

--- a/mods/cameo/chrome/settings_gameplay.yaml
+++ b/mods/cameo/chrome/settings_gameplay.yaml
@@ -70,3 +70,18 @@ Container@GAMEPLAY_PANEL:
 									Text: checkbox_quota_mode.label
 									TooltipText: checkbox_quota_mode.tooltip
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+				Container@BUILDING_COUNTS_ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 25
+					Children:
+						Container@BUILDING_COUNTS_CHECKBOX_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH - 20
+							Children:
+								Checkbox@BUILDING_COUNTS_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-building-counts.label
+									TooltipText: checkbox-building-counts.tooltip
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -312,6 +312,8 @@ checkbox_flash_transients_container =
     .tooltip = Flash important game-event notifications (base/unit under attack, superweapons) to draw attention
 
 ## settings_gameplay.yaml
+checkbox-building-counts.label = Show building counts in build menu
+checkbox-building-counts.tooltip = Display the number of owned buildings of each type on their build-menu icons.
 label_game_play_section_header = Gameplay
 auto-save-interval-label = Auto-save interval
 auto_save_nr_label = Auto-save files


### PR DESCRIPTION
## Summary

- add a Gameplay setting to show or hide owned building counts in the build menu
- keep the setting enabled by default to preserve the existing behavior
- persist the preference in Cameo settings and apply changes immediately

## Why

The green owned-building count overlay was always visible. Players can now disable it when they prefer an uncluttered production palette.

## Validation

- `git diff --check`
- full `./make all` completed successfully before updating to the latest master base: 0 warnings, 0 errors
- installed `OpenRA.Mods.Cameo.dll` byte-scan confirmed the new setting marker
- final-base preflight correctly stopped because the local engine tree is still at `5965336e...` while current master pins `35b13f0`; no destructive engine sync or pin change was performed
