### PR TITLE
Update 20260722

### DIFF
--- a/OpenRA.Mods.Cameo.Test/StatisticsWindowLogicTest.cs
+++ b/OpenRA.Mods.Cameo.Test/StatisticsWindowLogicTest.cs
@@ -1,0 +1,51 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Globalization;
+using NUnit.Framework;
+using OpenRA.Mods.Cameo.Traits;
+using OpenRA.Mods.Cameo.Widgets.Logic;
+
+namespace OpenRA.Mods.Cameo.Test
+{
+	[TestFixture]
+	public sealed class StatisticsWindowLogicTest
+	{
+		[TestCase(999, "999")]
+		[TestCase(1000, "1K")]
+		[TestCase(1250, "1.3K")]
+		[TestCase(999999, "1M")]
+		[TestCase(999999999, "1B")]
+		[TestCase(999999999999, "1T")]
+		[TestCase(-999999, "-1M")]
+		public void MetricUsesNormalizedSuffixes(long value, string expected)
+		{
+			var previousCulture = CultureInfo.CurrentCulture;
+			try
+			{
+				CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+				Assert.That(StatisticsWindowLogic.Metric(value), Is.EqualTo(expected));
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = previousCulture;
+			}
+		}
+
+		[TestCase(WinState.Undefined, null)]
+		[TestCase(WinState.Won, "Won")]
+		[TestCase(WinState.Lost, "Lost")]
+		public void RecorderAcceptsOnlyFinalOutcomes(WinState state, string expected)
+		{
+			Assert.That(CameoCareerRecorder.FinalOutcome(state), Is.EqualTo(expected));
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
@@ -27,39 +27,45 @@ namespace OpenRA.Mods.Cameo.Traits
 	public class CameoCareerRecorder : ITick, INotifyWinStateChanged
 	{
 		bool recorded;
+		bool outcomeNotified;
 		int retryCount;
 		int nextAttemptTick;
 		PendingCameoCareerMatch pending;
 
 		void ITick.Tick(Actor self)
 		{
-			if (recorded || self.World.WorldTick < nextAttemptTick)
+			var world = self.World;
+			if (recorded || !outcomeNotified || self != world.LocalPlayer?.PlayerActor ||
+				world.WorldTick < nextAttemptTick)
 				return;
 
+			pending ??= Capture(world);
 			if (pending == null)
 				return;
 
-			TryPersist(self.World.WorldTick);
+			TryPersist(world.WorldTick);
 		}
 
 		void INotifyWinStateChanged.OnPlayerWon(OpenRA.Player player)
 		{
-			CaptureAndPersist(player, "Won");
+			if (player == player.World.LocalPlayer)
+				outcomeNotified = true;
 		}
 
 		void INotifyWinStateChanged.OnPlayerLost(OpenRA.Player player)
 		{
-			CaptureAndPersist(player, "Lost");
+			if (player == player.World.LocalPlayer)
+				outcomeNotified = true;
 		}
 
-		void CaptureAndPersist(OpenRA.Player player, string outcome)
+		internal void FinalizeMatch(World world)
 		{
-			if (recorded || pending != null)
+			if (recorded)
 				return;
 
-			pending = Capture(player, outcome);
-			if (pending != null)
-				TryPersist(player.World.WorldTick);
+			pending ??= Capture(world);
+			for (var i = 0; pending != null && i < 5 && !recorded; i++)
+				TryPersist(world.WorldTick);
 		}
 
 		void TryPersist(int worldTick)
@@ -73,11 +79,15 @@ namespace OpenRA.Mods.Cameo.Traits
 			}
 		}
 
-		static PendingCameoCareerMatch Capture(OpenRA.Player player, string outcome)
+		static PendingCameoCareerMatch Capture(World world)
 		{
-			var world = player.World;
-			if (world.Type != WorldType.Regular || world.IsReplay ||
-				player != world.LocalPlayer || player.Spectating || player.NonCombatant || player.IsBot)
+			var player = world.LocalPlayer;
+			if (world.Type != WorldType.Regular || world.IsReplay || player == null ||
+				player.Spectating || player.NonCombatant || player.IsBot)
+				return null;
+
+			var outcome = FinalOutcome(player.WinState);
+			if (outcome == null)
 				return null;
 
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
@@ -107,6 +117,32 @@ namespace OpenRA.Mods.Cameo.Traits
 			};
 
 			return new PendingCameoCareerMatch(new CameoCareerRepository(Platform.SupportDir), recordId, match);
+		}
+
+		internal static string FinalOutcome(WinState winState)
+		{
+			return winState switch
+			{
+				WinState.Won => "Won",
+				WinState.Lost => "Lost",
+				_ => null
+			};
+		}
+	}
+
+	[TraitLocation(SystemActors.World)]
+	[Desc("Flushes the local player's pending Cameo career result when the game ends.",
+		"Place on the world actor.")]
+	public class CameoCareerFinalizerInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new CameoCareerFinalizer(); }
+	}
+
+	public class CameoCareerFinalizer : IGameOver
+	{
+		void IGameOver.GameOver(World world)
+		{
+			world.LocalPlayer?.PlayerActor.TraitOrDefault<CameoCareerRecorder>()?.FinalizeMatch(world);
 		}
 	}
 }

