### PR TITLE
Fix damage-scaled physical state stacking

### DIFF
--- a/docs/design/PHYSICAL_STATE_SYSTEM.md
+++ b/docs/design/PHYSICAL_STATE_SYSTEM.md
@@ -182,7 +182,7 @@ reference an image+sequence, so the yaml wires with placeholders and the art dro
 
 ## 5. Build STATUS + RESUME TRACKER (updated 2026-08-09 — ⭐ RESUME HERE after /compact)
 
-**DONE (committed, each boot-gated):**
+**DONE (committed work was boot-gated unless noted):**
 - ✅ C# damage-scaled `PhysicalStateName`/`PhysicalStateScale` on `AreaDamage` + `_Percentage` — `406261128`
 - ✅ C# MULTI-state `PhysicalStates` dict (one warhead → many meters) — `2e6d6968a`
 - ✅ Corrosion meter axis on `^Corrodible` (green tint 200→20000, DoT+slow+vuln 50→100%, hazmat-half,
@@ -192,6 +192,9 @@ reference an image+sequence, so the yaml wires with placeholders and the art dro
   `INHERIT_FAMILIES`) — `f97a3b77c`
 - ✅ Plasma family = avg(Flame,Chemical) Versus + Temperature 50 + Corrosion 50 (generator `BLEND_FAMILIES`
   + `versus_override`/`physical_states`) — `2e6d6968a`. Inert until a weapon adopts `^Warhead_Plasma_*`.
+- ✅ Flame/Chemical `_Percentage` twins use `AreaDamagePercentage` and feed the matching meter; active
+  fixed `ApplyPhysicalState` duplicates were removed, with `audit_physical_state_warheads` preventing
+  regressions (static-audited; runtime test pending).
 - (Temperature axis + framework were ALREADY built — see §0.)
 
 **TODO — resume queue (in order):**
