### PR TITLE
Update 2026-07-25 (2)

### DIFF
--- a/mods/cameo/sequences/tiberiansun.yaml
+++ b/mods/cameo/sequences/tiberiansun.yaml
@@ -45,10 +45,6 @@
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-	die3:
-		Start: 149
-		Length: 15
-		ShadowStart: 441
 	die6:
 		Start: 149
 		Length: 15
@@ -93,6 +89,10 @@ tsengineer:
 	Inherits: ^TSBasicInfantry
 	Defaults:
 		Filename: ts_gdi_engineer_tsengineer.shp
+	die3:
+		Start: 149
+		Length: 15
+		ShadowStart: 441
 	icon:
 		Filename: ts_gdi_engineer_icon.shp
 


### PR DESCRIPTION
## Summary

- remove `die3` from the shared `^TSBasicInfantry` sequence template
- define the fallback only on `tsengineer`, which is the image that requires it

## Root cause

PR #224 added standard TS `die3` frame indices to the shared infantry template. This propagated those reservations to all 33 inheriting images. Custom-layout sprites such as `forgotten_mutantmortarman.shp` then inherited shadow frames 441-455 despite containing only 284 frames, causing sprite loading to fail.

## Impact

The TS engineer still resolves its inherited `SmallExplosionDeath` animation, while compact/custom TS infantry sprites no longer receive incompatible frame reservations.

## Validation

- identified `8f04522a1` / merged PR #224 as the introducing change
- audited 33 active `^TSBasicInfantry` inheritors
- verified Mortarman has 284 frames (maximum index 283)
- verified TS engineer has 584 frames and supports the requested maximum index 455
- verified the shared template no longer contains `die3` and `tsengineer` contains exactly one definition
- `git diff --check` passes

YAML-only change; no build required. Runtime confirmation requires a game restart.