### PR TITLE
Halve active weapon recoil

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/vehicles.yaml
@@ -58,7 +58,7 @@ combat_tank.harkonnen:
 		TurnSpeed: 13
 	Armament:
 		Weapon: 80mm_H
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/vehicles.yaml
@@ -124,7 +124,7 @@ ixian_ixsiegetank:
 		Weapon: D2K_155mm2
 		PauseOnCondition: !ammo
 		LocalOffset: 600,0,600
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		MuzzlePalette: d2keffect
@@ -675,7 +675,7 @@ ixian_kodatank:
 		TurnSpeed: 13
 	Armament:
 		Weapon: IxianCombatTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle
@@ -735,7 +735,7 @@ ixian_heavykodatank:
 		TurnSpeed: 12
 	Armament:
 		Weapon: HeavyIxianCombatTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle
@@ -1167,7 +1167,7 @@ ixian_ixcombatsiege:
 		Offset: 0,0,0
 	Armament:
 		Weapon: D2K_155mm3
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 19
 		LocalOffset: 256,0,320
 		MuzzleSequence: muzzle
@@ -1439,14 +1439,14 @@ apparition.ixian:
 	Armament:
 		Name: primary
 		Weapon: d2k_basq
-		Recoil: 65
+		Recoil: 33
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		LocalOffset: 600, 0, 175
 	Armament@aa:
 		Name: secondary
 		Weapon: d2k_basq_AA
-		Recoil: 65
+		Recoil: 33
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		LocalOffset: 600, 0, 175
@@ -1591,7 +1591,7 @@ duelist_tank.ixian:
 		Offset: 0,0,0
 	Armament:
 		Weapon: DuelistTankCannon
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 15
 		LocalOffset: 256,0,320
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
@@ -521,7 +521,7 @@ ordos_artilleryplatform:
 	Armament:
 		Weapon: D2K_155mm_turret
 		LocalOffset: 512,0,640
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 19
 		MuzzleSequence: muzzle
 		MuzzlePalette: d2keffect

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
@@ -1634,7 +1634,7 @@ ordos_combattank:
 		TurnSpeed: 17
 	Armament:
 		Weapon: OrdosCombatTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle
@@ -1691,7 +1691,7 @@ ordos_heavycombattank:
 		TurnSpeed: 15
 	Armament:
 		Weapon: HeavyOrdosCombatTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -1043,7 +1043,7 @@
 		TurnSpeed: 15
 	Armament:
 		Weapon: 80mm_A
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/vehicles.yaml
@@ -32,7 +32,7 @@ siege_tank:
 		TurnSpeed: 48
 	Armament:
 		Weapon: D2K_155mm
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 19
 		LocalOffset: 512,0,320
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/vehicles.yaml
@@ -36,7 +36,7 @@ ra1_allies_alliedlighttank:
 		TurnSpeed: 24
 	Armament:
 		Weapon: 25mm
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 768,0,90
 		MuzzleSequence: muzzle
@@ -94,7 +94,7 @@ ra1_allies_alliedmediumtank:
 		TurnSpeed: 20
 	Armament:
 		Weapon: 90mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
 		MuzzleSequence: muzzle
@@ -154,12 +154,12 @@ ra1_allies_alliedheavyaatank:
 		Offset: -128,0,0
 	Armament@AG:
 		Weapon: HeavyAATankCannonAG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 800,80,360, 800,-80,360
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: HeavyAATankCannon_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 800,80,360, 800,-80,360
 		MuzzleSequence: muzzle
 	FirepowerMultiplier@ra1_allies_alliedheavyaatank:
@@ -435,7 +435,7 @@ ra1_allies_sheridanassaulttank:
 		TurnSpeed: 17
 	Armament:
 		Weapon: SheridanCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 640,0,128
 		MuzzleSequence: muzzle
@@ -443,7 +443,7 @@ ra1_allies_sheridanassaulttank:
 		PauseOnCondition: ammo < 4
 	Armament@Missile:
 		Weapon: SheridanMissiles
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 128,64,192
 		MuzzleSequence: muzzle
@@ -452,7 +452,7 @@ ra1_allies_sheridanassaulttank:
 		RequiresCondition: !ra1_allies_upgrade_cryomissiles
 	Armament@Upgrade:
 		Weapon: SheridanMissilesCryo
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 128,64,192
 		MuzzleSequence: muzzle
@@ -623,7 +623,7 @@ ra1_allies_alliedtigerheavytank:
 		Offset: 0,0,0
 	Armament:
 		Weapon: TigerCannon
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 50
 		LocalOffset: 1200,0,200
 		MuzzleSequence: muzzle
@@ -681,7 +681,7 @@ ra1_allies_alliedtankdestroyer:
 		TurnSpeed: 24
 	Armament:
 		Weapon: AlliedTankDestroyerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1150,0,250
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/vehicles.yaml
@@ -136,14 +136,14 @@ japan_igomediumtank:
 		TurnSpeed: 18
 	Armament:
 		Weapon: Type89Cannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,240
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade: ##########
 		Weapon: Type89PlasmaCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,320
 		MuzzleSequence: muzzle
@@ -201,7 +201,7 @@ japan_nanodronebuggy:
 		Offset: -250,0,0
 	Armament:
 		Weapon: NanoArtilleryAG
-		Recoil: 77
+		Recoil: 39
 		LocalOffset: 500,0,500
 		MuzzleSequence: muzzle
 	FirepowerMultiplier@Nanodrones:
@@ -332,7 +332,7 @@ japan_oitank:
 		Turret: main
 		Weapon: OIBigCannon
 		LocalOffset: 1200,0,600
-		Recoil: 350
+		Recoil: 175
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -340,7 +340,7 @@ japan_oitank:
 		Turret: main
 		Weapon: OIBigPlasmaCannon
 		LocalOffset: 1200,0,600
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -348,7 +348,7 @@ japan_oitank:
 		Turret: primary
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -356,7 +356,7 @@ japan_oitank:
 		Turret: secondary
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -364,7 +364,7 @@ japan_oitank:
 		Turret: back
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -372,7 +372,7 @@ japan_oitank:
 		Turret: primary
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -380,7 +380,7 @@ japan_oitank:
 		Turret: secondary
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -388,7 +388,7 @@ japan_oitank:
 		Turret: back
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -759,25 +759,25 @@ japan_armoredcar:
 		Offset: -200,0,100
 	Armament@AG:
 		Weapon: ArmoredCarMG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_waveforcebullets
 	Armament@AA:
 		Weapon: ArmoredCarMG_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_waveforcebullets
 	Armament@UpgradeAG:
 		Weapon: ArmoredCarMGWaveforce
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_waveforcebullets
 	Armament@UpgradeAA:
 		Weapon: ArmoredCarMGAAWaveforce
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_waveforcebullets
@@ -872,14 +872,14 @@ japan_chihaheavytank:
 		TurnSpeed: 17
 	Armament:
 		Weapon: Type97Cannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,320
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade: ##########
 		Weapon: Type97PlasmaCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,320
 		MuzzleSequence: muzzle
@@ -952,14 +952,14 @@ japan_hovercraftflametank:
 		Offset: 0,0,0
 	Armament:
 		Weapon: HeavyFlamer
-		Recoil: 160
+		Recoil: 80
 		RecoilRecovery: 36
 		LocalOffset: 800,-120,160, 800,120,160
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade: ##########
 		Weapon: HeavyPlasmaFlamer
-		Recoil: 160
+		Recoil: 80
 		RecoilRecovery: 36
 		LocalOffset: 800,-120,160, 800,120,160
 		MuzzleSequence: muzzle
@@ -1161,7 +1161,7 @@ japan_shrineminitank:
 		TurnSpeed: 24
 	Armament:
 		Weapon: ShrineTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 240,0,32
 		MuzzleSequence: muzzle
@@ -1218,21 +1218,21 @@ japan_waveforcetank:
 		TurnSpeed: 12
 	Armament:
 		Weapon: WaveforceCannon
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,360
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade1: ##########
 		Weapon: WaveforceCannonChargedLaser
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,360
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade2: ##########
 		Weapon: WaveforceCannonDistortedBeam1
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,360
 		FireDelay: 1
@@ -1240,7 +1240,7 @@ japan_waveforcetank:
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
 	Armament@Upgrade3: ##########
 		Weapon: WaveforceCannonDistortedBeam2
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,360
 		FireDelay: 2
@@ -1312,7 +1312,7 @@ japan_waveforceartillery:
 		Offset: -12,0,33
 	Armament@AG:
 		Weapon: WaveArtilleryShell
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 512,0,192
 		MuzzleSequence: muzzle
 	FirepowerMultiplier@SplashCompensation:
@@ -1400,21 +1400,21 @@ japan_exorcistoitank:
 		Turret: main
 		Weapon: OIHakureiring
 		LocalOffset: 600,0,600
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 	Armament@AntiEpic:
 		Turret: main
 		Weapon: OIHakureiring2
 		LocalOffset: 600,0,600
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -1422,7 +1422,7 @@ japan_exorcistoitank:
 		Turret: secondary
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -1430,7 +1430,7 @@ japan_exorcistoitank:
 		Turret: back
 		Weapon: OISmallCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_advancedplasmaweapons