--- a/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
@@ -16,15 +16,15 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cameo.Traits
 {
-	[TraitLocation(SystemActors.World)]
-	[Desc("Records the local human player's final win or loss in the persistent Cameo career.",
-		"Place on the world actor.")]
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Records the local human player's notified win or loss in the persistent Cameo career.",
+		"Place on the player actor.")]
 	public class CameoCareerRecorderInfo : TraitInfo
 	{
 		public override object Create(ActorInitializer init) { return new CameoCareerRecorder(); }
 	}
 
-	public class CameoCareerRecorder : ITick, IGameOver
+	public class CameoCareerRecorder : ITick, INotifyWinStateChanged
 	{
 		bool recorded;
 		int retryCount;
@@ -36,27 +36,30 @@ namespace OpenRA.Mods.Cameo.Traits
 			if (recorded || self.World.WorldTick < nextAttemptTick)
 				return;
 
-			var world = self.World;
-			pending ??= Capture(world);
 			if (pending == null)
 				return;
 
-			TryPersist(world.WorldTick);
+			TryPersist(self.World.WorldTick);
 		}
 
-		void IGameOver.GameOver(World world)
+		void INotifyWinStateChanged.OnPlayerWon(OpenRA.Player player)
 		{
-			if (recorded)
+			CaptureAndPersist(player, "Won");
+		}
+
+		void INotifyWinStateChanged.OnPlayerLost(OpenRA.Player player)
+		{
+			CaptureAndPersist(player, "Lost");
+		}
+
+		void CaptureAndPersist(OpenRA.Player player, string outcome)
+		{
+			if (recorded || pending != null)
 				return;
 
-			pending ??= Capture(world);
-			if (pending == null)
-				return;
-
-			// EndGame stops world ticks. Make a few short final attempts so a momentary lock held by
-			// another Cameo instance cannot strand an otherwise complete match.
-			for (var i = 0; i < 5 && !recorded; i++)
-				TryPersist(world.WorldTick);
+			pending = Capture(player, outcome);
+			if (pending != null)
+				TryPersist(player.World.WorldTick);
 		}
 
 		void TryPersist(int worldTick)
@@ -70,20 +73,11 @@ namespace OpenRA.Mods.Cameo.Traits
 			}
 		}
 
