### PR TITLE
Update 2026-07-25

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/sequences.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/sequences.yaml
@@ -595,13 +595,11 @@ steelconsortium_consortiummobileconstructionvehicle:
 	idle:
 		Length: 10
 		Facings: -8
-		InterpolatedFacings: 32
 		Tick: 9999
 		ShadowStart: 80
 	move:
 		Length: 10
 		Facings: -8
-		InterpolatedFacings: 32
 		Tick: 80
 		ShadowStart: 80
 	icon:
@@ -614,21 +612,17 @@ steelconsortium_consortiumminer:
 		Offset: 0,32
 	idle:
 		Facings: -8
-		InterpolatedFacings: 32
 		ShadowStart: 88
 	dock:
 		Facings: -8
-		InterpolatedFacings: 32
 		ShadowStart: 88
 	dock-loop:
 		Facings: -8
-		InterpolatedFacings: 32
 		ShadowStart: 88
 	move:
 		Start: 8
 		Length: 10
 		Facings: -8
-		InterpolatedFacings: 32
 		Tick: 80
 		ShadowStart: 96
 	harvesting:

--- a/mods/cameo/rules/misc.yaml
+++ b/mods/cameo/rules/misc.yaml
@@ -380,6 +380,7 @@ rafactj.colorpicker:
 
 ra1_soviets_mammothtank.colorpicker:
 	Inherits: ra1_soviets_mammothtank
+	-Buildable:
 	-MapEditorData:
 	RenderSprites:
 		Image: ra1_soviets_mammothtank

--- a/mods/cameo/sequences/tiberiansun.yaml
+++ b/mods/cameo/sequences/tiberiansun.yaml
@@ -45,6 +45,10 @@
 		Start: 149
 		Length: 15
 		ShadowStart: 441
+	die3:
+		Start: 149
+		Length: 15
+		ShadowStart: 441
 	die6:
 		Start: 149
 		Length: 15


### PR DESCRIPTION
## Summary

- add the missing `die3` sequence to the shared Tiberian Sun infantry sequence template
- reuse the existing `die2` frames as the small-explosion death fallback
- prevent the RA1 Soviet Mammoth color-picker preview actor from appearing as a second production icon
- remove screen-space facing interpolation from the Consortium MCV and Miner sequences

## Root causes

`TSENGINEER` inherits the Tiberian Dawn engineer death mapping, which requests `die3` for `SmallExplosionDeath`. The `tsengineer` image inherits `^TSBasicInfantry`, but that sequence template defined `die1`, `die2`, and `die4` through `die7` without `die3`, causing a runtime `InvalidOperationException` when that death type was selected.

`ra1_soviets_mammothtank.colorpicker` inherits the gameplay Mammoth actor for the faction color preview, but did not remove the inherited `Buildable` trait. This made both the real Mammoth and its preview clone appear in the Soviet vehicle production palette.

The Consortium MCV and Miner art provides eight genuine perspective-rendered facings. `InterpolatedFacings: 32` rotated the nearest source facing in screen space, making both vehicles visibly lean and corkscrew between their real directions.

## Impact

- Tiberian Sun engineers and other images using `^TSBasicInfantry` can resolve the inherited `die3` death animation instead of crashing.
- the RA1 Soviet vehicle palette shows one Mammoth Tank production icon while retaining the dedicated color-picker preview.
- the Consortium MCV and Miner now turn using their clean eight-direction artwork without distorted intermediate rotations.

## Validation

- confirmed the active `mod.yaml` rules and sequence include chains
- traced `TSENGINEER` -> `E6` / `^TSInfantry` and `tsengineer` -> `^TSBasicInfantry`
- traced the duplicate Mammoth icon to the inherited `Buildable` trait on `ra1_soviets_mammothtank.colorpicker`
- reviewed the MCV recording frame by frame and extracted its raw SHP frames to confirm the source layout is correct
- confirmed the MCV and Miner blocks retain their original facings, movement frames, timing, and shadow mappings
- staged and committed only the intended YAML paths
- `git diff --check` passes

YAML-only changes; no build required. Game restart is required to load the updated rules and sequences.
