### PR TITLE
Update 2026-07-28

### DIFF
--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
@@ -9,6 +9,9 @@ protoss_probe:
 	Inherits@announce: ^AnnounceOnBuild
 	Inherits@SHADOWS: ^Shadows
 	Inherits@shieldgenerator: ^ProtossPersonalShield
+	FireWarheadsOnDeath:
+		Weapon: SCWorkerExplodeProtoss
+		EmptyWeapon: SCWorkerExplodeProtoss
 	Tooltip:
 		Name: Protoss Probe
 	Buildable:

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
@@ -861,6 +861,15 @@ UnitExplodeSmallProtoss:
 		Explosions: blue_big_frag
 		ImpactSounds: xplobig4.aud
 
+SCWorkerExplodeProtoss:
+	Inherits: UnitExplodeSmallProtoss
+	Warhead@Grenade: SpreadDamage
+		Damage: 12000
+	Warhead@GrenadeFriendlyFire: SpreadDamage
+		Damage: 6000
+	Warhead@GrenadePercentage: HealthPercentageDamage
+		Damage: 6
+
 ScoutMG:
 	Inherits: ^Grenade
 	Inherits: ^HeavyCannon

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/vehicles.yaml
@@ -8,6 +8,9 @@ terran_scv:
 	Inherits@AutoRepair: ^PrioritizeRepair
 	Inherits@announce: ^AnnounceOnBuild
 	Inherits@SHADOWS: ^Shadows
+	FireWarheadsOnDeath:
+		Weapon: SCWorkerExplode
+		EmptyWeapon: SCWorkerExplode
 	#AutoTargetPriority@Repair:
 	#	ValidTargets: Repair, Repairing
 	#	ValidStances: Ally

--- a/mods/cameo/ContentPacks/StarCraft/Zerg/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Zerg/yaml/vehicles.yaml
@@ -10,6 +10,9 @@ zerg_drone:
 	Inherits@ZergBurrow: ^ZergBurrow
 	Inherits@weapon: ^ZergMeleeWeaponUpgrades
 	Inherits@armor: ^ZergGroundArmorUpgrades
+	FireWarheadsOnDeath:
+		Weapon: SCWorkerExplode
+		EmptyWeapon: SCWorkerExplode
 	Tooltip:
 		Name: Zerg Drone
 	Buildable:

--- a/mods/cameo/weapons/starcraft.yaml
+++ b/mods/cameo/weapons/starcraft.yaml
@@ -171,6 +171,15 @@ SCVRepair:
 	ReloadDelay: 5
 	Range: 2000
 
+SCWorkerExplode:
+	Inherits: UnitExplodeSmall
+	Warhead@Grenade: SpreadDamage
+		Damage: 12000
+	Warhead@GrenadeFriendlyFire: SpreadDamage
+		Damage: 6000
+	Warhead@GrenadePercentage: HealthPercentageDamage
+		Damage: 6
+
 RavenTurretSpawner:
 	ValidTargets: Air, Ground, Water
 	ReloadDelay: 25


### PR DESCRIPTION
## Summary

- add dedicated 20%-strength death explosions for StarCraft workers
- apply the reduced explosion to the Terran SCV, Protoss Probe, and Zerg Drone
- preserve the Probe's blue explosion effect and leave large harvesters unchanged

## Why

StarCraft workers inherited the normal small-vehicle death explosion. Its full damage could trigger frustrating chain deaths among tightly clustered workers. Removing the explosion entirely would also remove its intended protection against worker-rush abuse, so this keeps the mechanic at reduced strength.

## Impact

Worker death-explosion damage is reduced from 60,000 enemy / 30,000 allied / 30% percentage damage to 12,000 / 6,000 / 6%. Visual effects remain unchanged.

## Validation

- `git diff --check`
- reviewed the staged five-file YAML diff
- no build required for YAML-only changes
