### PR TITLE
Update 2026-07-27

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
@@ -281,6 +281,7 @@ SteelQuantumCannon_eliteScatter:
 	Inherits: SteelQuantumCannon_elite
 	Range: 3500
 	-Report:
+	Projectile: LaserZap
 		Color: 00EEFF88
 		-HitAnim:
 		Damage: 2000
@@ -1219,6 +1220,7 @@ SteelAirTurretEScatter:
 	Inherits: SteelAirTurretE
 	Range: 4500
 	-Report:
+	Projectile: LaserZap
 		Color: 00EEFF88
 		Width: 64
 		-HitAnim:
@@ -1699,6 +1701,7 @@ SteelStalkerRailgunEScatter:
 	Inherits: SteelStalkerRailgunE
 	Range: 5000
 	-Report:
+	Projectile: LaserZap
 		Color: 00EEFF88
 		Width: 96
 		-HitAnim:


### PR DESCRIPTION
## Summary

- restore `Projectile: LaserZap` for the Steel Consortium elite quantum, air-turret, and stalker scatter weapons
- keep their inherited railgun main weapons while preventing scatter projectiles from entering the unsafe railgun impact-animation render path

## Root cause

Lint cleanup commit `d42ad53a1` removed the explicit `Projectile: LaserZap` headers from the three scatter definitions. They consequently inherited `Projectile: Railgun`, while their indented `-HitAnim:` entries no longer belonged to a projectile node. The resolved scatter weapons therefore retained `HitAnim: laserfire`, allowing `Railgun.Render()` to call `Animation.Render()` before `CurrentSequence` was initialized and crash with `NullReferenceException`.

## Validation

- resolved `SteelQuantumCannon_eliteScatter`: `Projectile: LaserZap`, no inherited `HitAnim`
- resolved `SteelAirTurretEScatter`: `Projectile: LaserZap`, no inherited `HitAnim`
- resolved `SteelStalkerRailgunEScatter`: `Projectile: LaserZap`, no inherited `HitAnim`
- `git diff --check` passes

YAML-only change; no engine build required. Runtime reproduction remains for in-game confirmation.