### PR TITLE
Update 20260723

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
+++ b/OpenRA.Mods.Cameo/Traits/CameoCareerRecorder.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Cameo.Traits
 	{
 		bool recorded;
 		bool outcomeNotified;
+		bool captureScheduled;
 		int retryCount;
 		int nextAttemptTick;
 		PendingCameoCareerMatch pending;
@@ -48,14 +49,34 @@ namespace OpenRA.Mods.Cameo.Traits
 
 		void INotifyWinStateChanged.OnPlayerWon(OpenRA.Player player)
 		{
-			if (player == player.World.LocalPlayer)
-				outcomeNotified = true;
+			ScheduleCapture(player);
 		}
 
 		void INotifyWinStateChanged.OnPlayerLost(OpenRA.Player player)
 		{
-			if (player == player.World.LocalPlayer)
-				outcomeNotified = true;
+			ScheduleCapture(player);
+		}
+
+		void ScheduleCapture(OpenRA.Player player)
+		{
+			if (player != player.World.LocalPlayer || recorded)
+				return;
+
+			outcomeNotified = true;
+			if (captureScheduled)
+				return;
+
+			captureScheduled = true;
+			player.World.AddFrameEndTask(world =>
+			{
+				captureScheduled = false;
+				if (recorded)
+					return;
+
+				pending ??= Capture(world);
+				if (pending != null)
+					TryPersist(world.WorldTick);
+			});
 		}
 
 		internal void FinalizeMatch(World world)


### PR DESCRIPTION
## Summary

- persist local career outcomes at frame end immediately after win/loss notification processing
- retain tick-based retries and the world game-over finalizer as fallbacks
- continue rejecting non-final cooperative outcomes until `WinState` becomes `Won` or `Lost`

## Root cause

Two completed skirmish replays had distinct game IDs and final local `Won` outcomes, but neither updated `cameo-career.yaml`:

- Ixian: 41,877 ticks, game ID `23ea90c5-2c59-44ce-98d4-be87b9826ecf`
- Ordos: 2,315 ticks, game ID `3d9950b8-29c0-4327-b635-402a8b1fab54`

The notification-based recorder waited until the next simulation tick to capture the finalized state. This left a gap where a match could have a finalized replay outcome but leave the world before the recorder's next tick or delayed game-over callback. The recorder now schedules a frame-end capture: it runs after all win-state callbacks finalize the result in the same simulation frame, before control returns to the result UI.

## Validation

- replay metadata confirms both reported matches were valid wins with unique game IDs
- resolved rules confirm `CameoCareerRecorder` on `Player` and `CameoCareerFinalizer` on `World`
- `tools\preflight-build.ps1`
- `./make all` — 0 warnings, 0 errors
- NUnit: 19 discovered, 19 passed, 0 failed/skipped
- `git diff --check`
- independent adversarial lifecycle review found no concrete blocker

## Remaining verification

- complete a new skirmish and confirm a new row is appended to `%AppData%\OpenRA\cameo-career.yaml`