@@ -1438,7 +1438,7 @@ japan_exorcistoitank:
 		Turret: primary
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -1446,7 +1446,7 @@ japan_exorcistoitank:
 		Turret: secondary
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons
@@ -1454,7 +1454,7 @@ japan_exorcistoitank:
 		Turret: back
 		Weapon: OISmallPlasmaCannon
 		LocalOffset: 600,0,400
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_advancedplasmaweapons

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/naval.yaml
@@ -169,7 +169,7 @@ ra1_allies_cruiser:
 		Turret: primary
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
@@ -177,7 +177,7 @@ ra1_allies_cruiser:
 		Turret: secondary
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 	AttackTurreted:
@@ -234,13 +234,13 @@ japan_japanesespeedboat:
 		Offset: 200,0,200
 	Armament@AG:
 		Weapon: JapanSpeedBoatGun
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: !japan_upgrade_waveforcebullets
 	Armament@Upgrade:
 		Weapon: JapanSpeedBoatGunWaveforce
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 400,-100,300, 400,100,300
 		MuzzleSequence: muzzle
 		RequiresCondition: japan_upgrade_waveforcebullets
@@ -330,7 +330,7 @@ japan_yamatobattleship:
 		Turret: primary
 		Weapon: YamatoCannon
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
@@ -338,14 +338,14 @@ japan_yamatobattleship:
 		Turret: secondary
 		Weapon: YamatoCannon
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Turret: flak
 		Weapon: YamatoFlak
 		LocalOffset: 240,-100,40, 240,100,40
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 10
 		MuzzleSequence: muzzle
 	AttackTurreted:

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/vehicles.yaml
@@ -35,14 +35,14 @@ ra1_allies_alliedapc:
 		TurnSpeed: 42
 	Armament@PRIMARY:
 		Weapon: APCGunAllies
-		Recoil: 96
+		Recoil: 48
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: APCGunAllies_AA
-		Recoil: 96
+		Recoil: 48
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
 		MuzzleSequence: muzzle
@@ -126,7 +126,7 @@ ra1_allies_alliedcybertank:
 		Offset: 0,0,0
 	Armament:
 		Weapon: TigerCannon
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 50
 		LocalOffset: 1200,0,200
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/vehicles.yaml
@@ -335,14 +335,14 @@ ra1_soviets_heavytank:
 		TurnSpeed: 14
 	Armament:
 		Weapon: 105mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_nucleartankshells
 	Armament@Upgrade:
 		Weapon: 105mmThermobaric
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -404,21 +404,21 @@ ra1_soviets_hammertank:
 		TurnSpeed: 12
 	Armament:
 		Weapon: HammerTankCannon
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 25
 		LocalOffset: 1100,100,100, 1100,-100,100
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_nucleartankshells
 	Armament@Upgrade:
 		Weapon: HammerTankCannonThermobaric
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 25
 		LocalOffset: 1100,100,100, 1100,-100,100
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_nucleartankshells
 	Armament@shtora:
 		Weapon: ShtoraLaser
-		Recoil: 20
+		Recoil: 10
 		RecoilRecovery: 10
 		LocalOffset: 0,200,50
 		MuzzleSequence: muzzle
@@ -624,14 +624,14 @@ ra1_soviets_kotinnucleartank:
 		TurnSpeed: 13
 	Armament:
 		Weapon: KotinCannon
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 25
 		LocalOffset: 1100,100,200, 1100,-100,200
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_nucleartankshells
 	Armament@Upgrade:
 		Weapon: KotinCannonThermobaric
-		Recoil: 150
+		Recoil: 75
 		RecoilRecovery: 25
 		LocalOffset: 1100,100,200, 1100,-100,200
 		MuzzleSequence: muzzle
@@ -705,28 +705,28 @@ ra1_soviets_mammothtank:
 	Armament@PRIMARY:
 		Weapon: ra120mm
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_nucleartankshells && !ra1_soviets_promotion_mammothtanktargetingcomputer
 	Armament@PRIMARYTargetingComputer:
 		Weapon: ra120mmTargetingComputer
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_nucleartankshells && ra1_soviets_promotion_mammothtanktargetingcomputer
 	Armament@Upgrade:
 		Weapon: ra120mmThermobaric
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_nucleartankshells && !ra1_soviets_promotion_mammothtanktargetingcomputer
 	Armament@UpgradeTargetingComputer:
 		Weapon: ra120mmThermobaricTargetingComputer
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_nucleartankshells && ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -735,7 +735,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTusk
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_teslarockets && !ra1_soviets_upgrade_thermonuclearrockets && !ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -744,7 +744,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTuskTargetingComputer
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_teslarockets && !ra1_soviets_upgrade_thermonuclearrockets && ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -753,7 +753,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTuskTesla
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslarockets && !ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -762,7 +762,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTuskTeslaTargetingComputer
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslarockets && ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -771,7 +771,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTuskThermobaric
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_thermonuclearrockets && !ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -780,7 +780,7 @@ ra1_soviets_mammothtank:
 		Weapon: MammothTuskThermobaricTargetingComputer
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50,50
-		Recoil: 50
+		Recoil: 25
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_thermonuclearrockets && ra1_soviets_promotion_mammothtanktargetingcomputer
@@ -845,7 +845,7 @@ ra1_soviets_siegemammothtank:
 	Armament@PRIMARY:
 		Weapon: ra120mm2
 		LocalOffset: 960,144,272, 960,-144,272
-		Recoil: 140
+		Recoil: 70
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -853,7 +853,7 @@ ra1_soviets_siegemammothtank:
 	Armament@PRIMARYTargetingComputer:
 		Weapon: ra120mm2TargetingComputer
 		LocalOffset: 960,144,272, 960,-144,272
-		Recoil: 140
+		Recoil: 70
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -861,7 +861,7 @@ ra1_soviets_siegemammothtank:
 	Armament@Upgrade:
 		Weapon: ra120mm2Thermobaric
 		LocalOffset: 960,144,272, 960,-144,272
-		Recoil: 140
+		Recoil: 70
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -869,7 +869,7 @@ ra1_soviets_siegemammothtank:
 	Armament@UpgradeTargetingComputer:
 		Weapon: ra120mm2ThermobaricTargetingComputer
 		LocalOffset: 960,144,272, 960,-144,272
-		Recoil: 140
+		Recoil: 70
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -879,7 +879,7 @@ ra1_soviets_siegemammothtank:
 		Weapon: MammothTusk2
 		LocalOffset: -68,307,272, -68,-307,272
 		LocalYaw: -50,50
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -889,7 +889,7 @@ ra1_soviets_siegemammothtank:
 		Weapon: MammothTusk2TargetingComputer
 		LocalOffset: -68,307,272, -68,-307,272
 		LocalYaw: -50,50
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -899,7 +899,7 @@ ra1_soviets_siegemammothtank:
 		Weapon: MammothTusk2Thermobaric
 		LocalOffset: -68,307,272, -68,-307,272
 		LocalYaw: -50,50
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -909,7 +909,7 @@ ra1_soviets_siegemammothtank:
 		Weapon: MammothTusk2ThermobaricTargetingComputer
 		LocalOffset: -68,307,272, -68,-307,272
 		LocalYaw: -50,50
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 25
 		MuzzleSequence: muzzle
 		PauseOnCondition: ammo < 2
@@ -1178,12 +1178,12 @@ ra1_soviets_flaktruck:
 		Offset: -298,0,298
 	Armament@AA:
 		Weapon: FLAK-23-AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 512,0,192
 		MuzzleSequence: muzzle
 	Armament@AG:
 		Weapon: FLAK-23-AG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 512,0,192
 		MuzzleSequence: muzzle
 	AttackTurreted:
@@ -1256,35 +1256,35 @@ ra1_soviets_btr80:
 	AttackTurreted:
 	Armament:
 		Weapon: BTRMachineGun
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: BTRMachineGun_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 	Armament@TeslaUpgrade1:
 		Weapon: BTRTeslaMachineGun
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_doctrine_teslaandexperimentaltech && !ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade2:
 		Weapon: BTRTeslaMachineGunArc
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade1AA:
 		Weapon: BTRTeslaMachineGun_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_doctrine_teslaandexperimentaltech && !ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade2AA:
 		Weapon: BTRTeslaMachineGunArc_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslaarcing
@@ -1563,49 +1563,49 @@ ra1_soviets_gatlingtank:
 		Offset: -128,0,0
 	Armament@AG:
 		Weapon: RAGatlingTankCannon
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_incendiarybullets
 	Armament@AA:
 		Weapon: RAGatlingTankCannon_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: !ra1_soviets_upgrade_incendiarybullets
 	Armament@UpgradeAG:
 		Weapon: IncendiaryRAGatlingTankCannon
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_incendiarybullets
 	Armament@UpgradeAA:
 		Weapon: IncendiaryRAGatlingTankCannon_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_incendiarybullets
 	Armament@TeslaUpgrade1:
 		Weapon: TeslaRAGatlingTankCannon
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_doctrine_teslaandexperimentaltech && !ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade2:
 		Weapon: TeslaRAGatlingTankCannonArc
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade1AA:
 		Weapon: TeslaRAGatlingTankCannon_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_doctrine_teslaandexperimentaltech && !ra1_soviets_upgrade_teslaarcing
 	Armament@TeslaUpgrade2AA:
 		Weapon: TeslaRAGatlingTankCannonArc_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 		RequiresCondition: ra1_soviets_upgrade_teslaarcing
