### PR TITLE
Update 2026-07-27

### DIFF
--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/husks.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/husks.yaml
@@ -92,6 +92,7 @@ cabal_manticore_backup:
 	WithMoveAnimation:
 		MoveSequence: walk
 		ValidMovementTypes: Horizontal, Turn
+	-SpawnActorOnDeath@backup:
 	GrantPeriodicCondition@rebuild:
 		Condition: buildingrebirth
 		CooldownDuration: 40


### PR DESCRIPTION
## Summary

- Prevent the CABAL Manticore from spawning another Backup-mode Manticore when destroyed.
- Preserve the intended timed rebuild into the normal Manticore.

## Root cause

`cabal_manticore_backup` inherited `SpawnActorOnDeath@backup` from `cabal_manticore`. Unlike the other CABAL backup actors, it did not remove that inherited trait, so destroying it spawned another backup actor indefinitely.

## Validation

- `git diff --check`
- Confirmed the commit contains one insertion in `mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/husks.yaml`
- Runtime gameplay validation remains to be performed after restarting the game