@@ -207,16 +210,15 @@ reference an image+sequence, so the yaml wires with placeholders and the art dro
 4. **RETROFIT cryo-upgrade weapons** (RA1 Allies etc.): armament-swap to a variant that adds `^Warhead_Cryo_*`
    (dual/triple, §3b) + the FP tax; replace the old manual `ApplyPhysicalState` rings.
 5. **MIGRATE** the Schwarzer Mond binary `corroded` → the Corrosion meter (Chemical/Plasma weapons feed
-   it via the wired templates). Convert generated `_Percentage` twins → `AreaDamagePercentage` so the
-   %-damage also feeds the meters (currently main-only). Verify overheat/corrosion DoT credits `firedBy`
-   for XP (`ChangesHealthProportionalToPhysicalState`).
+   it via the wired templates). Verify overheat/corrosion DoT credits `firedBy` for XP
+   (`ChangesHealthProportionalToPhysicalState`).
 6. **ART** (artist): looped shifting-blue Sonic overlay + armor-breach breach-icon (PngSheet, §4b).
 7. Then the broader roadmap: faction damage-type binding, temporal signatures, spread/falloff per-type
    curves, Railgun charge-delay, resume Phase B mixed-weapon collapse (~350, behavior-preserving).
 
 **Guardrails to keep:** boot-gate every commit (kill lingering OpenRA before a C# rebuild — it locks
 `engine/bin`); `verify_generator_sync` drift stays **1** (pre-existing `^Warhead_Sniper_Light`, not the
-generator's); scoped `git add`; the family PhysicalState goes on the MAIN warhead only (chip excluded).
+generator's); scoped `git add`; family PhysicalState goes on the main and percentage warheads (chip excluded).
 
 ## 6. Decisions (maintainer 2026-08-09) + what's still open
 DECIDED:

--- a/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/weapons.yaml
@@ -18,13 +18,8 @@ HarkonnenFlameTurret:
 		Palette: tseffect
 	Warhead@Flame_Medium:
 		Damage: 25135
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 4
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 8378
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 4189
-
 harkonnen_autogunturret:
 	Inherits: ordos_autogunturret
 	ReloadDelay: 132

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml
@@ -400,7 +400,7 @@ mtank_pri2:
 		Damage: 4
 	Warhead@Flame_Medium:
 		Damage: 8000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 4
 	Warhead@MissileAP_Heavy:
 		ValidTargets: Ground, Water, Air
@@ -1472,6 +1472,8 @@ farasha_drone_ixian:
 		ValidTargets: Ground, Water, Air
 		Damage: 1
 		DamageTypes: Prone75Percent, TriggerProne, ElectricityDeath
+	-Warhead@PhysicalStateLightFlameWeapon:
+	-Warhead@PhysicalStateLightFlameWeaponFriendlyFire:
 
 d2k_basq:
 	Inherits: ^Warhead_CannonHE_Heavy

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1231,7 +1231,7 @@ d2k_chemgun:
 		Color: 88FF00
 	Warhead@Chemical_Light:
 		Damage: 30000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 15
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/weapons.yaml
@@ -184,12 +184,8 @@ HeavyFlamer:
 		Inaccuracy: 900
 	Warhead@Flame_Medium:
 		Damage: 2000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
 	Warhead@Effect: CreateEffect
 		Explosions: napalm
 		GlowScale: 1.5
@@ -215,21 +211,15 @@ HeavyPlasmaFlamer:
 	Warhead@Chemical_Heavy:
 		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 1
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@Flame_Heavy:
 		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 1
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		Amount: 4000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		Amount: 2000
 	Warhead@Effect: CreateEffect
 		Explosions: blue_building_napalm
 
@@ -1884,7 +1874,7 @@ OIFlamer:
 		Inaccuracy: 850
 	Warhead@Flame_Medium:
 		Damage: 2000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 1
 
 OIPlasmaFlamer:
@@ -1906,13 +1896,13 @@ OIPlasmaFlamer:
 	Warhead@Chemical_Heavy:
 		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 1
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@Flame_Heavy:
 		Damage: 2000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 1
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@Effect: CreateEffect
@@ -2039,13 +2029,13 @@ JapanesePlasmaBomb:
 	Warhead@Chemical_Heavy:
 		Damage: 10000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 5
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@Flame_Heavy:
 		Damage: 10000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 5
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
 	Warhead@HeavyBomb: SpreadDamage

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
@@ -73,7 +73,7 @@ OreExplosion:
 	Inherits@fx: ^Effect_Flame_Medium
 	Warhead@Flame_Medium:
 		Damage: 40000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 20
 	Warhead@Resource: CreateResource
 		AddsResourceType: Ore
@@ -168,10 +168,6 @@ ConscriptMolotov:
 		Damage: 8000
 	Warhead@Flame_Light_Percentage:
 		Damage: 4
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 8000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 4000
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 3
 		Duration: 40
@@ -193,10 +189,6 @@ ConscriptMolotovExplode:
 		Damage: 4000
 	Warhead@Flame_Light_Percentage:
 		Damage: 2
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 3
 		Duration: 25
@@ -281,13 +273,8 @@ Flamer:
 		Inaccuracy: 850
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
-
 PortaTesla:
 	Inherits@wh: ^Warhead_Tesla_Heavy
 	Inherits@proj: ^Projectile_Lightning_Heavy
@@ -877,7 +864,7 @@ WaveforceCannonDistortedBeam2:
 		ValidTargets: Ground, Water, Air
 		Damage: 10000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 5
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
@@ -885,7 +872,7 @@ WaveforceCannonDistortedBeam2:
 		ValidTargets: Ground, Water, Air
 		Damage: 10000
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 5
 		DamageTypes: Prone100Percent, TriggerProne, ElectricityDeath, Tesla

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
@@ -8,7 +8,7 @@ IncendiaryM1Carbine:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 1
 	Warhead@Bullet_Light: AreaDamage
@@ -115,6 +115,8 @@ GrenadeThermobaric:
 		Damage: 4000
 	Warhead@Flame_Light_Percentage:
 		Damage: 2
+	-Warhead@PhysicalStateMediumFlameWeapon:
+	-Warhead@PhysicalStateMediumFlameWeaponFriendlyFire:
 
 GrenadeThermobaricExplode:
 	Inherits: GrenadeThermobaric
@@ -392,12 +394,8 @@ FireballLauncher:
 		TrailDelay: 0
 	Warhead@Flame_Medium:
 		Damage: 18000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 9
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 18000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 9000
 	Warhead@Effect: CreateEffect
 		Explosions: napalm
 		GlowScale: 1.5
@@ -457,12 +455,8 @@ FireballGun:
 		TrailDelay: 0
 	Warhead@Flame_Medium:
 		Damage: 8000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 4
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 8000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 4000
 	Warhead@Effect: CreateEffect
 		Explosions: napalm
 		GlowScale: 1.5
@@ -473,13 +467,8 @@ FireballGunExplode:
 	Inherits: FireballGun
 	Warhead@Flame_Medium:
 		Damage: 4000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 2
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
-
 FireballGunThermobaric:
 	Inherits: ^HeavyFlameWeapon
 	Inherits@2: ^MediumFlameWeapon
@@ -1566,7 +1555,7 @@ IncendiaryChainGun:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 1
 	Warhead@Bullet_Medium:
@@ -1958,7 +1947,7 @@ IncendiaryYakChainGun:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 4000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 2
 	Warhead@Bullet_Medium:
@@ -2523,7 +2512,7 @@ ThermobaricNuclearMaverick:
 	Inherits: 105mm
 	Warhead@Flame_Medium:
 		Damage: 6000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 3
 	Warhead@CannonHE_Medium:
 		Damage: 6000
@@ -2722,7 +2711,7 @@ ra120mmThermobaric:
 		Speed: 641
 	Warhead@Flame_Heavy:
 		Damage: 8000
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 4
 	Warhead@Demolition_Heavy:
 		Damage: 8000
@@ -3059,7 +3048,7 @@ ra120mm2Thermobaric:
 		Speed: 666
 	Warhead@Flame_Heavy:
 		Damage: 16000
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 8
 	Warhead@Demolition_Heavy:
 		Damage: 16000
@@ -3216,7 +3205,7 @@ MonsterTank120mmThermobaric:
 	Inherits: MonsterTank120mm
 	Warhead@Flame_Heavy:
 		Damage: 40000
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 20
 
 MonsterTankTusk:
@@ -3661,7 +3650,7 @@ VolkovMagneticWeaponIncendiary:
 	Inherits@2: ^IncendiaryBulletProjectile
 	Warhead@Flame_Medium:
 		Damage: 10000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 5
 
 VolkovMagneticWeaponIncendiaryTesla:
@@ -4004,7 +3993,7 @@ IncendiaryRAGatlingTankCannon:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Damage: 1
 	Warhead@Bullet_Medium:
@@ -4017,7 +4006,7 @@ IncendiaryRAGatlingTankCannon_AA:
 	ValidTargets: Air
 	Warhead@Flame_Light:
 		ValidTargets: Air
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Air
 TeslaRAGatlingTankCannon:
 	Inherits@wh: ^Warhead_Tesla_Heavy
@@ -4150,7 +4139,7 @@ ra1_soviets_rifleinfantry_carbine_incendiary:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Damage: 1
 	Warhead@Bullet_Light: AreaDamage

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
@@ -477,7 +477,7 @@ RA2Comet:
 		DamageTypes: Prone75Percent, TriggerProne, ElectricityDeath
 	Warhead@Flame_Medium:
 		Damage: 20000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 10
 	Warhead@Laser_Heavy:
 		Damage: 20000

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
@@ -1326,7 +1326,7 @@ RA2RadBeamWeapon:
 	Warhead@Chemical_Medium:
 		Damage: 30000
 		DamageTypes: Prone100Percent, TriggerProne, RadiationDeath
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 15
 	-Warhead@Effect:
 
@@ -1516,7 +1516,7 @@ MigMissiles_rad:
 		ContrailEndColor: FFFFFF
 	Warhead@Chemical_Medium:
 		Damage: 4000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 2
 	Warhead@Radiation: CreateTintedCells
 		Falloff: 100, 75, 66, 50, 33, 25, 20, 10

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
@@ -68,7 +68,7 @@ RA2KirovBomb_rad:
 	Warhead@Chemical_Heavy:
 		Damage: 48000
 		DamageTypes: Prone75Percent, TriggerProne, RadiationDeath
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 24
 		DamageTypes: Prone75Percent, TriggerProne, RadiationDeath
 	Warhead@Demolition_Heavy:
@@ -210,7 +210,7 @@ RA2120mm_rad:
 	Inherits@rad: ^RA2RadShell
 	Warhead@Chemical_Medium:
 		Damage: 6000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 3
 	Warhead@CannonHE_Medium:
 		Damage: 6000
@@ -296,7 +296,7 @@ RA160mm_rad:
 		TrailPalette: effect
 	Warhead@Chemical_Light:
 		Damage: 36000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 18
 	Warhead@Concussion_Medium:
 		Damage: 36000

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
@@ -854,7 +854,7 @@ RA2Chemspray:
 	Warhead@Chemical_Medium:
 		Damage: 4000
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 2
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	-Warhead@Effect:
@@ -877,7 +877,7 @@ RA2Chemspray2:
 	Warhead@Chemical_Heavy:
 		Damage: 4000
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 2
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@Condition: GrantExternalCondition

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
@@ -163,12 +163,8 @@ AsianTankKillerRocketShrapnel:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
-		ValidTargets: Ground, Water, Air
-		Damage: 1
-	Warhead@Flame_Light:
-		Damage: 2000
 	Warhead@Flame_Light_Percentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 1
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 2

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
@@ -168,12 +168,8 @@ AsianTankKillerRocketShrapnel:
 		Damage: 1
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 2
 		Duration: 12
@@ -1407,13 +1403,8 @@ AsianFlamerTroopExplode:
 	Inherits: AsianFlamerTurret
 	Warhead@Flame_Light:
 		Damage: 12000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 6
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 12000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 6000
-
 AsianChaosTurret:
 	Range: 5000
 	ReloadDelay: 125
@@ -1673,7 +1664,7 @@ AsianChaosMine:
 		Falloff: 125, 100, 75, 50, 25
 		Damage: 125000
 		InvalidTargets: Mine
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Spread: 2500
 		Falloff: 125, 100, 75, 50, 25
 		InvalidTargets: Mine
@@ -1903,7 +1894,7 @@ AsianPhoenixRocket:
 	Warhead@Flame_Medium:
 		ValidTargets: Ground, Water, Air
 		Damage: 20000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 10
 	Warhead@Demolition_Light:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
@@ -423,13 +423,8 @@ NaxiFlamerTroopExplode:
 	Inherits: AsianFlamerTurret
 	Warhead@Flame_Light:
 		Damage: 6000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 3
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 6000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 3000
-
 NaxiSniper:
 	Inherits@wh: ^Warhead_Sniper_Light
 	Inherits@proj: ^Projectile_Sniper_Light

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
@@ -725,7 +725,7 @@ NaxDieGlocke:
 	Warhead@Chemical_Heavy:
 		Damage: 10000
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 5
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@Effect: CreateEffect

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml
@@ -330,19 +330,6 @@ SyndicateFireballLauncherExplode:
 		Damage: 2000
 	Warhead@HeavyFlameWeaponPercentage: HealthPercentageDamage
 		Damage: 2
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
-
 LatinMonkeyGrenade1:
 	Inherits@wh: ^Warhead_Demolition_Light
 	Inherits@wh2: ^Warhead_Concussion_Medium

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
@@ -274,12 +274,8 @@ ThermoF:
 		Palette: tseffect
 	Warhead@Flame_Medium:
 		Damage: 2000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
 tkmm203:
 	Inherits: ^Warhead_Demolition_Light
 	Inherits@2: ^Warhead_Flame_Light
@@ -727,10 +723,6 @@ sandmarinemortar:
 		Damage: 120000
 	Warhead@Flame_Medium_Percentage:
 		Damage: 60
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 120000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 60000
 	Warhead@Effect: CreateEffect
 		Explosions: ra2_large_explosion
 		ImpactSounds: gexpbara.wav, gexpbarb.wav, gexpbarc.wav
@@ -762,10 +754,6 @@ bigshieemortar:
 		Damage: 80000
 	Warhead@Flame_Medium_Percentage:
 		Damage: 40
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 80000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 40000
 	Warhead@Effect: CreateEffect
 		Explosions: ra2_large_explosion
 		ImpactSounds: gexpbara.wav, gexpbarb.wav, gexpbarc.wav

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml
@@ -109,13 +109,8 @@ FirebatF:
 		Palette: tseffect
 	Warhead@Flame_Medium:
 		Damage: 2000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
-
 HarakanF:
 	Inherits: ^HeavyFlameWeapon
 	Inherits@2: ^MediumFlameWeapon
@@ -178,31 +173,6 @@ MatadorFlamer:
 		Damage: 2000
 	Warhead@Flame_Heavy_Percentage:
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-
 MatadorLaser:
 	Inherits@wh: ^Warhead_Laser_Heavy
 	Inherits@proj: ^Projectile_Laser_Heavy

--- a/mods/cameo/ContentPacks/StarCraft/Zerg/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Zerg/yaml/weapons.yaml
@@ -289,7 +289,7 @@ CorruptorSpore:
 	Warhead@Chemical_Medium:
 		ValidTargets: Ground, Water, Air
 		Damage: 10000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 5
 	Warhead@Condition: GrantExternalCondition
@@ -1251,7 +1251,7 @@ DefilerPlague:
 		Speed: 900
 	Warhead@Chemical_Heavy:
 		Damage: 30000
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 15
 	#Warhead@2: GrantExternalCondition
 	#	Range: 3c512

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
@@ -383,12 +383,8 @@ StealthTankMissilesShrapnel:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
-		ValidTargets: Ground, Water, Air
-		Damage: 1
-	Warhead@Flame_Light:
-		Damage: 2000
 	Warhead@Flame_Light_Percentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 1
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 2

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
@@ -25,13 +25,8 @@ FlamethrowerExplode:
 	Inherits: Flamethrower
 	Warhead@Flame_Light:
 		Damage: 10000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 5
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 10000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 5000
-
 NodTurretLaser:
 	Inherits: ^SmallArms
 	Inherits@2: ^Chaingun
@@ -90,7 +85,7 @@ SmallTiberiumExplosion:
 	Inherits: Chemspray
 	Warhead@Chemical_Light:
 		Damage: 24000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 12
 	Warhead@Resource: CreateResource
 		AddsResourceType: Tiberium
@@ -102,7 +97,7 @@ BigTiberiumExplosion:
 	Inherits@fx: ^Effect_Chem_Heavy
 	Warhead@Chemical_Heavy:
 		Damage: 50000
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 25
 	Warhead@Resource: CreateResource
 		AddsResourceType: Tiberium
@@ -196,7 +191,7 @@ FireballLauncherBuggy:
 		Palette: tseffect
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
 
 BikeRockets:
@@ -393,12 +388,8 @@ StealthTankMissilesShrapnel:
 		Damage: 1
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1, 2
 		Duration: 12
@@ -1001,12 +992,8 @@ BigFlamer2:
 	Report: flamer2.aud
 	Warhead@Flame_Heavy:
 		Damage: 20000
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 10
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		Amount: 20000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 10000
 	Warhead@Glow: GlowImpact
 		Color: FF6600
 		Scale: 2.0
@@ -1019,12 +1006,8 @@ FlametankExplode2:
 	Inherits@fx: ^Effect_Flame_Heavy
 	Warhead@Flame_Heavy:
 		Damage: 40000
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		Damage: 20
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		Amount: 40000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 20000
 	Warhead@Effect: CreateEffect
 		Explosions: big_napalm
 		GlowScale: 2.0
@@ -1087,26 +1070,16 @@ BlackHandFlamer:
 		Palette: tseffect
 	Warhead@Flame_Medium:
 		Damage: 4000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 2
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
-
 BlackHandFlamerExplode:
 	Inherits@wh: ^Warhead_Flame_Medium
 	Inherits@proj: ^Projectile_Flame_Medium
 	Inherits@fx: ^Effect_Flame_Medium
 	Warhead@Flame_Medium:
 		Damage: 12000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 6
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 12000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 6000
-
 BHRedDarts:
 	Inherits: ^TeslaChargedWeapon
 	Inherits@2: ^TankDestroyerCannon

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
@@ -1579,7 +1579,7 @@ CabalRavagerPlasma:
 		Image: cabal_greenplasma
 	Warhead@Chemical_Medium:
 		Damage: 32000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 16
 	Warhead@Effect: CreateEffect
 		Explosions: cabal_greenplasmaimpact
@@ -1598,7 +1598,7 @@ CabalWidowPlasma:
 		Image: cabal_greenplasma
 	Warhead@Chemical_Medium:
 		Damage: 32000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 16
 	Warhead@Effect: CreateEffect
 		Explosions: cabal_greenplasmaimpact
@@ -2296,7 +2296,7 @@ CabalRavagerPlasmaNeutron:
 		Image: cabal_plasmabullet
 	Warhead@Chemical_Medium:
 		Damage: 32000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 16
 	Warhead@Effect: CreateEffect
 		Explosions: magicnuke_small

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
@@ -479,7 +479,7 @@ TSInfantryMortarChem:
 	ReloadDelay: 88
 	Warhead@Chemical_Medium:
 		Damage: 16000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 8
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 1
@@ -510,7 +510,7 @@ TS120mmxChem:
 		Damage: 20
 	Warhead@Chemical_Heavy:
 		Damage: 40000
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 20
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 5
@@ -1306,13 +1306,8 @@ MutFlamer:
 	Report: flamtnk1.aud
 	Warhead@Flame_Medium:
 		Damage: 28000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 14
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 28000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 14000
-
 MutFlamerChem:
 	Inherits: ^MediumFlameWeapon
 	Inherits@2: ^MediumChemicalWeapon
@@ -1441,7 +1436,7 @@ TSFiendShard:
 		TrailImage: green_smokey
 	Warhead@Chemical_Light:
 		Damage: 6000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 3
 	Warhead@3Eff: CreateEffect
 		Explosions: sczhsplash
@@ -1632,7 +1627,7 @@ TSChemspray:
 	Range: 3183
 	Warhead@Chemical_Light:
 		Damage: 32000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 16
 TSChemsprayUP:
 	Inherits: ^LightChemicalWeapon
@@ -1677,7 +1672,7 @@ TSVisceroidSpray:
 	Range: 1618
 	Warhead@Chemical_Light:
 		Damage: 10000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 5
 TSVisceroidSprayUP:
 	Inherits: ^LightChemicalWeapon
@@ -1763,7 +1758,7 @@ TSCropBombChem:
 		Damage: 60
 	Warhead@Chemical_Heavy:
 		Damage: 60000
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 30
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 10
@@ -1809,7 +1804,7 @@ TSLocustBombChem:
 		Damage: 90
 	Warhead@Chemical_Heavy:
 		Damage: 90000
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		Damage: 45
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 15
@@ -2025,7 +2020,7 @@ TSGhostGun:
 		Inaccuracy: 0
 	Warhead@Chemical_Light:
 		Damage: 20000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 10
 
 TSChemGhostGun:
@@ -2050,7 +2045,7 @@ TSChemGhostGun:
 		Inaccuracy: 0
 	Warhead@Chemical_Light:
 		Damage: 20000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 10
 MutAPRifle:
 	Inherits@wh: ^Warhead_Bullet_Light

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml
@@ -238,13 +238,8 @@ TSFireballLauncher:
 		LaunchAngle: 0
 	Warhead@Flame_Medium:
 		Damage: 8000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 4
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 8000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 4000
-
 TSLasergun:
 	Inherits@wh: ^Warhead_Bullet_Light
 	Inherits@wh2: ^Warhead_Laser_Heavy
@@ -584,6 +579,6 @@ TSToxinRifle:
 		Inaccuracy: 0
 	Warhead@Chemical_Light:
 		Damage: 16000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 8
 	-Warhead@Effect:

--- a/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/weapons.yaml
@@ -205,7 +205,7 @@ wc2deathknightFire:
 		ValidTargets: Ground, Water, Air
 		Damage: 8000
 		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 4
 		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary

--- a/mods/cameo/weapons/d2k.yaml
+++ b/mods/cameo/weapons/d2k.yaml
@@ -75,7 +75,7 @@ Debris2:
 		Damage: 8
 	Warhead@Flame_Light:
 		Damage: 16000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 8
 	Warhead@Effect: CreateEffect
 		Explosions: d2k_small_napalm
@@ -94,7 +94,7 @@ Debris3:
 		Damage: 4
 	Warhead@Flame_Light:
 		Damage: 8000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 4
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1350
@@ -1894,7 +1894,7 @@ PhoenixRocketShrapnel:
 	Warhead@Flame_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
 		Damage: 1
 

--- a/mods/cameo/weapons/redalert2mod.yaml
+++ b/mods/cameo/weapons/redalert2mod.yaml
@@ -29,12 +29,8 @@ AsianFlameFragment:
 	Range: 2000
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 1000
 	Warhead@FireShrapnel: FireShrapnel
 		Weapon: AsianFlameFragment2
 		Amount: 1
@@ -69,7 +65,7 @@ AsianOilBombFragments:
 	Warhead@Flame_Light:
 		Damage: 4000
 		Falloff: 100, 50, 25, 12, 6, 3, 1
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 2
 		Falloff: 100, 50, 25, 12, 6, 3, 1
 	Warhead@Effect: CreateEffect
@@ -97,12 +93,8 @@ AsianFlamerTurret:
 		Palette: tseffect
 	Warhead@Flame_Light:
 		Damage: 4000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 2
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 4000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 2000
 	Warhead@Effect: CreateEffect
 		Explosions: ra2_initfire
 		ExplosionPalette: ra2effect
@@ -1095,7 +1087,7 @@ MeteorFlameFragment:
 	Range: 2000
 	Warhead@Flame_Light:
 		Damage: 2000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 1
 	Warhead@Aliens: SpawnActorOrWeapon
 		Actors: alien.nax
@@ -1245,31 +1237,6 @@ SyndicateFireballLauncher:
 		Damage: 2000
 	Warhead@Flame_Heavy_Percentage:
 		Damage: 1
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 2000
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 1000
-
 RA2RTruckRocket:
 	Inherits: ^RA2Grenade
 	Inherits@2: ^LightFlameWeapon

--- a/mods/cameo/weapons/starcraft.yaml
+++ b/mods/cameo/weapons/starcraft.yaml
@@ -7,13 +7,8 @@ Flamethrower:
 	Report: flamer2.aud
 	Warhead@Flame_Light:
 		Damage: 20000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 10
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 20000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 10000
-
 WraithDroneLaser:
 	Inherits@wh: ^Warhead_Laser_Heavy
 	Inherits@proj: ^Projectile_Laser_Heavy
@@ -127,7 +122,7 @@ SCSPIDEREXPLOSION:
 		Damage: 80000
 		Spread: 2048
 		Falloff: 100, 25, 0
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 40
 		Spread: 2048
 		Falloff: 100, 25, 0

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -105,7 +105,7 @@ Chemspray:
 	Report: flamer2.aud
 	Warhead@Chemical_Light:
 		Damage: 48000
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 24
 
 TiberiumExplosion:
@@ -114,7 +114,7 @@ TiberiumExplosion:
 	Inherits@fx: ^Effect_Chem_Medium
 	Warhead@Chemical_Medium:
 		Damage: 40000
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		Damage: 20
 	Warhead@Resource: CreateResource
 		AddsResourceType: Tiberium
@@ -174,12 +174,8 @@ BigFlamer:
 	Report: flamer2.aud
 	Warhead@Flame_Medium:
 		Damage: 14000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 7
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 14000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 7000
 	Warhead@Glow: GlowImpact
 		Color: FF6600
 		Scale: 1.5
@@ -192,12 +188,8 @@ FlametankExplode:
 	Inherits@fx: ^Effect_Flame_Medium
 	Warhead@Flame_Medium:
 		Damage: 28000
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Damage: 14
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		Amount: 28000
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 14000
 	Warhead@Effect: CreateEffect
 		Explosions: big_napalm
 		GlowScale: 2.0

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -89,12 +89,8 @@ Flamethrower:
 	Report: flamer2.aud
 	Warhead@Flame_Light:
 		Damage: 20000
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		Damage: 10
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		Amount: 20000
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		Amount: 10000
 
 Chemspray:
 	Inherits@wh: ^Warhead_Chemical_Light
@@ -313,5 +309,4 @@ ChemTibAtomic:
 		AddsResourceType: Tiberium
 		Size: 10,10
 		Delay: 100
-
 

--- a/mods/cameo/weapons/tiberiansun.yaml
+++ b/mods/cameo/weapons/tiberiansun.yaml
@@ -911,7 +911,7 @@ TSSAPCCoreMissiles:
 	Warhead@Chemical_Light:
 		Damage: 8000
 		ValidTargets: Ground, Water, Air
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		Damage: 4
 		ValidTargets: Ground, Water, Air
 

--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -4958,7 +4958,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Temperature
 		PhysicalStateScale: 100
-	Warhead@Flame_Light_Percentage: HealthPercentageDamage
+	Warhead@Flame_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 200
 		Damage: 1
@@ -4982,6 +4982,8 @@ DefuseKit:
 			Helicopter: 2
 			Spaceship: 1
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Temperature
+		PhysicalStateScale: 100
 
 ^Warhead_Flame_Medium:
 	ValidTargets: Ground, Water
@@ -5018,7 +5020,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Temperature
 		PhysicalStateScale: 100
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 300
 		Damage: 1
@@ -5042,6 +5044,8 @@ DefuseKit:
 			Helicopter: 6
 			Spaceship: 5
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Temperature
+		PhysicalStateScale: 100
 
 ^Warhead_Flame_Heavy:
 	ValidTargets: Ground, Water
@@ -5078,7 +5082,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Temperature
 		PhysicalStateScale: 100
-	Warhead@Flame_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Flame_Heavy_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 400
 		Damage: 1
@@ -5102,6 +5106,8 @@ DefuseKit:
 			Helicopter: 11
 			Spaceship: 10
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Temperature
+		PhysicalStateScale: 100
 
 ###### Chemical: INF+VEH > BLD > AIR (heavy, air=False) ######
 ^Warhead_Chemical_Light:
@@ -5139,7 +5145,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
-	Warhead@Chemical_Light_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Light_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 200
 		Damage: 1
@@ -5163,6 +5169,8 @@ DefuseKit:
 			Bomber: 2
 			Fighter: 1
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Corrosion
+		PhysicalStateScale: 100
 
 ^Warhead_Chemical_Medium:
 	ValidTargets: Ground, Water
@@ -5199,7 +5207,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
-	Warhead@Chemical_Medium_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Medium_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 300
 		Damage: 1
@@ -5223,6 +5231,8 @@ DefuseKit:
 			Bomber: 6
 			Fighter: 5
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Corrosion
+		PhysicalStateScale: 100
 
 ^Warhead_Chemical_Heavy:
 	ValidTargets: Ground, Water
@@ -5259,7 +5269,7 @@ DefuseKit:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
-	Warhead@Chemical_Heavy_Percentage: HealthPercentageDamage
+	Warhead@Chemical_Heavy_Percentage: AreaDamagePercentage
 		ValidTargets: Ground, Water
 		Spread: 400
 		Damage: 1
@@ -5283,6 +5293,8 @@ DefuseKit:
 			Bomber: 11
 			Fighter: 10
 		UpdatesUnitStatistics: false
+		PhysicalStateName: Corrosion
+		PhysicalStateScale: 100
 
 ###### Plasma: blend of Flame+Chemical + PhysicalStates {'Temperature': 50, 'Corrosion': 50} ######
 ^Warhead_Plasma_Light:
@@ -8032,16 +8044,6 @@ DefuseKit:
 	Warhead@ShieldHitEffect: CreateEffect
 		ImpactSounds: shielded_bullet_hit1.wav, shielded_bullet_hit2.wav, shielded_bullet_hit3.wav, shielded_bullet_hit4.wav
 		ValidTargets: Shielded
-	Warhead@PhysicalStateLightFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 800
-		Range: 800
-	Warhead@PhysicalStateLightFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 400
-		Range: 400
 	Warhead@GroundFire: SpawnActor
 		Actors: groundfire
 		Range: 1
@@ -8071,16 +8073,6 @@ DefuseKit:
 	Warhead@ShieldHitEffect: CreateEffect
 		ImpactSounds: shielded_bullet_hit1.wav, shielded_bullet_hit2.wav, shielded_bullet_hit3.wav, shielded_bullet_hit4.wav
 		ValidTargets: Shielded
-	Warhead@PhysicalStateMediumFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 1200
-		Range: 1200
-	Warhead@PhysicalStateMediumFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 600
-		Range: 600
 	Warhead@GroundFire: SpawnActor
 		Actors: groundfire
 		Range: 1
@@ -8110,16 +8102,6 @@ DefuseKit:
 	Warhead@ShieldHitEffect: CreateEffect
 		ImpactSounds: shielded_bullet_hit1.wav, shielded_bullet_hit2.wav, shielded_bullet_hit3.wav, shielded_bullet_hit4.wav
 		ValidTargets: Shielded
-	Warhead@PhysicalStateHeavyFlameWeapon: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Neutral, Enemy
-		Amount: 1600
-		Range: 1600
-	Warhead@PhysicalStateHeavyFlameWeaponFriendlyFire: ApplyPhysicalState
-		PhysicalStateName: Temperature
-		ValidRelationships: Ally
-		Amount: 800
-		Range: 800
 	Warhead@GroundFire: SpawnActor
 		Actors: groundfire
 		Range: 1
@@ -9669,7 +9651,7 @@ CHFlame:
 		Falloff: 100, 75, 50, 25
 		Damage: 2000
 		DamageTypes: Prone75Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@Flame_Medium_Percentage: HealthPercentageDamage
+	Warhead@Flame_Medium_Percentage: AreaDamagePercentage
 		Spread: 250
 		Falloff: 100, 75, 50, 25
 		Damage: 1

--- a/tools/audit/audit_physical_state_warheads.py
+++ b/tools/audit/audit_physical_state_warheads.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Reject physical-state warhead combinations that double-apply a meter.
+
+The Formula V2 Flame and Chemical families apply Temperature/Corrosion in
+proportion to actual damage. Their percentage-damage twins must use
+AreaDamagePercentage so that damage also reaches the meter. A resolved weapon
+must not combine either damage-scaled implementation with a legacy fixed
+ApplyPhysicalState warhead for the same meter.
+"""
+
+from __future__ import annotations
+
+import sys
+import re
+
+from miniyaml import Ruleset, find_repo_root
+
+
+EXPECTED_PERCENTAGE_STATES = {
+	"Flame": ("Temperature", "100"),
+	"Chemical": ("Corrosion", "100"),
+}
+LEVELS = ("Light", "Medium", "Heavy")
+PERCENTAGE_KEY = re.compile(r"Warhead@(Flame|Chemical)_(Light|Medium|Heavy)_Percentage$")
+
+
+def scaled_states(warhead):
+	states = set()
+	state = warhead.get("PhysicalStateName")
+	if state:
+		states.add(state)
+
+	multiple = warhead.child("PhysicalStates")
+	if multiple:
+		states.update(child.key for child in multiple.children)
+
+	return states
+
+
+def main() -> int:
+	rs = Ruleset(find_repo_root())
+	problems = []
+
+	for family, (expected_state, expected_scale) in EXPECTED_PERCENTAGE_STATES.items():
+		for level in LEVELS:
+			tag = f"{family}_{level}"
+			template_name = f"^Warhead_{tag}"
+			template = rs.weapon(template_name)
+			percentage = template.child(f"Warhead@{tag}_Percentage") if template else None
+			if percentage is None:
+				problems.append(f"{template_name}: missing percentage warhead")
+				continue
+
+			if percentage.value != "AreaDamagePercentage":
+				problems.append(
+					f"{template_name}: percentage warhead is {percentage.value}, expected AreaDamagePercentage")
+			if percentage.get("PhysicalStateName") != expected_state:
+				problems.append(
+					f"{template_name}: percentage warhead does not apply {expected_state}")
+			if percentage.get("PhysicalStateScale") != expected_scale:
+				problems.append(
+					f"{template_name}: percentage warhead scale is not {expected_scale}")
+
+	for weapon_name in sorted(rs.weapons, key=str.lower):
+		if weapon_name.startswith("^"):
+			continue
+
+		weapon = rs.resolve_weapon(weapon_name)
+		if weapon is None:
+			continue
+
+		damage_scaled = set()
+		fixed = set()
+		for warhead in weapon.children:
+			match = PERCENTAGE_KEY.fullmatch(warhead.key)
+			if match:
+				family = match.group(1)
+				expected_state, expected_scale = EXPECTED_PERCENTAGE_STATES[family]
+				if (warhead.value != "AreaDamagePercentage"
+						or warhead.get("PhysicalStateName") != expected_state
+						or warhead.get("PhysicalStateScale") != expected_scale):
+					problems.append(
+						f"{weapon_name}: {warhead.key} does not feed {expected_state} through AreaDamagePercentage")
+
+			if warhead.value in {"AreaDamage", "AreaDamagePercentage"}:
+				damage_scaled.update(scaled_states(warhead))
+			elif warhead.value == "ApplyPhysicalState":
+				state = warhead.get("PhysicalStateName")
+				if state:
+					fixed.add(state)
+
+		for state in sorted(damage_scaled & fixed):
+			problems.append(
+				f"{weapon_name}: combines damage-scaled and fixed ApplyPhysicalState for {state}")
+
+	print("# Physical-state warhead audit\n")
+	print(f"Active concrete weapons checked: {sum(not name.startswith('^') for name in rs.weapons)}")
+	print(f"Formula percentage templates checked: {len(EXPECTED_PERCENTAGE_STATES) * len(LEVELS)}\n")
+	if problems:
+		print(f"## FAIL ({len(problems)} problem(s))\n")
+		for problem in problems:
+			print(f"- {problem}")
+		return 1
+
+	print("## PASS\n")
+	print("- Flame and Chemical percentage damage feeds the matching physical-state meter.")
+	print("- No active weapon double-applies a meter through scaled and fixed warheads.")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tools/audit/run_all.py
+++ b/tools/audit/run_all.py
@@ -35,7 +35,7 @@ AUDITS = [
     "effect_warhead_names", "weapon_suffixes", "balance_sheet",
     "consistency_report", "packs", "balance_drift", "template_conformance",
     "multiplier_modifiers", "nuclear_flash_bindings", "ts_death_palette",
-    "warhead_split",
+    "warhead_split", "physical_state_warheads",
 ]
 # NOTE: "elite_naming" is intentionally excluded — audit_elite_naming.py is
 # deprecated, fully superseded by audit_weapon_suffixes.py X1 section

--- a/tools/audit/run_all.sh
+++ b/tools/audit/run_all.sh
@@ -35,7 +35,7 @@ for a in inherits faction_leaks upgrades upgrade_coverage ai sequences \
          dune_rank_decoration effect_warhead_names weapon_suffixes \
          balance_sheet consistency_report packs balance_drift \
          template_conformance multiplier_modifiers nuclear_flash_bindings \
-         ts_death_palette warhead_split; do
+         ts_death_palette warhead_split physical_state_warheads; do
   echo "== audit_$a"
   "$PYTHON" "tools/audit/audit_$a.py" "$@" > "$OUT/$a.md" 2> "$OUT/$a.err" \
     || failed=1

--- a/tools/balance/gen_weapon_template.py
+++ b/tools/balance/gen_weapon_template.py
@@ -250,7 +250,9 @@ def family(name, order16, vt, levels, *, mode=None, damage=2000,
         if physical_states:  # multi-state blend (e.g. Plasma: Temperature 50 + Corrosion 50)
             main_wh.append("\t\tPhysicalStates:")
             main_wh += [f"\t\t\t{k}: {v}" for k, v in physical_states.items()]
-        pct_wh = [f"\tWarhead@{tag}_Percentage: HealthPercentageDamage",
+        percentage_state = FAMILY_PHYSICAL_STATE.get(name) if name in {"Flame", "Chemical"} else None
+        percentage_type = "AreaDamagePercentage" if percentage_state else "HealthPercentageDamage"
+        pct_wh = [f"\tWarhead@{tag}_Percentage: {percentage_type}",
              f"\t\tValidTargets: {vt}",
              f"\t\tSpread: {main_spread // 2}",
              f"\t\tDamage: {pct_damage}",
@@ -258,6 +260,9 @@ def family(name, order16, vt, levels, *, mode=None, damage=2000,
              f"\t\tVersus:",
              emit_versus(pct),
              f"\t\tUpdatesUnitStatistics: false"]
+        if percentage_state:
+            psn, pss = percentage_state
+            pct_wh += [f"\t\tPhysicalStateName: {psn}", f"\t\tPhysicalStateScale: {pss}"]
         parts = main_wh + pct_wh
         if name in CHIPS:  # paid-for ExtraDamage chip (energy families only)
             parts.append(emit_chip(tag, name, damage, vt))
@@ -291,10 +296,10 @@ FAMILY_SPREADS = {
     "MissileAA": (200, 300, 400),
 }
 
-# Per-family PhysicalState wiring (docs/design/PHYSICAL_STATE_SYSTEM.md): the MAIN AreaDamage warhead
+# Per-family PhysicalState wiring (docs/design/PHYSICAL_STATE_SYSTEM.md): the main AreaDamage warhead
 # adds `damage x Scale%` to a named meter on hit (Temperature = heat/cold, Corrosion = acid).
-# Emitted on the main warhead ONLY (the _ExtraDamage chip is auto-excluded; the HealthPercentageDamage
-# %-twin cannot carry the field until it is converted to AreaDamagePercentage — a later refinement).
+# Flame and Chemical also emit meter-aware AreaDamagePercentage twins so their percentage damage
+# contributes to the same meter. The _ExtraDamage chip remains excluded.
 # Cryo is a separate thin child of Prism (Temperature -100), not listed here.
 FAMILY_PHYSICAL_STATE = {
     "Flame":    ("Temperature", 100),   # heat -> overheat/pop


### PR DESCRIPTION
## Summary
- convert generated Flame and Chemical percentage twins to `AreaDamagePercentage` so percentage damage feeds Temperature/Corrosion
- remove legacy fixed `ApplyPhysicalState` heat from active weapons that already use damage-scaled physical states, while preserving fixed-only legacy weapons
- add a resolver-based regression audit to both audit runners and update the physical-state tracker

## Validation
- `python tools/audit/audit_physical_state_warheads.py` (PASS: 2,308 active weapons, 6 formula templates)
- resolved audit: 127 Flame + 42 Chemical percentage nodes, 0 invalid
- resolved audit: 0 weapons combine damage-scaled and fixed application for the same state
- targeted Flame/Chemical generator sync: 6 blocks, drift 0
- `python tools/audit/audit_consistency_report.py` (73 passed, 0 failed)
- `python tools/audit/audit_template_conformance.py` (0 blocking findings)
- `python tools/audit/audit_inherits.py` (0 dangling inherit targets)
- `git diff --check`

## Notes
- Full `verify_generator_sync.py` still reports the documented pre-existing `^Warhead_Sniper_Light` drift only.
- Static validation only; no game launch was performed.