@@ -1723,7 +1723,7 @@ ra1_soviets_monstertank:
 		TurnSpeed: 9
 	Armament@PRIMARY:
 		Weapon: MonsterTank120mm
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 25
 		LocalOffset: 1600,350,350, 1600,-350,350
 		MuzzleSequence: muzzle
@@ -1732,7 +1732,7 @@ ra1_soviets_monstertank:
 		RequiresCondition: !ra1_soviets_doctrine_inferno
 	Armament@Upgrade:
 		Weapon: MonsterTank120mmThermobaric
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 25
 		LocalOffset: 1600,350,350, 1600,-350,350
 		MuzzleSequence: muzzle
@@ -1741,7 +1741,7 @@ ra1_soviets_monstertank:
 		RequiresCondition: ra1_soviets_doctrine_inferno
 	Armament@SECONDARY:
 		Weapon: MonsterTankTusk
-		Recoil: 100
+		Recoil: 50
 		RecoilRecovery: 25
 		LocalOffset: -400,-500,300, -400,500,300
 		LocalYaw: 60, -60
@@ -1749,7 +1749,7 @@ ra1_soviets_monstertank:
 		RequiresCondition: !ra1_soviets_upgrade_teslarockets && !ra1_soviets_upgrade_thermonuclearrockets
 	Armament@TeslaSECONDARY:
 		Weapon: MonsterTankTuskTesla
-		Recoil: 100
+		Recoil: 50
 		RecoilRecovery: 25
 		LocalOffset: -400,-500,300, -400,500,300
 		LocalYaw: 60, -60
@@ -1757,7 +1757,7 @@ ra1_soviets_monstertank:
 		RequiresCondition: ra1_soviets_upgrade_teslarockets
 	Armament@NukeSECONDARY:
 		Weapon: MonsterTankTuskThermobaric
-		Recoil: 100
+		Recoil: 50
 		RecoilRecovery: 25
 		LocalOffset: -400,-500,300, -400,500,300
 		LocalYaw: 60, -60

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/vehicles.yaml
@@ -133,7 +133,7 @@ ra2_allies_grizzlytank:
 	Armament:
 		Name: primary
 		Weapon: RA2105mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -142,7 +142,7 @@ ra2_allies_grizzlytank:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2105mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -392,7 +392,7 @@ ra2_allies_prismtank:
 		#Name: secondary
 		Weapon: PrismTankCharge
 		LocalOffset: 410,0,650
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		TargetRelationships: Ally
 		ForceTargetRelationships: Ally
@@ -401,7 +401,7 @@ ra2_allies_prismtank:
 		#Name: secondary
 		Weapon: PrismTankCharge_elite
 		LocalOffset: 410,0,650
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		TargetRelationships: Ally
 		ForceTargetRelationships: Ally
@@ -410,7 +410,7 @@ ra2_allies_prismtank:
 		#Name: primary
 		Weapon: RA2Comet
 		LocalOffset: 410,0,650
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		TargetRelationships: Enemy
 		RequiresCondition: !rank-elite
@@ -418,7 +418,7 @@ ra2_allies_prismtank:
 		#Name: primary
 		Weapon: RA2Comet_elite
 		LocalOffset: 410,0,650
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		TargetRelationships: Enemy
 		RequiresCondition: rank-elite
@@ -482,7 +482,7 @@ ra2_allies_miragetank:
 		Name: primary
 		Weapon: RA2MirageGun
 		LocalOffset: 512,0,128
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
@@ -491,7 +491,7 @@ ra2_allies_miragetank:
 		Name: primary
 		Weapon: RA2MirageGun_elite
 		LocalOffset: 512,0,128
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
@@ -571,7 +571,7 @@ ra2_allies_heavymiragetank:
 		Name: primary
 		Weapon: RA2HeavyMirageGun
 		LocalOffset: 1024,0,128
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 16
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
@@ -580,7 +580,7 @@ ra2_allies_heavymiragetank:
 		Name: primary
 		Weapon: RA2HeavyMirageGun_elite
 		LocalOffset: 1024,0,128
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 16
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/misc.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/misc.yaml
@@ -1211,7 +1211,7 @@ ra2dred:
 		Type: Superheavy
 	Armament@AG:
 		Weapon: DreadnoughtLaunch
-		Recoil: 85
+		Recoil: 43
 		Damage: 2500
 		ReloadDelay: 125
 	MissileSpawnerMasterCA:
@@ -2212,7 +2212,7 @@ ra2leopard:
 	Armament:
 		Name: primary
 		Weapon: RA2120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -2221,7 +2221,7 @@ ra2leopard:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2120mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -2230,7 +2230,7 @@ ra2leopard:
 	Armament@machinegun:
 		Name: primary
 		Weapon: RA2GattlingMG1
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,8,80
 		MuzzleSequence: muzzle-3
@@ -2284,7 +2284,7 @@ ra2_c_ifv:
 	Armament:
 		Name: primary
 		Weapon: RA2GattlingMG1
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,0,80
 		MuzzleSequence: muzzle
@@ -2293,7 +2293,7 @@ ra2_c_ifv:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2GattlingMG2
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,0,80
 		MuzzleSequence: muzzle-2
@@ -2302,7 +2302,7 @@ ra2_c_ifv:
 	Armament@AA:
 		Name: primary
 		Weapon: RA2GattlingMG1_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -2311,7 +2311,7 @@ ra2_c_ifv:
 	Armament@eliteAA:
 		Name: primary
 		Weapon: RA2GattlingMG2_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -2363,7 +2363,7 @@ ra2_c_hum:
 	Armament:
 		Name: primary
 		Weapon: RA2GattlingMG1
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,0,80
 		MuzzleSequence: muzzle
@@ -2372,7 +2372,7 @@ ra2_c_hum:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2GattlingMG2
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,0,80
 		MuzzleSequence: muzzle-2
@@ -2432,7 +2432,7 @@ ra2_c_abram:
 	Armament:
 		Name: primary
 		Weapon: RA2120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -2441,7 +2441,7 @@ ra2_c_abram:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2120mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -2450,7 +2450,7 @@ ra2_c_abram:
 	Armament@machinegun:
 		Name: primary
 		Weapon: RA2GattlingMG1
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,8,80
 		MuzzleSequence: muzzle-3
@@ -5657,7 +5657,7 @@ yrrobo:
 	Armament:
 		Name: primary
 		Weapon: RA2Robotmm
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 800,0,-250
 		MuzzleSequence: muzzle
@@ -5666,7 +5666,7 @@ yrrobo:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2Robotmm_elite
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 800,0,-250
 		MuzzleSequence: muzzle-2

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/naval.yaml
@@ -27,13 +27,13 @@ ra2_soviets_seascorpion:
 		Type: Light
 	Armament@AA:
 		Weapon: SeaScorpion_AA
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 256,0,400
 	Armament@AG:
 		Weapon: RA2FlakTrackGun
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 256,0,400

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/vehicles.yaml
@@ -73,7 +73,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARY:
 		Name: primary
 		Weapon: RA2120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -82,7 +82,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYRad:
 		Name: primary
 		Weapon: RA2120mm_rad
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -91,7 +91,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYFire:
 		Name: primary
 		Weapon: RA2120mm_fire
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -100,7 +100,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYTesla:
 		Name: primary
 		Weapon: RA2120mm_tesla
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -109,7 +109,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYELITE:
 		Name: primary
 		Weapon: RA2120mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -118,7 +118,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYELITERad:
 		Name: primary
 		Weapon: RA2120mm_rad_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -127,7 +127,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYELITEFire:
 		Name: primary
 		Weapon: RA2120mm_fire_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -136,7 +136,7 @@ ra2_soviets_rhinoheavytank:
 	Armament@PRIMARYELITETesla:
 		Name: primary
 		Weapon: RA2120mm_tesla_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -199,26 +199,26 @@ ra2_soviets_flaktrack:
 	Armament@AA:
 		Weapon: RA2FlakTrackAAGun
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@AG:
 		Weapon: RA2FlakTrackGun
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@AAE:
 		Weapon: RA2FlakTrackAAGun_elite
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
 	Armament@AGE:
 		Weapon: RA2FlakTrackGun_elite
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
@@ -285,7 +285,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARY:
 		Name: primary
 		Weapon: RA2120xmm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -294,7 +294,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYRad:
 		Name: primary
 		Weapon: RA2120xmm_rad
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -303,7 +303,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYFire:
 		Name: primary
 		Weapon: RA2120xmm_fire
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -312,7 +312,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYTesla:
 		Name: primary
 		Weapon: RA2120xmm_tesla
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -323,12 +323,12 @@ ra2_soviets_apocalypsetank:
 		Weapon: RA2MammothTusk_AA
 		LocalOffset: -85,90,340, -85,-90,340
 		LocalYaw: -100, 100
