### PR TITLE
Extend transient notification linger time

### DIFF
--- a/mods/cameo/chrome/ingame_transients.yaml
+++ b/mods/cameo/chrome/ingame_transients.yaml
@@ -8,7 +8,7 @@ Container@TRANSIENTS_PANEL:
 		TextNotificationsDisplay@TRANSIENTS_DISPLAY:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT
-			DisplayDurationMs: 8000
+			DisplayDurationMs: 11000
 			LogLength: 10
 			HideOverflow: False
 			TransientsTemplate: CAMEO_TRANSIENT_LINE_TEMPLATE


### PR DESCRIPTION
## Summary
- extend transient notification linger time from 8 seconds to 11 seconds
- keep the existing notification layout, capacity, and flash behavior unchanged

## Validation
- `git diff --check`
- confirmed the active Cameo transient panel resolves `DisplayDurationMs: 11000`

## User impact
Transient gameplay notifications remain visible three seconds longer, giving players more time to read them during busy moments.