-		static PendingCameoCareerMatch Capture(World world)
+		static PendingCameoCareerMatch Capture(OpenRA.Player player, string outcome)
 		{
-			var player = world.LocalPlayer;
-			if (world.Type != WorldType.Regular || world.IsReplay || player == null ||
-				player.Spectating || player.NonCombatant || player.IsBot)
-				return null;
-
-			var outcome = player.WinState switch
-			{
-				WinState.Won => "Won",
-				WinState.Lost => "Lost",
-				_ => null
-			};
-			if (outcome == null)
+			var world = player.World;
+			if (world.Type != WorldType.Regular || world.IsReplay ||
+				player != world.LocalPlayer || player.Spectating || player.NonCombatant || player.IsBot)
 				return null;
 
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();

--- a/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
@@ -49,8 +49,8 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			SetText(widget, "FACTIONS_PLAYED_VALUE", $"{Number(factionsPlayed)} / {Number(factions.Count)}");
 			SetText(widget, "ENEMIES_KILLED_VALUE", Number(enemiesKilled));
 			SetText(widget, "BUILDINGS_DESTROYED_VALUE", Number(buildingsDestroyed));
-			SetText(widget, "RESOURCES_COLLECTED_VALUE", Number(resourcesEarned));
-			SetText(widget, "RESOURCES_SPENT_VALUE", Number(resourcesSpent));
+			SetText(widget, "RESOURCES_COLLECTED_VALUE", Metric(resourcesEarned));
+			SetText(widget, "RESOURCES_SPENT_VALUE", Metric(resourcesSpent));
 
 			var list = widget.GetOrNull<ScrollPanelWidget>("FACTION_LIST");
 			var template = list?.GetOrNull<ScrollItemWidget>("ROW_TEMPLATE");
@@ -85,6 +85,21 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 		static string Number(long value)
 		{
 			return value.ToString("N0", CultureInfo.CurrentCulture);
+		}
+
+		static string Metric(long value)
+		{
+			var magnitude = Math.Abs((double)value);
+			if (magnitude >= 1_000_000_000_000)
+				return (value / 1_000_000_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "T";
+			if (magnitude >= 1_000_000_000)
+				return (value / 1_000_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "B";
+			if (magnitude >= 1_000_000)
+				return (value / 1_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "M";
+			if (magnitude >= 1_000)
+				return (value / 1_000d).ToString("0.#", CultureInfo.CurrentCulture) + "K";
+
+			return Number(value);
 		}
 
 		static bool IsRandom(FactionInfo f)

--- a/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/Logic/StatisticsWindowLogic.cs
@@ -87,19 +87,28 @@ namespace OpenRA.Mods.Cameo.Widgets.Logic
 			return value.ToString("N0", CultureInfo.CurrentCulture);
 		}
 
-		static string Metric(long value)
+		internal static string Metric(long value)
 		{
-			var magnitude = Math.Abs((double)value);
-			if (magnitude >= 1_000_000_000_000)
-				return (value / 1_000_000_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "T";
-			if (magnitude >= 1_000_000_000)
-				return (value / 1_000_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "B";
-			if (magnitude >= 1_000_000)
-				return (value / 1_000_000d).ToString("0.#", CultureInfo.CurrentCulture) + "M";
-			if (magnitude >= 1_000)
-				return (value / 1_000d).ToString("0.#", CultureInfo.CurrentCulture) + "K";
+			var suffixes = new[] { "", "K", "M", "B", "T" };
+			var scaled = (double)value;
+			var suffix = 0;
+			while (Math.Abs(scaled) >= 1000 && suffix < suffixes.Length - 1)
+			{
+				scaled /= 1000;
+				suffix++;
+			}
 
-			return Number(value);
+			if (suffix == 0)
+				return Number(value);
+
+			var rounded = Math.Round(scaled, 1, MidpointRounding.AwayFromZero);
+			if (Math.Abs(rounded) >= 1000 && suffix < suffixes.Length - 1)
+			{
+				rounded /= 1000;
+				suffix++;
+			}
+
+			return rounded.ToString("0.#", CultureInfo.CurrentCulture) + suffixes[suffix];
 		}
 
 		static bool IsRandom(FactionInfo f)

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/upgrades.yaml
@@ -7,6 +7,9 @@ ra2_allies_upgrade_assaultsquadtraining:
 		Prerequisites: ~ra2_allies_airforcecommandhq, !ra2_allied_doctrine_1
 	RenderSprites:
 		Image: ra2_allies_upgrade_assaultsquadtraining
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_1
+		OutlineColor: 3B82F6
 	ProvidesPrerequisite@ra2_allied_doctrine_1:
 		Prerequisite: ra2_allied_doctrine_1
 
@@ -19,6 +22,9 @@ ra2_allies_upgrade_vanguardtraining:
 		Prerequisites: ~ra2_allies_airforcecommandhq, !ra2_allied_doctrine_1
 	RenderSprites:
 		Image: ra2_allies_upgrade_vanguardtraining
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_1
+		OutlineColor: 3B82F6
 	ProvidesPrerequisite@ra2_allied_doctrine_1:
 		Prerequisite: ra2_allied_doctrine_1
 
@@ -31,6 +37,9 @@ ra2_allies_upgrade_infiltratorstraining:
 		Prerequisites: ~ra2_allies_airforcecommandhq, !ra2_allied_doctrine_1
 	RenderSprites:
 		Image: ra2_allies_upgrade_infiltratorstraining
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_1
+		OutlineColor: 3B82F6
 	ProvidesPrerequisite@ra2_allies_upgrade_infiltratorstraining:
 		Prerequisite: infantry.upgraded
 	ProvidesPrerequisite@ra2_allied_doctrine_1:
@@ -45,6 +54,9 @@ ra2_allies_upgrade_compositearmorplating:
 		Prerequisites: ~ra2_allies_alliedbattlelab, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_compositearmorplating
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_2
+		OutlineColor: FBBF24
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
 		Prerequisite: ra2_allied_doctrine_2
 
@@ -57,6 +69,9 @@ ra2_allies_upgrade_reflectivearmorplating:
 		Prerequisites: ~ra2_allies_alliedbattlelab, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_reflectivearmorplating
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_2
+		OutlineColor: FBBF24
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
 		Prerequisite: ra2_allied_doctrine_2
 
@@ -69,6 +84,9 @@ ra2_allies_upgrade_ionpulseplating:
 		Prerequisites: ~ra2_allies_alliedbattlelab, ra2_allied_doctrine_1, !ra2_allied_doctrine_2
 	RenderSprites:
 		Image: ra2_allies_upgrade_ionpulseplating
+	ProductionIconMutualExclusion:
+		Group: ra2_allies_doctrine_tier_2
+		OutlineColor: FBBF24
 	ProvidesPrerequisite@ra2_allied_doctrine_2:
 		Prerequisite: ra2_allied_doctrine_2
 

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/upgrades.yaml
@@ -7,6 +7,9 @@ ra2_soviets_doctrine_conscription:
 		Prerequisites: ~ra2_soviets_radar, !ra2_soviets_doctrine_1, !global_conscription_buff
 	RenderSprites:
 		Image: ra2_soviets_doctrine_conscription
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_1
+		OutlineColor: EF4444
 	ProvidesPrerequisite@ra2_soviets_doctrine_1:
 		Prerequisite: ra2_soviets_doctrine_1
 	ProvidesPrerequisite@global_conscription_buff:
@@ -21,6 +24,9 @@ ra2_soviets_doctrine_harshenvironmentinfantryconditioning:
 		Prerequisites: ~ra2_soviets_radar, !ra2_soviets_doctrine_1
 	RenderSprites:
 		Image: ra2_soviets_doctrine_harshenvironmentinfantryconditioning
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_1
+		OutlineColor: EF4444
 	ProvidesPrerequisite@ra1_soviets_upgrade_hazmatsuits:
 		Prerequisite: ra1_soviets_upgrade_hazmatsuits
 	ProvidesPrerequisite@ra2_soviets_doctrine_1:
@@ -35,6 +41,9 @@ ra2_soviets_doctrine_shocktroopertraining:
 		Prerequisites: ~ra2_soviets_radar, !ra2_soviets_doctrine_1
 	RenderSprites:
 		Image: ra2_soviets_doctrine_shocktroopertraining
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_1
+		OutlineColor: EF4444
 	ProvidesPrerequisite@ra2_soviets_doctrine_shocktroopertraining:
 		Prerequisite: infantry.upgraded
 	ProvidesPrerequisite@ra2_soviets_doctrine_1:
@@ -49,6 +58,9 @@ ra2_soviets_doctrine_heavyarmorplatings:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_doctrine_1, !ra2_soviets_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_doctrine_heavyarmorplatings
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_soviets_doctrine_2:
 		Prerequisite: ra2_soviets_doctrine_2
 
@@ -61,6 +73,9 @@ ra2_soviets_doctrine_reactivearmor:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_doctrine_1, !ra2_soviets_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_doctrine_reactivearmor
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_soviets_doctrine_2:
 		Prerequisite: ra2_soviets_doctrine_2
 
@@ -73,6 +88,9 @@ ra2_soviets_doctrine_tesladischargearmor:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_doctrine_1, !ra2_soviets_doctrine_2
 	RenderSprites:
 		Image: ra2_soviets_doctrine_tesladischargearmor
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_soviets_doctrine_2:
 		Prerequisite: ra2_soviets_doctrine_2
 
@@ -85,6 +103,9 @@ ra2_soviets_doctrine_firemunitions:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_industrialplant, ra2_soviets_doctrine_2, !ra2_soviets_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_doctrine_firemunitions
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_soviets_doctrine_3:
 		Prerequisite: ra2_soviets_doctrine_3
 
@@ -97,6 +118,9 @@ ra2_soviets_doctrine_nuclearmunitions:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_industrialplant, ra2_soviets_doctrine_2, !ra2_soviets_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_doctrine_nuclearmunitions
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_soviets_doctrine_3:
 		Prerequisite: ra2_soviets_doctrine_3
 
@@ -109,6 +133,9 @@ ra2_soviets_doctrine_teslamunitions:
 		Prerequisites: ~ra2_soviets_battlelab, ra2_soviets_industrialplant, ra2_soviets_doctrine_2, !ra2_soviets_doctrine_3
 	RenderSprites:
 		Image: ra2_soviets_doctrine_teslamunitions
+	ProductionIconMutualExclusion:
+		Group: ra2_soviets_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_soviets_doctrine_3:
 		Prerequisite: ra2_soviets_doctrine_3
 

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/upgrades.yaml
@@ -7,6 +7,9 @@ yuri_doctrine_psioniclegion:
 		Prerequisites: ~yuri_psychicsensor, !ra2_yuri_doctrine_1, !global_conscription_buff
 	RenderSprites:
 		Image: yuri_doctrine_psioniclegion
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_1
+		OutlineColor: A855F7
 	ProvidesPrerequisite@ra2_yuri_doctrine_1:
 		Prerequisite: ra2_yuri_doctrine_1
 	ProvidesPrerequisite@global_conscription_buff:
@@ -21,6 +24,9 @@ yuri_doctrine_psionicfanatics:
 		Prerequisites: ~yuri_psychicsensor, !ra2_yuri_doctrine_1
 	RenderSprites:
 		Image: yuri_doctrine_psionicfanatics
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_1
+		OutlineColor: A855F7
 	ProvidesPrerequisite@ra2_yuri_doctrine_1:
 		Prerequisite: ra2_yuri_doctrine_1
 
@@ -33,6 +39,9 @@ yuri_doctrine_psionicelite:
 		Prerequisites: ~yuri_psychicsensor, !ra2_yuri_doctrine_1
 	RenderSprites:
 		Image: yuri_doctrine_psionicelite
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_1
+		OutlineColor: A855F7
 	ProvidesPrerequisite@yuri_doctrine_psionicelite:
 		Prerequisite: infantry.upgraded
 	ProvidesPrerequisite@ra2_yuri_doctrine_1:
@@ -47,6 +56,9 @@ yuri_doctrine_lasherhecannon:
 		Prerequisites: ~yuri_battlelab, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: yuri_doctrine_lasherhecannon
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
 		Prerequisite: ra2_yuri_doctrine_2
 
@@ -59,6 +71,9 @@ yuri_doctrine_lashertoxicgasshells:
 		Prerequisites: ~yuri_battlelab, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: yuri_doctrine_lashertoxicgasshells
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
 		Prerequisite: ra2_yuri_doctrine_2
 
@@ -71,6 +86,9 @@ yuri_doctrine_lasherlasercannon:
 		Prerequisites: ~yuri_battlelab, ra2_yuri_doctrine_1, !ra2_yuri_doctrine_2
 	RenderSprites:
 		Image: yuri_doctrine_lasherlasercannon
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_2
+		OutlineColor: F59E0B
 	ProvidesPrerequisite@ra2_yuri_doctrine_2:
 		Prerequisite: ra2_yuri_doctrine_2
 
@@ -83,6 +101,9 @@ yuri_doctrine_scrapvehiclearmor:
 		Prerequisites: ~yuri_battlelab, yuri_lunarcommandcenter, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: yuri_doctrine_scrapvehiclearmor
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
 		Prerequisite: ra2_yuri_doctrine_3
 
@@ -95,6 +116,9 @@ yuri_doctrine_chaosgasemitters:
 		Prerequisites: ~yuri_battlelab, yuri_lunarcommandcenter, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: yuri_doctrine_chaosgasemitters
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
 		Prerequisite: ra2_yuri_doctrine_3
 
@@ -107,6 +131,9 @@ yuri_doctrine_psionicvehicleshields:
 		Prerequisites: ~yuri_battlelab, yuri_lunarcommandcenter, ra2_yuri_doctrine_2, !ra2_yuri_doctrine_3
 	RenderSprites:
 		Image: yuri_doctrine_psionicvehicleshields
+	ProductionIconMutualExclusion:
+		Group: yuri_doctrine_tier_3
+		OutlineColor: 22D3EE
 	ProvidesPrerequisite@ra2_yuri_doctrine_3:
 		Prerequisite: ra2_yuri_doctrine_3
 

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/upgrades.yaml
@@ -11,6 +11,9 @@ tkm_upgrade_berezkaarsenalupgrade:
 		Prerequisites: ~tkm_constructionyard, ~!tkm_upgrade_berezkaarsenalupgrade, ~!tkm_upgrade_titanarsenalupgrade, ~!tkm_upgrade_natoarsenalupgrade
 	RenderSprites:
 		Image: berezkaupgradeicon
+	ProductionIconMutualExclusion:
+		Group: tkm_arsenal_choice
+		OutlineColor: 22C55E
 	ProvidesPrerequisite:
 tkm_upgrade_titanarsenalupgrade:
 	Inherits: ^researched_upgrade.template
@@ -26,6 +29,9 @@ tkm_upgrade_titanarsenalupgrade:
 	ProvidesPrerequisite:
 	RenderSprites:
 		Image: titanplatingupgradeicon
+	ProductionIconMutualExclusion:
+		Group: tkm_arsenal_choice
+		OutlineColor: 22C55E
 tkm_upgrade_natoarsenalupgrade:
 	Inherits: ^researched_upgrade.template
 	Tooltip:
@@ -40,6 +46,9 @@ tkm_upgrade_natoarsenalupgrade:
 	ProvidesPrerequisite:
 	RenderSprites:
 		Image: natoupgradeicon
+	ProductionIconMutualExclusion:
+		Group: tkm_arsenal_choice
+		OutlineColor: 22C55E
 tkm_upgrade_semiautoriflesupgrade:
 	Inherits: ^researched_upgrade.template
 	Tooltip:

--- a/mods/cameo/rules/player.yaml
+++ b/mods/cameo/rules/player.yaml
@@ -15,6 +15,7 @@ EditorPlayer:
 
 Player:
 	Inherits: ^BasePlayer
+	CameoCareerRecorder:
 	QuotaProductionManager:
 	NewConstructionOptionsNotification:
 		Notification: NewOptions

--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -909,7 +909,6 @@ World:
 	Inherits@MapGenerators: ^MapGenerators
 	CryoFogLimiter:
 		Max: 24
-	CameoCareerRecorder:
 	ChatCommands:
 	DevCommands:
 	DebugVisualizationCommands:

--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -909,6 +909,7 @@ World:
 	Inherits@MapGenerators: ^MapGenerators
 	CryoFogLimiter:
 		Max: 24
+	CameoCareerFinalizer:
 	ChatCommands:
 	DevCommands:
 	DebugVisualizationCommands:


### PR DESCRIPTION
## Summary

### Career statistics

- record the local player's career result only after `WinState` reaches a final `Won` or `Lost` value
- receive outcome notifications on the player actor and flush pending writes from a world-level game-over finalizer
- retry temporary persistence failures both during subsequent ticks and when the game ends
- display collected and spent resources with normalized metric suffixes (`K`, `M`, `B`, `T`)

### RA2 doctrine hover feedback

- group mutually exclusive Yuri, Allied, and Soviet doctrine cards by tier
- outline every visible card in the hovered card's tier using YAML-configured colors
- cover Yuri's three tiers, the Allies' two tiers, and the Soviets' three tiers
- keep ordinary unit and technology upgrades outside these groups
- group TKM's mutually exclusive Berezka, Titan, and NATO commitments as an Arsenal Choice

| Faction | Tier I | Tier II | Tier III |
| --- | --- | --- | --- |
| Yuri | Violet (`A855F7`) | Amber (`F59E0B`) | Cyan (`22D3EE`) |
| Allies | Blue (`3B82F6`) | Gold (`FBBF24`) | — |
| Soviets | Crimson (`EF4444`) | Amber (`F59E0B`) | Electric cyan (`22D3EE`) |
| TKM Arsenal Choice | Bright green (`22C55E`) | — | — |

## Root cause

The original career recorder polled the local player's final state from the world actor and could miss completed skirmishes. The first notification-based revision then trusted the callback name before cooperative outcomes were necessarily final and lost retry opportunities after world ticks stopped. The final implementation uses notifications only as a signal, reads the finalized `WinState`, and performs an end-game flush.

Resource totals previously used full locale-formatted numbers. The compact formatter now promotes rounded boundary values correctly, so values such as `999999` display as `1M` instead of `1000K`.

The RA2 doctrine cards and TKM Arsenal commitments already enforced mutually exclusive selections through prerequisite markers, but lacked `ProductionIconMutualExclusion` metadata. The production palette therefore had no group or color information to display related choices on hover.

## Validation

- `tools\preflight-build.ps1`
- `./make all` (0 warnings, 0 errors)
- `dotnet restore OpenRA.Mods.Cameo.Test\OpenRA.Mods.Cameo.Test.csproj`
- `dotnet test OpenRA.Mods.Cameo.Test\OpenRA.Mods.Cameo.Test.csproj -c Release --no-restore` — 19 discovered, 19 passed
- added tests for final outcome acceptance and normalized metric suffix boundaries
- byte-verified the game-over finalizer marker in `engine\bin\OpenRA.Mods.Cameo.dll`
- confirmed every doctrine mutual-exclusion group contains exactly three cards
- `git diff --check`

The doctrine metadata changes are YAML-only and require a game restart, not another rebuild.

## Remaining verification

- complete an in-game skirmish and confirm the career result persists
- visually confirm each RA2 doctrine tier outlines the intended three cards on hover
- visually confirm the three TKM Arsenal choices outline together on hover