-		Recoil: 10
+		Recoil: 5
 		RequiresCondition: !rank-elite
 	Armament@PRIMARYELITE:
 		Name: primary
 		Weapon: RA2120xmm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle-2
@@ -337,7 +337,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYELITERad:
 		Name: primary
 		Weapon: RA2120xmm_rad_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle-2
@@ -346,7 +346,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYELITEFire:
 		Name: primary
 		Weapon: RA2120xmm_fire_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle-2
@@ -355,7 +355,7 @@ ra2_soviets_apocalypsetank:
 	Armament@PRIMARYELITETesla:
 		Name: primary
 		Weapon: RA2120xmm_tesla_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle-2
@@ -366,7 +366,7 @@ ra2_soviets_apocalypsetank:
 		Weapon: RA2MammothTusk_AA_elite
 		LocalOffset: -85,90,340, -85,-90,340
 		LocalYaw: -100, 100
-		Recoil: 10
+		Recoil: 5
 		RequiresCondition: rank-elite
 	FirepowerMultiplier@ra2_soviets_doctrine_nuclearmunitions:
 		Modifier: 125
@@ -514,19 +514,19 @@ ra2_soviets_teslatank:
 	Armament@PRIMARY:
 		Weapon: RA2TankBolt
 		LocalOffset: 600,200,200, 600,-200,200
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		RequiresCondition: (!ra2_soviets_upgrade_teslaoverload && !rank-elite)
 	Armament@PRIMARY2:
 		Weapon: RA2TankBolt2
 		LocalOffset: 600,200,200, 600,-200,200
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		RequiresCondition: (ra2_soviets_upgrade_teslaoverload && !rank-elite) || (!ra2_soviets_upgrade_teslaoverload && rank-elite)
 	Armament@PRIMARY3:
 		Weapon: RA2TankBolt3
 		LocalOffset: 600,200,200, 600,-200,200
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		RequiresCondition: (ra2_soviets_upgrade_teslaoverload && rank-elite)
 	AttackTurreted:

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/vehicles.yaml
@@ -424,7 +424,7 @@ yuri_chaosdrone:
 		TurnSpeed: 2000
 	Armament:
 		Weapon: RA2Dronegas
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 	AttackTurreted:
 	SelectionDecorations:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/naval.yaml
@@ -45,7 +45,7 @@ panth.asian:
 	Armament:
 		Name: primary
 		Weapon: RA2120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
 		MuzzleSequence: muzzle
@@ -54,7 +54,7 @@ panth.asian:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2120mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
 		MuzzleSequence: muzzle-2

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/vehicles.yaml
@@ -202,7 +202,7 @@ asianalliance_lynxtank:
 	Armament:
 		Name: primary
 		Weapon: AsianLynxTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -211,7 +211,7 @@ asianalliance_lynxtank:
 	Armament@elite:
 		Name: primary
 		Weapon: AsianLynxTankCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -483,13 +483,13 @@ ptnk.asian:
 	Armament@PRIMARY:
 		Weapon: AsianTwinPlasma
 		LocalOffset: 900,80,340, 900,-80,340
-		Recoil: 170
+		Recoil: 85
 		RecoilRecovery: 42
 		RequiresCondition: !rank-elite
 	Armament@ELITE:
 		Weapon: AsianTwinPlasma_elite
 		LocalOffset: 900,80,340, 900,-80,340
-		Recoil: 170
+		Recoil: 85
 		RecoilRecovery: 42
 		RequiresCondition: rank-elite
 	AttackTurreted:
@@ -654,7 +654,7 @@ asianalliance_howitzer:
 	Armament:
 		Name: primary
 		Weapon: AsianHowitzerCannon
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
 		MuzzleSequence: muzzle
@@ -663,7 +663,7 @@ asianalliance_howitzer:
 	Armament@ELITE:
 		Name: primary
 		Weapon: AsianHowitzerCannon_elite
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/vehicles.yaml
@@ -49,7 +49,7 @@ steelconsortium_katytank:
 	Armament:
 		Name: primary
 		Weapon: SteelKatyCannons
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 50
 		LocalOffset: 1250,-250,250, 1250,250,250
 		MuzzleSequence: muzzle
@@ -58,7 +58,7 @@ steelconsortium_katytank:
 	Armament@ELITE:
 		Name: primary
 		Weapon: SteelKatyCannons_elite
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 50
 		LocalOffset: 1250,-250,250, 1250,250,250
 		MuzzleSequence: muzzle
@@ -67,7 +67,7 @@ steelconsortium_katytank:
 	Armament@Upgrade:
 		Name: primary
 		Weapon: SteelKatyCannons_EMP
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 50
 		LocalOffset: 1250,-250,250, 1250,250,250
 		MuzzleSequence: muzzle
@@ -76,7 +76,7 @@ steelconsortium_katytank:
 	Armament@UpgradeELITE:
 		Name: primary
 		Weapon: SteelKatyCannons_EMP_elite
-		Recoil: 250
+		Recoil: 125
 		RecoilRecovery: 50
 		LocalOffset: 1250,-250,250, 1250,250,250
 		MuzzleSequence: muzzle
@@ -564,7 +564,7 @@ oldqtnk.steel:
 	Armament:
 		Name: primary
 		Weapon: SteelQuantumCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 600,-200,300
 		MuzzleSequence: muzzle
@@ -925,7 +925,7 @@ steelconsortium_quantumtank:
 	Armament:
 		Name: primary
 		Weapon: SteelQuantumCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1000,0,100
 		MuzzleSequence: muzzle
@@ -934,7 +934,7 @@ steelconsortium_quantumtank:
 	Armament@Upgrade:
 		Name: primary
 		Weapon: SteelQuantumCannon_EMP
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1000,0,100
 		MuzzleSequence: muzzle
@@ -943,7 +943,7 @@ steelconsortium_quantumtank:
 	Armament@elite:
 		Name: primary
 		Weapon: SteelQuantumCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1000,0,100
 		MuzzleSequence: muzzle
@@ -1111,7 +1111,7 @@ steelconsortium_barracuda:
 	Armament@AG1:
 		Name: primary
 		Weapon: SteelMantaHunterCannons
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,200,-150
 		MuzzleSequence: muzzle
@@ -1119,7 +1119,7 @@ steelconsortium_barracuda:
 	Armament@AG2:
 		Name: primary
 		Weapon: SteelMantaHunterCannons
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,-200,-150
 		MuzzleSequence: muzzle
@@ -1127,7 +1127,7 @@ steelconsortium_barracuda:
 	Armament@AA1:
 		Name: primary
 		Weapon: SteelMantaHunterCannons_AA
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,200,-150
 		MuzzleSequence: muzzle
@@ -1135,7 +1135,7 @@ steelconsortium_barracuda:
 	Armament@AA2:
 		Name: primary
 		Weapon: SteelMantaHunterCannons_AA
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,-200,-150
 		MuzzleSequence: muzzle
@@ -1143,7 +1143,7 @@ steelconsortium_barracuda:
 	Armament@UpgradeAG1:
 		Name: primary
 		Weapon: SteelMantaHunterCannonsResonance
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,200,-150
 		MuzzleSequence: muzzle
@@ -1152,7 +1152,7 @@ steelconsortium_barracuda:
 	Armament@UpgradeAG2:
 		Name: primary
 		Weapon: SteelMantaHunterCannonsResonance
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,-200,-150
 		MuzzleSequence: muzzle
@@ -1161,7 +1161,7 @@ steelconsortium_barracuda:
 	Armament@UpgradeAA1:
 		Name: primary
 		Weapon: SteelMantaHunterCannonsAAResonance_AA
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,200,-150
 		MuzzleSequence: muzzle
@@ -1170,7 +1170,7 @@ steelconsortium_barracuda:
 	Armament@UpgradeAA2:
 		Name: primary
 		Weapon: SteelMantaHunterCannonsAAResonance_AA
-		Recoil: 125
+		Recoil: 63
 		RecoilRecovery: 25
 		LocalOffset: 500,-200,-150
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/vehicles.yaml
@@ -221,7 +221,7 @@ futuretech_robottank:
 	Armament:
 		Name: primary
 		Weapon: RA2Robotmm
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 800,0,-250
 		MuzzleSequence: muzzle
@@ -230,7 +230,7 @@ futuretech_robottank:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2Robotmm_elite
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 800,0,-250
 		MuzzleSequence: muzzle-2
@@ -317,7 +317,7 @@ futuretech_guardiantank:
 	Armament:
 		Name: primary
 		Weapon: GuardianTankCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1720,0,440
 		MuzzleSequence: muzzle
@@ -326,7 +326,7 @@ futuretech_guardiantank:
 	Armament@elite:
 		Name: primary
 		Weapon: GuardianTankCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1720,0,440
 		MuzzleSequence: muzzle-2
@@ -405,7 +405,7 @@ futuretech_riptideacv:
 	Armament@AG:
 		Weapon: ACV_Machinegun
 		LocalOffset: 150,0,0
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 	GrantConditionOnTerrain:
@@ -630,7 +630,7 @@ futuretech_oriontank:
 	Armament:
 		Name: primary
 		Weapon: OrionRailgun
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 45
 		LocalOffset: 1000,0,325
 		MuzzleSequence: muzzle
