### PR TITLE
Ignore spice bloom harvester alerts

### DIFF
--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -4741,7 +4741,7 @@ BloomExplosion:
 			Medium: 35
 			Heavy: 25
 			Concrete: 30
-		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 
@@ -6116,7 +6116,7 @@ SpiceExplosion:
 			Medium: 45
 			Heavy: 30
 			Concrete: 15
-		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource


### PR DESCRIPTION
## Summary

- tag the initial spice mound `BloomExplosion` damage as `SpiceExplosion`
- tag the bloom's ejected `SpiceExplosion` projectile damage the same way

## Why

`HarvesterAttackNotifier` already excludes damage carrying the `SpiceExplosion` type, but Cameo's active bloom warheads did not apply that type. As a result, environmental spice bloom damage could incorrectly play the resource collector under-attack notification.

## Impact

Harvesters damaged by spice blooms or spice mound explosions no longer trigger the under-attack voice and text notification. Normal enemy damage remains unchanged.

## Validation

- confirmed both active bloom warheads now carry `SpiceExplosion`
- confirmed the player notifier excludes `SpiceExplosion`
- `git diff --check` passes

YAML-only change; no engine build required.
