### PR TITLE
Restore reverted balance and weapon effects

### DIFF
--- a/docs/balance/tiberiandawn_nod.json
+++ b/docs/balance/tiberiandawn_nod.json
@@ -2351,62 +2351,62 @@
       "burstdelays": "5",
       "damage_warheads": [
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "TeslaChargedWeapon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "22000",
+        "damage": "2000",
         "tag": "TeslaChargedExtraDamage",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "TeslaChargedWeaponPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "TankDestroyerCannon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "TankDestroyerCannonPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "Chaingun",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "ChaingunPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "ShrapnelWeapon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "22000",
+        "damage": "2000",
         "tag": "ShrapnelWeaponFriendlyFire",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "ShrapnelWeaponPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "MediumMissile",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "MediumMissilePercentage",
         "type": "HealthPercentageDamage"
        }
@@ -2434,62 +2434,62 @@
       "burstdelays": "5",
       "damage_warheads": [
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "TeslaChargedWeapon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "22000",
+        "damage": "2000",
         "tag": "TeslaChargedExtraDamage",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "TeslaChargedWeaponPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "TankDestroyerCannon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "TankDestroyerCannonPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "Chaingun",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "ChaingunPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "ShrapnelWeapon",
         "type": "SpreadDamage"
        },
        {
-        "damage": "22000",
+        "damage": "2000",
         "tag": "ShrapnelWeaponFriendlyFire",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "ShrapnelWeaponPercentage",
         "type": "HealthPercentageDamage"
        },
        {
-        "damage": "22000",
+        "damage": "4000",
         "tag": "MediumMissile",
         "type": "SpreadDamage"
        },
        {
-        "damage": "1",
+        "damage": "2",
         "tag": "MediumMissilePercentage",
         "type": "HealthPercentageDamage"
        }

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1038,6 +1038,9 @@ ordos_autogunturret:
 	Warhead@Bullet_Medium_Percentage:
 		ValidTargets: Ground, Water, Air
 		Damage: 1
+	Warhead@Ricochet: CreateEffect
+		ImpactSounds: 2100richet1.wav, 2100richet2.wav
+		ValidTargets: Ground, Water, Air
 
 autogun_tank:
 	Inherits: ^Warhead_CannonHE_Heavy

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
@@ -2201,9 +2201,11 @@ YakNuclearBomb:
 	Warhead@NuclearWarhead: SpreadDamage
 		ValidTargets: Ground, Water
 		Damage: 50000
+		AffectsParent: false
 	Warhead@NuclearWarheadPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water
 		Damage: 25
+		AffectsParent: false
 	Warhead@Effect: CreateEffect
 		Explosions: nuke_small
 		ImpactSounds: kaboom22.aud
@@ -2347,9 +2349,11 @@ ThermobaricMaverick:
 	Warhead@NuclearWarhead: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 12000
+		AffectsParent: false
 	Warhead@NuclearWarheadPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 6
+		AffectsParent: false
 	Warhead@MediumFlameWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 12000
@@ -2405,9 +2409,11 @@ NuclearMaverick:
 	Warhead@NuclearWarhead: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 20000
+		AffectsParent: false
 	Warhead@NuclearWarheadPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 10
+		AffectsParent: false
 	Warhead@MissileHE_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 20000
@@ -2456,9 +2462,11 @@ ThermobaricNuclearMaverick:
 	Warhead@NuclearWarhead: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 14000
+		AffectsParent: false
 	Warhead@NuclearWarheadPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 7
+		AffectsParent: false
 	Warhead@MissileHE_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 14000
@@ -3885,8 +3893,10 @@ ParaBombNuke:
 		Damage: 50
 	Warhead@NuclearWarhead: SpreadDamage
 		Damage: 100000
+		AffectsParent: false
 	Warhead@NuclearWarheadPercentage: HealthPercentageDamage
 		Damage: 50
+		AffectsParent: false
 	Warhead@Effect: CreateEffect
 		ImpactSounds: kaboom22.aud
 

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
@@ -724,19 +724,17 @@ RA2vulcan:
 	Inherits: ^RA2SmallArms
 	Inherits@2: ^RA2Chaingun
 	ValidTargets: Ground, Water