@@ -639,7 +639,7 @@ futuretech_oriontank:
 	Armament@elite:
 		Name: primary
 		Weapon: OrionRailgun_elite
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 45
 		LocalOffset: 1000,0,325
 		MuzzleSequence: muzzle-2
@@ -936,7 +936,7 @@ futuretech_futuretank:
 		Name: primary
 		Weapon: FutureTankCannons
 		LocalOffset: 400,400,400, 400,-400,400
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
@@ -945,7 +945,7 @@ futuretech_futuretank:
 		Name: primary
 		Weapon: FutureTankCannons_elite
 		LocalOffset: 400,400,400, 400,-400,400
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		MuzzleSequence: muzzle-2
 		MuzzlePalette: ra2effect

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/aircraft.yaml
@@ -328,28 +328,28 @@ naxis_transportzeppelin:
 	Armament:
 		Name: primary
 		Weapon: NaxQuadCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite
 	Armament@elite:
 		Name: primary
 		Weapon: NaxQuadCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite
 	Armament@AA:
 		Name: primary
 		Weapon: NaxQuadCannon_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite
 	Armament@eliteAA:
 		Name: primary
 		Weapon: NaxQuadCannon_AA_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/naval.yaml
@@ -169,7 +169,7 @@ nax_bitsmark:
 		Turret: primary
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
@@ -178,7 +178,7 @@ nax_bitsmark:
 		Turret: secondary
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
@@ -186,7 +186,7 @@ nax_bitsmark:
 		Turret: tercera
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
@@ -194,7 +194,7 @@ nax_bitsmark:
 		Turret: cuarta
 		Weapon: 8Inch
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/vehicles.yaml
@@ -206,7 +206,7 @@ wirbelwind.nax:
 	Armament:
 		Name: primary
 		Weapon: NaxQuadCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		MuzzleSequence: muzzle
@@ -215,7 +215,7 @@ wirbelwind.nax:
 	Armament@elite:
 		Name: primary
 		Weapon: NaxQuadCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		MuzzleSequence: muzzle-2
@@ -224,7 +224,7 @@ wirbelwind.nax:
 	Armament@AA:
 		Name: primary
 		Weapon: NaxQuadCannon_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		MuzzleSequence: muzzle
@@ -233,7 +233,7 @@ wirbelwind.nax:
 	Armament@eliteAA:
 		Name: primary
 		Weapon: NaxQuadCannon_AA_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		MuzzleSequence: muzzle-2
@@ -314,7 +314,7 @@ tiger.nax:
 	Armament:
 		Name: primary
 		Weapon: NaxTigerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -323,7 +323,7 @@ tiger.nax:
 	Armament@elite:
 		Name: primary
 		Weapon: NaxTigerCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -377,7 +377,7 @@ naxis_kingtigerheavytank:
 	Armament:
 		Name: primary
 		Weapon: KingNaxTigerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -386,7 +386,7 @@ naxis_kingtigerheavytank:
 	Armament@elite:
 		Name: primary
 		Weapon: KingNaxTigerCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -441,7 +441,7 @@ naxis_maus:
 	Armament:
 		Name: primary
 		Weapon: NaxMausCannon
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,300
 		MuzzleSequence: muzzle
@@ -450,7 +450,7 @@ naxis_maus:
 	Armament@elite:
 		Name: primary
 		Weapon: NaxMausCannon_elite
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,300
 		MuzzleSequence: muzzle-2
@@ -508,7 +508,7 @@ naxis_ratte:
 	Armament:
 		Name: primary
 		Weapon: NaxRatteCannon
-		Recoil: 500
+		Recoil: 250
 		RecoilRecovery: 50
 		LocalOffset: 2000,250,500, 2000,-250,500
 		MuzzleSequence: muzzle
@@ -517,7 +517,7 @@ naxis_ratte:
 	Armament@elite:
 		Name: primary
 		Weapon: NaxRatteCannon_elite
-		Recoil: 500
+		Recoil: 250
 		RecoilRecovery: 50
 		LocalOffset: 2000,250,500, 2000,-250,500
 		MuzzleSequence: muzzle
@@ -526,13 +526,13 @@ naxis_ratte:
 	Armament@AA1:
 		Name: secondary
 		Weapon: NaxQuadCannon_AA_elite
-		Recoil: 100
+		Recoil: 50
 		RecoilRecovery: 20
 		LocalOffset: 1024,400,80, 1024,-400,80
 	Armament@AA2:
 		Name: secondary
 		Weapon: NaxQuadCannon_AA_elite
-		Recoil: 100
+		Recoil: 50
 		RecoilRecovery: 20
 		LocalOffset: 1024,-400,80, 1024,400,80
 	AttackTurreted:
@@ -1061,7 +1061,7 @@ naxis_shoekarn:
 	Armament:
 		Name: primary
 		Weapon: RA2120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -1070,7 +1070,7 @@ naxis_shoekarn:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2120mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -1295,7 +1295,7 @@ assault.nax:
 	Armament:
 		Name: primary
 		Weapon: Nax120mmAssault
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -1304,7 +1304,7 @@ assault.nax:
 	Armament@elite:
 		Name: primary
 		Weapon: Nax120mmAssault_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -1365,7 +1365,7 @@ naxis_imperialturbotank:
 	Armament:
 		Name: primary
 		Weapon: Nax120mmAssault
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,-100,80
 		MuzzleSequence: muzzle
@@ -1374,7 +1374,7 @@ naxis_imperialturbotank:
 	Armament@elite:
 		Name: primary
 		Weapon: Nax120mmAssault_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,-100,80
 		MuzzleSequence: muzzle-2
@@ -1429,7 +1429,7 @@ panzer.nax:
 	Armament:
 		Name: primary
 		Weapon: RA2105mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -1438,7 +1438,7 @@ panzer.nax:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2105mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -1493,7 +1493,7 @@ car.nax:
 	Armament:
 		Name: primary
 		Weapon: NaxiWW2MachinegunTop
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -1502,7 +1502,7 @@ car.nax:
 	Armament@AA:
 		Name: primary
 		Weapon: NaxiWW2MachinegunTop_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
@@ -141,84 +141,84 @@ schwarzermond_spacezeppelin:
 	Armament:
 		Name: primary
 		Weapon: NaxiBeetleLaser_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && !schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@elite:
 		Name: primary
 		Weapon: NaxiBeetleLaser_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && !schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@AA:
 		Name: primary
 		Weapon: NaxiBeetleLaser_AA_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && !schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@eliteAA:
 		Name: primary
 		Weapon: NaxiBeetleLaser_AA_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && !schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@UP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@eliteUP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@AA_UP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@eliteAA_UP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && schwarzermond_upgrade_crystallens && !schwarzermond_upgrade_amplifiedlens
 	Armament@AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && schwarzermond_upgrade_amplifiedlens
 	Armament@eliteAMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && schwarzermond_upgrade_amplifiedlens
 	Armament@AA_AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: !rank-elite && schwarzermond_upgrade_amplifiedlens
 	Armament@eliteAA_AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,200,80, 512,-200,80, 512,200,280, 512,-200,280
 		RequiresCondition: rank-elite && schwarzermond_upgrade_amplifiedlens

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/vehicles.yaml
@@ -120,7 +120,7 @@ schwarzermond_laserbeetle:
 	Armament:
 		Name: primary
 		Weapon: NaxiBeetleLaser_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -129,7 +129,7 @@ schwarzermond_laserbeetle:
 	Armament@AA:
 		Name: primary
 		Weapon: NaxiBeetleLaser_AA_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -138,7 +138,7 @@ schwarzermond_laserbeetle:
 	Armament@UP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -147,7 +147,7 @@ schwarzermond_laserbeetle:
 	Armament@AA_UP:
 		Name: primary
 		Weapon: Lunar_YellowBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -156,7 +156,7 @@ schwarzermond_laserbeetle:
 	Armament@AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -165,7 +165,7 @@ schwarzermond_laserbeetle:
 	Armament@AA_AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedBeetleLaser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 512,1,80, 512,-1,80
 		MuzzleSequence: muzzle
@@ -223,7 +223,7 @@ schwarzermond_lunarpanzer:
 	Armament:
 		Name: primary
 		Weapon: LunarPanzerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -232,7 +232,7 @@ schwarzermond_lunarpanzer:
 	Armament@elite:
 		Name: primary
 		Weapon: LunarPanzerCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -241,7 +241,7 @@ schwarzermond_lunarpanzer:
 	Armament@upgraded:
 		Name: primary
 		Weapon: Lunar_Green105mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle
@@ -250,7 +250,7 @@ schwarzermond_lunarpanzer:
 	Armament@upgraded-elite:
 		Name: primary
 		Weapon: Lunar_Green105mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1280,0,80
 		MuzzleSequence: muzzle-2
@@ -309,7 +309,7 @@ schwarzermond_lunartiger:
 	Armament:
 		Name: primary
 		Weapon: LunarTigerCannon
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,0
 		MuzzleSequence: muzzle
