### PR TITLE
Set D2K turret armor to Concrete

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
@@ -280,6 +280,8 @@ harkonnen_autogunturret:
 	Inherits@AntiInf: ^PrioritizeInfantry
 	Inherits@AntiAir: ^PrioritizeAir
 	Inherits@gat: ^GatlingSpeedUpTurretBehavior
+	Armor:
+		Type: Concrete
 	Tooltip:
 		Name: Harkonnen Autogun Turret
 	Valued:
@@ -410,6 +412,8 @@ harkonnen_rocketturret:
 	Inherits@EMP: ^DefenseTurretedEMP
 	Inherits@HeavyMissiles: ^D2K_HeavyMissilesUpgrade
 	Inherits@Armor: ^D2K_GeneralPurposeArmor
+	Armor:
+		Type: Concrete
 	Buildable:
 		Prerequisites: ~harkonnen_constructionyard, harkonnen_outpost
 	Valued:

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
@@ -697,6 +697,8 @@ ixian_rocketturret:
 	Inherits@EMP: ^DefenseTurretedEMP
 	Inherits@HeavyMissiles: ^D2K_HeavyMissilesUpgrade
 	Inherits@Armor: ^D2K_GeneralPurposeArmor
+	Armor:
+		Type: Concrete
 	Buildable:
 		Queue: Defence, RADefence
 		Prerequisites: ~ixian_constructionyard, ixian_outpost
@@ -1102,6 +1104,8 @@ ixian_stormlasher:
 	Inherits@detect: ^GenericGroundDetector
 	Inherits@Armor: ^D2K_GeneralPurposeArmor
 	Inherits@IxianTechnology: ^D2K_AdvancedIxianTechnology
+	Armor:
+		Type: Concrete
 	Buildable:
 		Queue: Defence, RADefence
 		Prerequisites: ~ixian_constructionyard, ~ixian_promotion_stormlasher, ixian_ixresearchcenter

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
@@ -494,6 +494,8 @@ ordos_artilleryplatform:
 	Inherits@shape: ^1x1Shape
 	Inherits@ContrabandUpgradeOrdos: ^ContrabandUpgradeOrdos
 	-WithTurretSearchlight:
+	Armor:
+		Type: Concrete
 	Tooltip:
 		Name: Artillery Platform
 	Valued:
@@ -567,6 +569,8 @@ ordos_autogunturret:
 	Inherits@gat: ^GatlingSpeedUpTurretBehavior
 	Inherits@ContrabandUpgradeOrdos: ^ContrabandUpgradeOrdos
 	Inherits@RapidFireArmorPiercingBelts: ^Ordos_RapidFireArmorPiercingBelts
+	Armor:
+		Type: Concrete
 	Tooltip:
 		Name: Autogun Turret
 	Valued:


### PR DESCRIPTION
## Summary

Changes the six active D2K turrets that previously resolved to Steel armor to explicitly use `Armor: Type: Concrete`.

`^AdvancedDefenseTemplate` remains inherited, so its low-power behavior, build-duration modifier, damage modifier, disguise detection, and other advanced-defense traits are preserved.

## Why

Changing the template reference would remove several unrelated Advanced-defense behaviors. A local Armor override changes only the armor class.

## Player impact

All active D2K turrets now use Concrete armor while retaining their existing combat and Advanced-defense behavior.

## Validation

- Confirmed six Advanced-template turrets retain their template and declare local Concrete armor.
- Confirmed the three Basic-template turrets already inherit Concrete armor.
- `git diff --check` passed.
- No global templates or weapon data changed.
