### PR TITLE
Align CABAL Obelisk effects with tip

### DIFF
--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
@@ -213,7 +213,7 @@ cabal_obeliskofdarkness:
 	WithSpriteBody:
 	Armament:
 		Weapon: DarkObeliskLaser
-		LocalOffset: -160,-54,2000
+		LocalOffset: -160,-96,2000
 	AttackCharges:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: lowpower || disabled


### PR DESCRIPTION
## Summary
- align the CABAL Obelisk of Darkness laser source with the crystal tip
- align the charging lens flare by correcting the shared armament muzzle offset

## Root cause
The Obelisk armament's local muzzle offset placed both effects beside the sprite's tip. The laser projectile and charge flare use that same muzzle position, so correcting the actor offset fixes both visuals together.

## Validation
- `git diff --check`
- iterative in-game visual review from recorded footage
- final position confirmed by Blackrobe