@@ -318,7 +318,7 @@ schwarzermond_lunartiger:
 	Armament@elite:
 		Name: primary
 		Weapon: LunarTigerCannon_elite
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,0
 		MuzzleSequence: muzzle-2
@@ -327,7 +327,7 @@ schwarzermond_lunartiger:
 	Armament@-upgrade:
 		Name: primary
 		Weapon: Lunar_GreenTigerCannon
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,0
 		MuzzleSequence: muzzle
@@ -336,7 +336,7 @@ schwarzermond_lunartiger:
 	Armament@elite-upgrade:
 		Name: primary
 		Weapon: Lunar_GreenTigerCannon_elite
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 1500,0,0
 		MuzzleSequence: muzzle-2
@@ -849,7 +849,7 @@ schwarzermond_lasertank:
 	Armament:
 		Name: primary
 		Weapon: NaxiTank2Laser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle
@@ -858,7 +858,7 @@ schwarzermond_lasertank:
 	Armament@AA:
 		Name: primary
 		Weapon: NaxiTank2Laser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle
@@ -867,7 +867,7 @@ schwarzermond_lasertank:
 	Armament@UP:
 		Name: primary
 		Weapon: Lunar_YellowTank2Laser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle
@@ -876,7 +876,7 @@ schwarzermond_lasertank:
 	Armament@AA_UP:
 		Name: primary
 		Weapon: Lunar_YellowTank2Laser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle
@@ -885,7 +885,7 @@ schwarzermond_lasertank:
 	Armament@AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedTank2Laser
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle
@@ -894,7 +894,7 @@ schwarzermond_lasertank:
 	Armament@AA_AMP:
 		Name: primary
 		Weapon: Lunar_AmplifiedTank2Laser_AA
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 850,150,-60, 850,-150,-60
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/naval.yaml
@@ -29,14 +29,14 @@ triton.latin:
 		Type: Light
 	Armament@PRIMARY:
 		Weapon: LatinSentryMG
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 512,0,256
 		RequiresCondition: !rank-elite
 	Armament@ELITE:
 		Weapon: LatinSentryMG_elite
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 512,0,256
@@ -167,14 +167,14 @@ rammax.latin:
 		Type: Medium
 	Armament@PRIMARY:
 		Weapon: Rammax_Sabot
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 512,0,256
 		RequiresCondition: !rank-elite
 	Armament@ELITE:
 		Weapon: Rammax_Sabot
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: 512,0,256

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
@@ -358,7 +358,7 @@ latinsyndicate_rushertank:
 	Armament:
 		Name: primary
 		Weapon: RA2Gren60mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -367,7 +367,7 @@ latinsyndicate_rushertank:
 	Armament@elite:
 		Name: primary
 		Weapon: RA2Gren60mm_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle-2
@@ -376,14 +376,14 @@ latinsyndicate_rushertank:
 	Armament@AA:
 		Weapon: LatinRusherRocket
 		LocalOffset: 600,200,300, 600,-200,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && !rank-elite
 	Armament@AAE:
 		Weapon: LatinRusherRocket_elite
 		LocalOffset: 600,200,300, 600,-200,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && rank-elite
@@ -447,7 +447,7 @@ latinsyndicate_smokertank:
 	Armament:
 		Name: primary
 		Weapon: LatinSmokerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -456,7 +456,7 @@ latinsyndicate_smokertank:
 	Armament@elite:
 		Name: primary
 		Weapon: LatinSmokerCannon_elite
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -465,7 +465,7 @@ latinsyndicate_smokertank:
 	Armament@GrenadePack:
 		Weapon: RA2GrenadePack
 		LocalOffset: 600,100,300, 600,200,300, 600,-100,300, 600,-200,300
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle-2
 		MuzzlePalette: ra2effect
@@ -473,7 +473,7 @@ latinsyndicate_smokertank:
 	Armament@GrenadePackE:
 		Weapon: RA2GrenadePack_elite
 		LocalOffset: 600,100,300, 600,200,300, 600,-100,300, 600,-200,300
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle-2
 		MuzzlePalette: ra2effect
@@ -481,14 +481,14 @@ latinsyndicate_smokertank:
 	Armament@AA:
 		Weapon: LatinSmokerRocket
 		LocalOffset: 600,200,300, 600,-200,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && !rank-elite
 	Armament@AAE:
 		Weapon: LatinSmokerRocket_elite
 		LocalOffset: 600,200,300, 600,-200,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && rank-elite
@@ -553,7 +553,7 @@ latinsyndicate_diablo:
 	Armament:
 		Name: primary
 		Weapon: DiabloCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1024,0,80
 		MuzzleSequence: muzzle
@@ -562,7 +562,7 @@ latinsyndicate_diablo:
 	Armament@Elite:
 		Name: primary
 		Weapon: DiabloCannon_elite
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
@@ -570,14 +570,14 @@ latinsyndicate_diablo:
 		Name: secondary
 		Weapon: DiabloCannon_AA
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@AAE:
 		Name: secondary
 		Weapon: DiabloCannonAAE_AA
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
@@ -673,84 +673,84 @@ latinsyndicate_latinapc:
 	Armament@Flak:
 		Weapon: RA2APCFlakCannon
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@FlakELITE:
 		Weapon: RA2APCFlakCannon_elite
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
 	Armament@FlakAA:
 		Weapon: RA2APCFlakCannonAA
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@FlakAAELITE:
 		Weapon: RA2APCFlakCannonAA_elite
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
 	Armament@Machinegun:
 		Weapon: RA2APCMachineGun
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_upgrade_yuristolentechchainguns && !rank-elite
 	Armament@MachinegunELITE:
 		Weapon: RA2APCMachineGun_elite
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_upgrade_yuristolentechchainguns && rank-elite
 	Armament@MachinegunAA:
 		Weapon: RA2APCMachineGun_AA
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_upgrade_yuristolentechchainguns && !rank-elite
 	Armament@MachinegunAAELITE:
 		Weapon: RA2APCMachineGun_AA_elite
 		LocalOffset: 600,15,300, 600,-15,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_upgrade_yuristolentechchainguns && rank-elite
 	Armament@Rockets:
 		Weapon: RA2APCRocket
 		LocalOffset: 600,-150,300, 600,150,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && !rank-elite
 	Armament@RocketsELITE:
 		Weapon: RA2APCRocket_elite
 		LocalOffset: 600,-150,300, 600,150,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && rank-elite
 	Armament@RocketsAA:
 		Weapon: RA2APCRocket_AA
 		LocalOffset: 600,-150,300, 600,150,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && !rank-elite
 	Armament@RocketsAAELITE:
 		Weapon: RA2APCRocket_AA_elite
 		LocalOffset: 600,-150,300, 600,150,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: latinsyndicate_doctrine_cartelrockets && rank-elite
@@ -826,14 +826,14 @@ latinsyndicate_narcohummer:
 	Armament@AG:
 		Weapon: RA2NarcoAKM
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@AGE:
 		Weapon: RA2NarcoAKM_elite
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite
@@ -910,14 +910,14 @@ latinsyndicate_carteltruck:
 	Armament@AG:
 		Weapon: RA2Narco60mm
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: !rank-elite
 	Armament@AGE:
 		Weapon: RA2Narco60mm_elite
 		LocalOffset: 600,0,300
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		RequiresCondition: rank-elite

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/defenses.yaml
@@ -84,7 +84,7 @@ tkm_quadturretbunker:
 	# 	MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: TKMAATurretCannon
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 	AttackTurreted:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/vehicles.yaml
@@ -256,7 +256,7 @@ tkm_technicaltank:
 		Offset: -160,0,400
 	Armament@cannon:
 		Weapon: tkmltgun
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -323,12 +323,12 @@ tkm_quadtruck:
 		Offset: -350,0,250
 	Armament@AG:
 		Weapon: TKMQuadCannonAG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: TKMQuadCannonAA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -373,12 +373,12 @@ tkm_zaza:
 		Offset: -160,0,500
 	Armament@AG:
 		Weapon: TKMZazaCannonAG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: TKMZazaCannonAA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 500,100,450, 500,-100,450
 		MuzzleSequence: muzzle
 	FirepowerMultiplier@GattlingSpeed1:
@@ -528,7 +528,7 @@ tkm_abrams:
 		Offset: 0,0,300
 	Armament@cannon:
 		Weapon: tkmrh120gun
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -613,7 +613,7 @@ tkm_t72m:
 		Offset: 0,0,200
 	Armament:
 		Weapon: tkm2a46gun
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -1041,7 +1041,7 @@ tkm_trenchtank:
 		Offset: 75,0,425
 	Armament:
 		Weapon: tkmtrenchcannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -1105,7 +1105,7 @@ tkm_t30:
 		Offset: 0,0,400
 	Armament:
 		Weapon: t30shell
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 1600,85,90, 1600,-85,90
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
@@ -293,20 +293,20 @@ protoss_idol:
 		Type: Medium
 	Armament@Upgrade1: ##########
 		Weapon: WaveforceCannonChargedLaser
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 600,0,100
 		MuzzleSequence: muzzle
 	Armament@Upgrade2: ##########
 		Weapon: WaveforceCannonDistortedBeam1
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 600,0,100
 		FireDelay: 1
 		MuzzleSequence: muzzle
 	Armament@Upgrade3: ##########
 		Weapon: WaveforceCannonDistortedBeam2
