### PR TITLE
Remove BFG 10000 searchlight

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/buildings.yaml
@@ -634,6 +634,7 @@ steelconsortium_quantumcannon:
 steelconsortium_bfg10000:
 	Inherits: ^Defense
 	Inherits@Template: ^AdvancedDefenseTemplate
+	-WithTurretSearchlight:
 	Inherits@EXPERIENCE: ^GainsExperienceRA2
 	Inherits@AUTOTARGET: ^AutoTargetAll
 	Inherits@EMP: ^DefenseTurretedEMP


### PR DESCRIPTION
## Summary

- remove the inherited turret searchlight from BFG 10000
- preserve the rest of its advanced-defense behavior

## Why

BFG 10000 has an exceptionally long weapon range. Its inherited searchlight stretches into a very thin beam across the battlefield, producing an undesirable visual.

## Validation

- `git diff --check`
- verified the PR contains one YAML insertion in the BFG 10000 actor

Runtime confirmation requires restarting the game; no engine build is required for this YAML-only change.