-	ReloadDelay: 14
+	ReloadDelay: 18
 	Range: 6577
-	Burst: 3
+	Burst: 4
 	BurstDelays: 3
 	Report: bsenatta.wav, bsenattb.wav, bsenattc.wav, bsenattd.wav
 	Warhead@Bullet_Light:
 		Damage: 2000
-	Warhead@Bullet_Light_Percentage: HealthPercentageDamage
-		Damage: 1
+	-Warhead@Bullet_Light_Percentage:
 	Warhead@Bullet_Medium:
 		Damage: 2000
-	Warhead@Bullet_Medium_Percentage: HealthPercentageDamage
-		Damage: 1
+	-Warhead@Bullet_Medium_Percentage:
 
 RA2CRFlakGuyGun:
 	Inherits: RA2FLAKAG

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
@@ -1129,51 +1129,51 @@ BHRedDarts:
 		ContrailStartColor: ff0000
 	Warhead@TeslaChargedWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 4000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@TeslaChargedExtraDamage: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@TeslaChargedWeaponPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 1
+		Damage: 2
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@TankDestroyerCannon: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 4000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@TankDestroyerCannonPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 1
+		Damage: 2
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@Chaingun: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 4000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@ChaingunPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 1
+		Damage: 2
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@ShrapnelWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 4000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@ShrapnelWeaponFriendlyFire: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@ShrapnelWeaponPercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 1
+		Damage: 2
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@MediumMissile: SpreadDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 22000
+		Damage: 4000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@MediumMissilePercentage: HealthPercentageDamage
 		ValidTargets: Ground, Water, Air
-		Damage: 1
+		Damage: 2
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@EMPUnit: AffectsIntegrity
 		Damage: 5000

--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -9347,7 +9347,7 @@ BloomExplosion:
 			Medium: 35
 			Heavy: 25
 			Concrete: 30
-		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 
@@ -10714,7 +10714,7 @@ SpiceExplosion:
 			Medium: 45
 			Heavy: 30
 			Concrete: 15
-		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
+		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath, SpiceExplosion
 		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource
@@ -10735,9 +10735,11 @@ SpiceExplosion:
 		ValidTargets: Vehicle, Ship, Air, Cyborg, Defense, Building, Epic
 
 generic_bullet_casing:
-	Range: 2c0
-	ReloadDelay: 100
+	Range: 1c0
 	Projectile: Bullet
+		Speed: 48
+		Blockable: false
+		LaunchAngle: 100
 		Image: generic_bullet_casing
-		Speed: 200
-	Warhead@1: CreateEffect
+		Sequences: idle
+		Palette: d2keffect


### PR DESCRIPTION
## Summary

- restore the `SpiceExplosion` damage type on bloom and spice explosions so harvesters ignore those alerts again (PR #237)
- restore the original spent-casing trajectory parameters and Ordos autogun ricochet effect (PR #238)
- restore `AffectsParent: false` on the nuclear warheads used by five RA1 Soviet bomber weapons (PR #239)
- restore the TD Nod Stealth Soldier `BHRedDarts` balance and regenerate its balance-ledger entries (PR #240)
- restore the RA2 Soviet Sentry Gun reload, burst, and percentage-warhead removals from `c240b615`

## Root cause

Merge `7d76bd56` combined a long-lived production-queue repair branch with master. Its conflict result accepted older branch-side weapon sections and the minimal casing placeholder from `2bc3034c`, selectively replacing balance and effect changes that had already landed on master.

This recovery preserves the later weapon-family naming changes. The Sentry Gun warhead removals are expressed using the current `Bullet_Light_Percentage` and `Bullet_Medium_Percentage` keys.

## Validation

- `git diff --check origin/master...HEAD`
- exact PR #238 casing-block comparison
- recovery assertions for 2 spice tags, 1 ricochet warhead, 10 bomber self-damage guards, 12 `BHRedDarts` values, 4 Sentry Gun settings, and all 28 casing hookups
- `python tools/balance/extract_stats.py --check --faction tiberiandawn_nod` reports 0 drifted ledgers

No engine build is required because this recovery changes only YAML and the generated JSON balance ledger.