-		Recoil: 256
+		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 600,0,100
 		FireDelay: 2

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/naval.yaml
@@ -152,7 +152,7 @@ CNCCA:
 		Turret: primary
 		Weapon: GDIBattleshipRailgun
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
@@ -161,7 +161,7 @@ CNCCA:
 		Turret: secondary
 		Weapon: GDIBattleshipRailgun
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
@@ -66,14 +66,14 @@ td_gdi_apc:
 		TurnSpeed: 40
 	Armament@PRIMARY:
 		Weapon: APCGun
-		Recoil: 96
+		Recoil: 48
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: APCGun_AA
-		Recoil: 96
+		Recoil: 48
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
 		MuzzleSequence: muzzle
@@ -186,21 +186,21 @@ td_gdi_battletank:
 		TurnSpeed: 16
 	Armament:
 		Weapon: 120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 768,0,90
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_highvelocitycannons
 	Armament@HV:
 		Weapon: 120mmHV
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 768,0,90
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_highvelocitycannons
 	Armament@Missile:
 		Weapon: M1A1Missiles
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 512,256,128
 		MuzzleSequence: muzzle
@@ -208,7 +208,7 @@ td_gdi_battletank:
 		RequiresCondition: !td_gdi_upgrade_advancedmissiletargeting
 	Armament@AdvancedMissileTargeting:
 		Weapon: M1A1MissilesAMT
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 512,256,128
 		MuzzleSequence: muzzle
@@ -281,14 +281,14 @@ td_gdi_mammothtank:
 	Armament@PRIMARY:
 		Weapon: 120mmDual
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_highvelocitycannons
 	Armament@HV:
 		Weapon: 120mmDualHV
 		LocalOffset: 900,180,340, 900,-180,340
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_highvelocitycannons
@@ -297,7 +297,7 @@ td_gdi_mammothtank:
 		Weapon: MammothMissiles
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -75, 75
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 20
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_advancedmissiletargeting
@@ -306,7 +306,7 @@ td_gdi_mammothtank:
 		Weapon: MammothMissilesAMT
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -50, 50
-		Recoil: 40
+		Recoil: 20
 		RecoilRecovery: 20
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_advancedmissiletargeting
@@ -367,12 +367,12 @@ td_gdi_boxer:
 		Offset: -128,0,0
 	Armament@AG:
 		Weapon: BoxerCannonAG
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 800,80,400, 800,-80,400
 		MuzzleSequence: muzzle
 	Armament@AA:
 		Weapon: BoxerCannon_AA
-		Recoil: 85
+		Recoil: 43
 		LocalOffset: 800,80,400, 800,-80,400
 		MuzzleSequence: muzzle
 	FirepowerMultiplier@ra1_allies_alliedheavyaatank:
@@ -747,14 +747,14 @@ td_gdi_predatortank:
 	Armament@PRIMARY:
 		Weapon: GDIPredatorTankCannon
 		LocalOffset: 1000,0,300
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 50
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_highvelocitycannons
 	Armament@Upgrade:
 		Weapon: GDIPredatorTankCannonHV
 		LocalOffset: 1000,0,300
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 50
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_highvelocitycannons
@@ -763,7 +763,7 @@ td_gdi_predatortank:
 		Weapon: GDIPredatorTankMissiles
 		LocalOffset: 150,-300,300
 		LocalYaw: 50
-		Recoil: 10
+		Recoil: 5
 		MuzzleSequence: muzzle
 		FireDelay: 10
 		RequiresCondition: !td_gdi_upgrade_advancedmissiletargeting
@@ -772,7 +772,7 @@ td_gdi_predatortank:
 		Weapon: GDIPredatorTankMissilesAMT
 		LocalOffset: 150,-300,300
 		LocalYaw: 50
-		Recoil: 10
+		Recoil: 5
 		MuzzleSequence: muzzle
 		FireDelay: 10
 		RequiresCondition: td_gdi_upgrade_advancedmissiletargeting
@@ -846,14 +846,14 @@ td_gdi_mammothtankmkiii:
 	Armament@PRIMARY:
 		Weapon: MammothTank3Cannons
 		LocalOffset: 1200,200,150, 1200,-200,150
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 50
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_highvelocitycannons
 	Armament@HV:
 		Weapon: MammothTank3CannonsHV
 		LocalOffset: 1200,200,150, 1200,-200,150
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 50
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_highvelocitycannons
@@ -862,7 +862,7 @@ td_gdi_mammothtankmkiii:
 		Weapon: MammothTank3Missiles
 		LocalOffset: -100,300,250, -100,-300,250
 		LocalYaw: -75, 75
-		Recoil: 10
+		Recoil: 5
 		MuzzleSequence: muzzle
 		RequiresCondition: !td_gdi_upgrade_advancedmissiletargeting
 	Armament@AdvancedMissileTargeting:
@@ -870,7 +870,7 @@ td_gdi_mammothtankmkiii:
 		Weapon: MammothTank3MissilesAMT
 		LocalOffset: -100,300,250, -100,-300,250
 		LocalYaw: -50, 50
-		Recoil: 10
+		Recoil: 5
 		MuzzleSequence: muzzle
 		RequiresCondition: td_gdi_upgrade_advancedmissiletargeting
 	AttackTurreted:
@@ -1092,7 +1092,7 @@ td_gdi_defenserig:
 	Armament@mobile:
 		Weapon: GDIRigPhalanx
 		LocalOffset: 640,0,480
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle
 		ForceTargetRelationships: Enemy, Neutral
@@ -1113,7 +1113,7 @@ td_gdi_defenserig:
 		Turret: railgun
 		Weapon: GDIRigRailgun
 		LocalOffset: 512,0,0
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle
 		ForceTargetRelationships: Enemy, Neutral
@@ -1123,7 +1123,7 @@ td_gdi_defenserig:
 		Turret: missilepod
 		Weapon: GDIRigMissilePod
 		LocalOffset: 640,0,480
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle
 		ForceTargetRelationships: Enemy, Neutral
@@ -1132,7 +1132,7 @@ td_gdi_defenserig:
 		Turret: missilepod
 		Weapon: GDIRigMissilePodAMT
 		LocalOffset: 640,0,480
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		MuzzleSequence: muzzle
 		ForceTargetRelationships: Enemy, Neutral

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/naval.yaml
@@ -167,7 +167,7 @@ nodlasercorvette:
 		Name: secondary
 		Weapon: CorvetteDragon
 		LocalOffset: 480,-100,40, 480,100,40
-		Recoil: 175
+		Recoil: 88
 		RecoilRecovery: 35
 		MuzzleSequence: muzzle
 	AttackTurreted:

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/vehicles.yaml
@@ -350,13 +350,13 @@ td_nod_lighttank:
 		TurnSpeed: 22
 	Armament:
 		Weapon: 70mm
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 15
 		LocalOffset: 720,0,90
 		MuzzleSequence: muzzle
 	Armament@Missile:
 		Weapon: LTNKMissiles
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 250,125,125
 		MuzzleSequence: muzzle
@@ -844,13 +844,13 @@ td_nod_lighttankmkii:
 	AttackTurreted:
 	Armament:
 		Weapon: LightTank2Cannon
-		Recoil: 85
+		Recoil: 43
 		RecoilRecovery: 25
 		LocalOffset: 720,0,90
 		MuzzleSequence: muzzle
 	Armament@Missile:
 		Weapon: LightTank2Missiles
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 250,125,125
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/naval.yaml
@@ -75,12 +75,12 @@ cabal_lazerboat:
 	Armament@PRIMARY:
 		Weapon: CabalLaserBoatLaser
 		LocalOffset: 350,-5,10, 350,5,10
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 	Armament@AA:
 		Weapon: CabalLaserBoatLaserAA
 		LocalOffset: 350,-5,10, 350,5,10
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 	Armament@SECONDARY:
 		Name: secondary

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
@@ -239,7 +239,7 @@ cabal_laserspider:
 	Armament@PRIMARY:
 		Weapon: CabalSpiderLaser
 		LocalOffset: 350,-30,250, 350,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -293,7 +293,7 @@ cabal_mantis:
 	Armament@PRIMARY:
 		Weapon: CabalMantisGun
 		LocalOffset: 350,-30,250, 350,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -399,14 +399,14 @@ cabal_artilleryspider:
 	Armament@PRIMARY:
 		Weapon: CabalArtilleryWalkerShell
 		LocalOffset: 300,0,1500
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: !cabal_upgrade_neutronnuclearcatalyst
 	Armament@Upgraded:
 		Weapon: CabalArtilleryWalkerShellUpgraded
 		LocalOffset: 300,0,1500
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: cabal_upgrade_neutronnuclearcatalyst
@@ -465,14 +465,14 @@ cabal_tarantula:
 		Offset: -500,0,0
 	Armament@PRIMARY:
 		Weapon: CabalTarantulaCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 500, 0, 250
 		MuzzleSequence: muzzle
 		RequiresCondition: !cabal_upgrade_neutronnuclearcatalyst
 	Armament@Upgraded:
 		Weapon: TS120mm_bluenuke
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 500, 0, 250
 		MuzzleSequence: muzzle
@@ -733,7 +733,7 @@ cabal_spidercnc4:
 	Armament@PRIMARY:
 		Weapon: CabalSpiderCnc4Laser
 		LocalOffset: 350,-30,250, 350,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -905,7 +905,7 @@ cabal_widow:
 	Armament@PRIMARY:
 		Weapon: CabalLegionGun
 		LocalOffset: 350,-30,250, 350,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/naval.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/naval.yaml
@@ -48,13 +48,13 @@ forgotten_lcraft:
 		VoiceSet: TSVehicle
 	Armament@PRIMARY:
 		Weapon: TSVanMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSChemVanMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -106,20 +106,20 @@ forgotten_juggerboat:
 		Offset: 512,0,0
 	Armament@AA:
 		Weapon: TSJuggerFlakAA_boat
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: -200,-100,0, -200,100,0
 	Armament@AG:
 		Weapon: TSJuggerboat90mm
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: -200,-100,0, -200,100,0
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSChemJuggerboat90mm
-		Recoil: 85
+		Recoil: 43
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		LocalOffset: -200,-100,0, -200,100,0

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/vehicles.yaml
@@ -162,13 +162,13 @@ forgotten_missilevan:
 		Offset: -120,0,1
 	Armament@PRIMARY:
 		Weapon: TSVanMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSChemVanMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -217,7 +217,7 @@ forgotten_raidercar:
 		Offset: 0,0,1
 	Armament:
 		Weapon: TSRaiderCarCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		MuzzleSequence: muzzle
@@ -270,7 +270,7 @@ forgotten_bowler:
 		Offset: -200,0,25
 	Armament:
 		Weapon: TSBowlerCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		MuzzleSequence: muzzle
@@ -325,14 +325,14 @@ forgotten_ruiner:
 		Offset: 0,0,1
 	Armament@PRIMARY:
 		Weapon: TSRuinerMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 		MuzzleSequence: muzzle
 	Armament@UPGRADE:
 		Weapon: TSChemRuinerMissile
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 0,121,271, 0,-121,271
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -387,13 +387,13 @@ forgotten_rattytank:
 		TurnSpeed: 18
 	Armament@PRIMARY:
 		Weapon: TS70mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TS70mmChem
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -449,14 +449,14 @@ forgotten_warriortank:
 		TurnSpeed: 15
 	Armament@PRIMARY:
 		Weapon: TSHighVelocity2
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 768,0,90
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSHighVelocity2Chem
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 768,0,90
 		MuzzleSequence: muzzle
@@ -515,14 +515,14 @@ forgotten_scoopertank:
 	WithSpriteTurret:
 	Armament@PRIMARY:
 		Weapon: TSScoopDual
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSScoopDualChem
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
 		MuzzleSequence: muzzle
@@ -574,13 +574,13 @@ forgotten_closhtank:
 		Type: Heavy
 	Armament@PRIMARY:
 		Weapon: MutFlamer
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: MutFlamerChem
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -694,14 +694,14 @@ forgotten_experimentalmammothtank:
 	Armament@PRIMARY:
 		Weapon: TS120mmx
 		LocalOffset: 900,85,340, 900,-85,340
-		Recoil: 170
+		Recoil: 85
 		RecoilRecovery: 42
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSChem120mmx
 		LocalOffset: 900,85,340, 900,-85,340
-		Recoil: 170
+		Recoil: 85
 		RecoilRecovery: 42
 		MuzzleSequence: muzzle
 		RequiresCondition: forgotten_upgrade_chemicalweapons
@@ -710,7 +710,7 @@ forgotten_experimentalmammothtank:
 		Weapon: TSMammothTusk
 		LocalOffset: -85,90,340, -85,-90,340
 		LocalYaw: -100, 100
-		Recoil: 10
+		Recoil: 5
 	WithMuzzleOverlay:
 	AttackTurreted:
 	WithSpriteTurret:
@@ -764,7 +764,7 @@ forgotten_chemicalmammothtank:
 	Armament@PRIMARY:
 		Weapon: TS120mmxChem
 		LocalOffset: 900,85,340, 900,-85,340
-		Recoil: 170
+		Recoil: 85
 		RecoilRecovery: 42
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
@@ -772,7 +772,7 @@ forgotten_chemicalmammothtank:
 		Weapon: TSMammothTuskChem
 		LocalOffset: -85,-90,340
 		LocalYaw: -100, 100
-		Recoil: 10
+		Recoil: 5
 	WithMuzzleOverlay:
 	AttackTurreted:
 	WithSpriteTurret:
@@ -824,14 +824,14 @@ forgotten_tankkiller:
 		Type: Medium
 	Armament@PRIMARY:
 		Weapon: TSHighVelocity
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSHighVelocityChem
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
@@ -886,14 +886,14 @@ forgotten_thumperbus:
 		Type: Heavy
 	Armament@PRIMARY:
 		Weapon: TSBusMortar
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 20
 		LocalOffset: 1200,0,600
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSBusMortarChem
-		Recoil: 200
+		Recoil: 100
 		RecoilRecovery: 20
 		LocalOffset: 1200,0,600
 		MuzzleSequence: muzzle
@@ -969,7 +969,7 @@ forgotten_nomadbarracks:
 		Type: Superheavy
 	Armament:
 		Weapon: TSNomadGun
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
@@ -1051,14 +1051,14 @@ forgotten_mlrs:
 		Type: Medium
 	Armament@PRIMARY:
 		Weapon: TSMLRSMissile
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 0,121,271, 0,-121,271
 		MuzzleSequence: muzzle
 		RequiresCondition: !forgotten_upgrade_chemicalweapons
 	Armament@UPGRADE:
 		Weapon: TSChemMLRSMissile
-		Recoil: 64
+		Recoil: 32
 		RecoilRecovery: 32
 		LocalOffset: 0,121,271, 0,-121,271
 		MuzzleSequence: muzzle

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/vehicles.yaml
@@ -142,7 +142,7 @@ ts_gdi_amphibiousapc:
 		TurnSpeed: 20
 	Armament:
 		Weapon: TSAAPCCannon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 	WithMuzzleOverlay:
@@ -262,14 +262,14 @@ ts_gdi_titan:
 		TurnSpeed: 15
 	Armament@PRIMARY:
 		Weapon: TS120mm
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 800, 300, 700
 		MuzzleSequence: muzzle
 		RequiresCondition: !ts_gdi_upgrade_railgunweaponry
 	Armament@Upgrade:
 		Weapon: TS120mmRail
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 800, 300, 700
 		MuzzleSequence: muzzle
@@ -338,14 +338,14 @@ ts_gdi_titanmkii:
 		Offset: -45,0,392
 	Armament@PRIMARY:
 		Weapon: TS120mmTal
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 800, 300, 700
 		MuzzleSequence: muzzle
 		RequiresCondition: !ts_gdi_upgrade_railgunweaponry
 	Armament@Upgrade:
 		Weapon: TS120mmTalRail
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 32
 		LocalOffset: 800, 300, 700
 		MuzzleSequence: muzzle
@@ -988,12 +988,12 @@ ts_gdi_disruptor:
 		TurnSpeed: 10
 	Armament@PRIMARY:
 		Weapon: TSSonicZapWeapon
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		RequiresCondition: !ts_gdi_upgrade_sonicweaponry
 	Armament@Upgrade:
 		Weapon: TSSonicZapWeaponSonic
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		RequiresCondition: ts_gdi_upgrade_sonicweaponry
 	AttackTurreted:

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/vehicles.yaml
@@ -174,21 +174,21 @@ ts_nod_attackbuggy:
 	Armament@PRIMARY:
 		Weapon: TSRaiderCannon
 		LocalOffset: 0,-30,250, 0,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: !ts_nod_upgrade_tiberiumlenses
 	Armament@UPGRADE:
 		Weapon: TSLaserRaiderCannon
 		LocalOffset: 0,-30,250, 0,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 24
 		MuzzleSequence: muzzle
 		RequiresCondition: ts_nod_upgrade_tiberiumlenses
 	Armament@SECONDARY:
 		Weapon: TSRaiderGrenade
 		LocalOffset: 0,-30,250, 0,30,250
-		Recoil: 128
+		Recoil: 64
 		RecoilRecovery: 26
 		MuzzleSequence: muzzle
 		RequiresCondition: ts_nod_upgrade_auxiliaryweapon


### PR DESCRIPTION
## What changed

- Halves all 390 active Armament.Recoil values across 40 YAML files.
- Leaves RecoilRecovery and dormant/commented rules unchanged.

## Why

Turret and weapon recoil use the Armament.Recoil distance directly for visual displacement. This reduces that movement to half its current baseline while preserving recovery timing.

## Player impact

Weapon recoil travels half as far, with the existing recovery cadence retained.

## Validation

- Traversed the active mod.yaml content graph.
- Verified all 390 active recoil values are exactly half their HEAD values, using nearest whole-unit rounding.
- Verified the diff contains only Recoil substitutions and no RecoilRecovery changes.
- git diff --check passes.