### PR TITLE
Improve hard bot economy and strategy

### DIFF
--- a/OpenRA.Mods.CA/Traits/BotModules/BaseBuilderBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/BaseBuilderBotModuleCA.cs
@@ -15,6 +15,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.AS.Traits;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -142,6 +143,12 @@ namespace OpenRA.Mods.CA.Traits
 		[Desc("Try to build another production building if there is too much cash.")]
 		public readonly int NewProductionCashThreshold = 10000;
 
+		[Desc("Bot types allowed to use NewProductionCashThreshold. Empty enables it for all bots.")]
+		public readonly FrozenSet<string> NewProductionBotTypes = FrozenSet<string>.Empty;
+
+		[Desc("Cash retained when NewProductionBotTypes add excess production capacity.")]
+		public readonly int ExcessProductionRecoveryReserve = 0;
+
 		[Desc("Only queue construction of a new building when above this requirement.")]
 		public readonly int BuildingProductionMinCashRequirement = 1750;
 
@@ -215,7 +222,7 @@ namespace OpenRA.Mods.CA.Traits
 	{
 		public CPos GetRandomBaseCenter()
 		{
-			var randomConstructionYard = ConstructionYardBuildings.Actors.Where(a => !a.IsDead)
+			var randomConstructionYard = ConstructionYardBuildings.Actors.Where(a => !a.IsDead && !IsExclusiveConstructionQueue(a))
 				.RandomOrDefault(world.LocalRandom);
 
 			return randomConstructionYard?.Location ?? initialBaseCenter;
@@ -254,7 +261,8 @@ namespace OpenRA.Mods.CA.Traits
 			if (conyardType != null)
 			{
 				var matchingConstructionYard = ConstructionYardBuildings.Actors
-					.Where(a => !a.IsDead && a.Info.Name == conyardType)
+					.Where(a => !a.IsDead && a.Info.Name == conyardType && !GetRequestedRefinery(a).HasValue &&
+						!IsExclusiveConstructionQueue(a))
 					.RandomOrDefault(world.LocalRandom);
 
 				if (matchingConstructionYard != null)
@@ -267,7 +275,7 @@ namespace OpenRA.Mods.CA.Traits
 		public CPos GetDefenseBaseCenter()
 		{
 			var defenceConstructionYard = DefenseCenter != null ? ConstructionYardBuildings.Actors.OrderBy(a => (DefenseCenter.Value - a.Location).LengthSquared)
-				.FirstOrDefault(a => !a.IsDead) : null;
+				.FirstOrDefault(a => !a.IsDead && !IsExclusiveConstructionQueue(a)) : null;
 
 			return defenceConstructionYard?.Location ?? GetRandomBaseCenter();
 		}
@@ -277,6 +285,8 @@ namespace OpenRA.Mods.CA.Traits
 		/// <Summary> Actor, ActorCount </Summary>
 		public Dictionary<string, int> BuildingsBeingProduced = [];
 		public IBotBaseExpansion[] BaseExpansionModules;
+		IBotExclusiveConstructionQueue[] exclusiveConstructionQueues;
+		IBotCashReservation cashReservation;
 		public ResourceMapBotModule ResourceMapModule;
 		public Actor RelocationHoldConyard { get; set; }
 
@@ -289,6 +299,105 @@ namespace OpenRA.Mods.CA.Traits
 		CPos initialBaseCenter;
 		public CPos? ResourceConyardCenter;
 		public Dictionary<Actor, (CPos ConyardLoc, CPos ResourceLoc)> RequestedRefineries = [];
+		readonly Dictionary<Actor, int> requestedRefineryPlacementTicks = [];
+		readonly Dictionary<Actor, uint> requestedRefineryStartActorIds = [];
+		readonly Dictionary<Actor, Actor> requestedPlacedRefineries = [];
+
+		public (Actor Requester, CPos ConyardLoc, CPos ResourceLoc)? GetRequestedRefinery(Actor producer)
+		{
+			Actor matchedRequester = null;
+			(CPos ConyardLoc, CPos ResourceLoc) matchedRequest = default;
+			foreach (var request in RequestedRefineries)
+			{
+				var replacement = request.Key;
+				while (replacement != null && replacement != producer)
+					replacement = replacement.ReplacedByActor;
+
+				if (replacement == producer)
+				{
+					matchedRequester = request.Key;
+					matchedRequest = request.Value;
+					break;
+				}
+			}
+
+			if (matchedRequester != null)
+			{
+				// Migrate the request from the mobile actor to its deployed replacement so the
+				// producer association remains durable across save/load.
+				if (matchedRequester != producer)
+				{
+					var hadPendingPlacement = requestedRefineryPlacementTicks.Remove(matchedRequester, out var pendingTick);
+					RequestedRefineries.Remove(matchedRequester);
+					RequestedRefineries[producer] = matchedRequest;
+					if (hadPendingPlacement)
+						requestedRefineryPlacementTicks[producer] = pendingTick;
+					if (requestedRefineryStartActorIds.Remove(matchedRequester, out var startActorId))
+						requestedRefineryStartActorIds[producer] = startActorId;
+					if (requestedPlacedRefineries.Remove(matchedRequester, out var placedRefinery))
+						requestedPlacedRefineries[producer] = placedRefinery;
+					matchedRequester = producer;
+				}
+
+				return (matchedRequester, matchedRequest.ConyardLoc, matchedRequest.ResourceLoc);
+			}
+
+			return null;
+		}
+
+		public bool IsExclusiveConstructionQueue(Actor producer) =>
+			exclusiveConstructionQueues != null && exclusiveConstructionQueues.Any(q => q.IsExclusiveConstructionQueue(producer));
+
+		public bool TryReserveExcessProductionCash(int cost) => cashReservation == null ||
+			cashReservation.TryReserveCash(cost, Info.ExcessProductionRecoveryReserve);
+
+		public bool IsRequestedRefineryPlacementPending(Actor producer)
+		{
+			var request = GetRequestedRefinery(producer);
+			if (!request.HasValue || !requestedRefineryPlacementTicks.TryGetValue(request.Value.Requester, out var tick))
+				return false;
+
+			if (requestedPlacedRefineries.ContainsKey(request.Value.Requester) || world.WorldTick - tick <= 250)
+				return true;
+
+			requestedRefineryPlacementTicks.Remove(request.Value.Requester);
+			return false;
+		}
+
+		public bool IsRequestedRefinerySatisfied(Actor producer)
+		{
+			var request = GetRequestedRefinery(producer);
+			if (!request.HasValue)
+				return false;
+
+			var requester = request.Value.Requester;
+			if (!requestedPlacedRefineries.TryGetValue(requester, out var refinery) || refinery.IsDead || !refinery.IsInWorld)
+			{
+				var startActorId = requestedRefineryStartActorIds.GetValueOrDefault(requester);
+				refinery = world.FindActorsInCircle(world.Map.CenterOfCell(request.Value.ResourceLoc), WDist.FromCells(20))
+					.Where(a => a.Owner == player && !a.IsDead && a.ActorID > startActorId && Info.RefineryTypes.Contains(a.Info.Name))
+					.OrderBy(a => a.ActorID).FirstOrDefault();
+				if (refinery == null)
+				{
+					requestedPlacedRefineries.Remove(requester);
+					return false;
+				}
+
+				requestedPlacedRefineries[requester] = refinery;
+			}
+
+			var requestStartActorId = requestedRefineryStartActorIds.GetValueOrDefault(requester);
+			return world.FindActorsInCircle(refinery.CenterPosition, WDist.FromCells(20))
+				.Any(a => a.Owner == player && !a.IsDead && a.ActorID > requestStartActorId &&
+					a.Info.HasTraitInfo<HarvesterInfo>() && a.CurrentActivity is FindAndDeliverResources);
+		}
+
+		public void MarkRequestedRefineryPlacementPending(Actor producer)
+		{
+			var request = GetRequestedRefinery(producer);
+			if (request.HasValue)
+				requestedRefineryPlacementTicks[request.Value.Requester] = world.WorldTick;
+		}
 
 		readonly Stack<TraitPair<RallyPoint>> rallyPoints = [];
 		int assignRallyPointsTicks;
@@ -362,6 +471,8 @@ namespace OpenRA.Mods.CA.Traits
 			pathFinder = self.World.WorldActor.TraitOrDefault<IPathFinder>();
 			positionsUpdatedModules = self.Owner.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
 			BaseExpansionModules = self.Owner.PlayerActor.TraitsImplementing<IBotBaseExpansion>().ToArray();
+			exclusiveConstructionQueues = self.Owner.PlayerActor.TraitsImplementing<IBotExclusiveConstructionQueue>().ToArray();
+			cashReservation = self.Owner.PlayerActor.TraitsImplementing<IBotCashReservation>().FirstOrDefault();
 
 			var i = 0;
 
@@ -879,7 +990,16 @@ namespace OpenRA.Mods.CA.Traits
 				new("OpeningBarracksCostCommitted", FieldSaver.FormatValue(openingBarracksCostCommitted)),
 				new("OpeningRefineryCommittedCost", FieldSaver.FormatValue(openingRefineryCommittedCost)),
 				new("OpeningRefineryCostCommitted", FieldSaver.FormatValue(openingRefineryCostCommitted)),
-				new("OpeningDefenseCommittedCost", FieldSaver.FormatValue(openingDefenseCommittedCost))
+				new("OpeningDefenseCommittedCost", FieldSaver.FormatValue(openingDefenseCommittedCost)),
+				new("RequestedRefineryActors", FieldSaver.FormatValue(RequestedRefineries.Keys.Select(a => a.ActorID).ToArray())),
+				new("RequestedRefineryConyardLocations", FieldSaver.FormatValue(RequestedRefineries.Values.Select(r => r.ConyardLoc).ToArray())),
+				new("RequestedRefineryResourceLocations", FieldSaver.FormatValue(RequestedRefineries.Values.Select(r => r.ResourceLoc).ToArray())),
+				new("RequestedRefineryPendingActors", FieldSaver.FormatValue(requestedRefineryPlacementTicks.Keys.Select(a => a.ActorID).ToArray())),
+				new("RequestedRefineryPendingTicks", FieldSaver.FormatValue(requestedRefineryPlacementTicks.Values.ToArray())),
+				new("RequestedRefineryStartActors", FieldSaver.FormatValue(requestedRefineryStartActorIds.Keys.Select(a => a.ActorID).ToArray())),
+				new("RequestedRefineryStartIds", FieldSaver.FormatValue(requestedRefineryStartActorIds.Values.ToArray())),
+				new("RequestedPlacedRefineryRequesters", FieldSaver.FormatValue(requestedPlacedRefineries.Keys.Select(a => a.ActorID).ToArray())),
+				new("RequestedPlacedRefineries", FieldSaver.FormatValue(requestedPlacedRefineries.Values.Select(a => a.ActorID).ToArray()))
 			};
 		}
 
@@ -938,6 +1058,69 @@ namespace OpenRA.Mods.CA.Traits
 			if (openingDefenseCommittedCostNode != null)
 				openingDefenseCommittedCost = FieldLoader.GetValue<int>("OpeningDefenseCommittedCost",
 					openingDefenseCommittedCostNode.Value.Value);
+
+			var requestActorsNode = data.NodeWithKeyOrDefault("RequestedRefineryActors");
+			var requestConyardsNode = data.NodeWithKeyOrDefault("RequestedRefineryConyardLocations");
+			var requestResourcesNode = data.NodeWithKeyOrDefault("RequestedRefineryResourceLocations");
+			if (requestActorsNode != null && requestConyardsNode != null && requestResourcesNode != null)
+			{
+				var actorIds = FieldLoader.GetValue<uint[]>("RequestedRefineryActors", requestActorsNode.Value.Value);
+				var conyardLocations = FieldLoader.GetValue<CPos[]>("RequestedRefineryConyardLocations", requestConyardsNode.Value.Value);
+				var resourceLocations = FieldLoader.GetValue<CPos[]>("RequestedRefineryResourceLocations", requestResourcesNode.Value.Value);
+				RequestedRefineries.Clear();
+				for (var i = 0; i < Math.Min(actorIds.Length, Math.Min(conyardLocations.Length, resourceLocations.Length)); i++)
+				{
+					var requester = self.World.GetActorById(actorIds[i]);
+					if (requester != null)
+						RequestedRefineries[requester] = (conyardLocations[i], resourceLocations[i]);
+				}
+			}
+
+			var pendingActorsNode = data.NodeWithKeyOrDefault("RequestedRefineryPendingActors");
+			var pendingTicksNode = data.NodeWithKeyOrDefault("RequestedRefineryPendingTicks");
+			if (pendingActorsNode != null && pendingTicksNode != null)
+			{
+				var actorIds = FieldLoader.GetValue<uint[]>("RequestedRefineryPendingActors", pendingActorsNode.Value.Value);
+				var pendingTicks = FieldLoader.GetValue<int[]>("RequestedRefineryPendingTicks", pendingTicksNode.Value.Value);
+				requestedRefineryPlacementTicks.Clear();
+				for (var i = 0; i < Math.Min(actorIds.Length, pendingTicks.Length); i++)
+				{
+					var requester = self.World.GetActorById(actorIds[i]);
+					if (requester != null)
+						requestedRefineryPlacementTicks[requester] = pendingTicks[i];
+				}
+			}
+
+			var startActorsNode = data.NodeWithKeyOrDefault("RequestedRefineryStartActors");
+			var startIdsNode = data.NodeWithKeyOrDefault("RequestedRefineryStartIds");
+			if (startActorsNode != null && startIdsNode != null)
+			{
+				var actorIds = FieldLoader.GetValue<uint[]>("RequestedRefineryStartActors", startActorsNode.Value.Value);
+				var startIds = FieldLoader.GetValue<uint[]>("RequestedRefineryStartIds", startIdsNode.Value.Value);
+				requestedRefineryStartActorIds.Clear();
+				for (var i = 0; i < Math.Min(actorIds.Length, startIds.Length); i++)
+				{
+					var requester = self.World.GetActorById(actorIds[i]);
+					if (requester != null)
+						requestedRefineryStartActorIds[requester] = startIds[i];
+				}
+			}
+
+			var placedRequestersNode = data.NodeWithKeyOrDefault("RequestedPlacedRefineryRequesters");
+			var placedRefineriesNode = data.NodeWithKeyOrDefault("RequestedPlacedRefineries");
+			if (placedRequestersNode != null && placedRefineriesNode != null)
+			{
+				var requesterIds = FieldLoader.GetValue<uint[]>("RequestedPlacedRefineryRequesters", placedRequestersNode.Value.Value);
+				var refineryIds = FieldLoader.GetValue<uint[]>("RequestedPlacedRefineries", placedRefineriesNode.Value.Value);
+				requestedPlacedRefineries.Clear();
+				for (var i = 0; i < Math.Min(requesterIds.Length, refineryIds.Length); i++)
+				{
+					var requester = self.World.GetActorById(requesterIds[i]);
+					var refinery = self.World.GetActorById(refineryIds[i]);
+					if (requester != null && refinery != null)
+						requestedPlacedRefineries[requester] = refinery;
+				}
+			}
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)
@@ -951,7 +1134,27 @@ namespace OpenRA.Mods.CA.Traits
 		void IBotSuggestRefineryProduction.RequestLocation(CPos refineryLocation, CPos conyardLocation, Actor expandActor)
 		{
 			if (ResourceMapModule == null || ResourceMapModule.FindClosestIndiceFromCPos(refineryLocation).PlayerRefineryCount < Info.MaxRefineryPerIndice)
+			{
 				RequestedRefineries[expandActor] = (conyardLocation, refineryLocation);
+				requestedRefineryPlacementTicks.Remove(expandActor);
+				requestedRefineryStartActorIds[expandActor] = world.Actors.Select(a => a.ActorID).DefaultIfEmpty(0u).Max();
+				requestedPlacedRefineries.Remove(expandActor);
+			}
+		}
+
+		bool IBotSuggestRefineryProduction.IsRequestSatisfied(Actor expandActor) => IsRequestedRefinerySatisfied(expandActor);
+
+		void IBotSuggestRefineryProduction.CompleteRequest(Actor expandActor)
+		{
+			var request = GetRequestedRefinery(expandActor);
+			if (!request.HasValue)
+				return;
+
+			var requester = request.Value.Requester;
+			RequestedRefineries.Remove(requester);
+			requestedRefineryPlacementTicks.Remove(requester);
+			requestedRefineryStartActorIds.Remove(requester);
+			requestedPlacedRefineries.Remove(requester);
 		}
 	}
 }

--- a/OpenRA.Mods.CA/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManagerCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManagerCA.cs
@@ -201,16 +201,30 @@ namespace OpenRA.Mods.CA.Traits
 				return false;
 
 			var currentBuilding = queue.AllQueued().FirstOrDefault();
+			var expeditionRequest = baseBuilder.GetRequestedRefinery(queue.Actor);
+			if (expeditionRequest.HasValue && baseBuilder.IsRequestedRefineryPlacementPending(queue.Actor) && currentBuilding == null)
+				return false;
+			if (baseBuilder.IsExclusiveConstructionQueue(queue.Actor) && !expeditionRequest.HasValue && currentBuilding == null)
+				return false;
 
 			// Waiting to build something
 			if (currentBuilding == null && failCount < baseBuilder.Info.MaximumFailedPlacementAttempts)
 			{
-				var item = ChooseBuildingToBuild(queue);
+				// Expansion conyards reserve their own queue for exactly one requested refinery.
+				var item = expeditionRequest.HasValue
+					? GetProducibleBuilding(baseBuilder.Info.RefineryTypes, queue.BuildableItems())
+					: ChooseBuildingToBuild(queue);
 				if (item == null)
 					return false;
 
 				// We shouldn't be queueing new buildings (other than refineries) when we're low on cash
 				if ((playerResources.GetCashAndResources() < minCashRequirement && !baseBuilder.Info.RefineryTypes.Contains(item.Name)) || itemQueuedThisTick)
+					return false;
+
+				var isExcessProduction = baseBuilder.Info.ProductionTypes.Contains(item.Name) &&
+					baseBuilder.Info.NewProductionBotTypes.Contains(player.BotType) &&
+					playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold;
+				if (isExcessProduction && !baseBuilder.TryReserveExcessProductionCash(queue.GetProductionCost(item)))
 					return false;
 
 				baseBuilder.RecordOpeningStructureQueued(queue, item);
@@ -314,6 +328,9 @@ namespace OpenRA.Mods.CA.Traits
 						ExtraData = queue.Actor.ActorID,
 						SuppressVisualFeedback = true
 					});
+
+					if (baseBuilder.Info.RefineryTypes.Contains(currentBuilding.Item))
+						baseBuilder.MarkRequestedRefineryPlacementPending(queue.Actor);
 
 					// After succesfuly placing a building, nudge BaseExpansionModules to expand.
 					// We want to avoid expanding too often, so we make a judgement by counting buildings.
@@ -452,7 +469,10 @@ namespace OpenRA.Mods.CA.Traits
 			}
 
 			// Make sure that we can spend as fast as we are earning
-			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold)
+			var canBuildExcessProduction = baseBuilder.Info.NewProductionBotTypes.Count == 0 ||
+				baseBuilder.Info.NewProductionBotTypes.Contains(player.BotType);
+			if (canBuildExcessProduction && baseBuilder.Info.NewProductionCashThreshold > 0 &&
+				playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold)
 			{
 				var production = GetProducibleBuilding(baseBuilder.Info.ProductionTypes, buildableThings);
 
@@ -473,7 +493,7 @@ namespace OpenRA.Mods.CA.Traits
 			}
 
 			// Only consider building this if there is enough water inside the base perimeter and there are close enough adjacent buildings
-			if (waterState == WaterCheck.EnoughWater && baseBuilder.Info.NewProductionCashThreshold > 0
+			if (canBuildExcessProduction && waterState == WaterCheck.EnoughWater && baseBuilder.Info.NewProductionCashThreshold > 0
 				&& playerResources.Resources > baseBuilder.Info.NewProductionCashThreshold
 				&& AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder.Info.CheckForWaterRadius, baseBuilder.Info.WaterTerrainTypes))
 			{
@@ -696,14 +716,15 @@ namespace OpenRA.Mods.CA.Traits
 
 				case BuildingType.Refinery:
 
-					var requestRef = baseBuilder.RequestedRefineries.Count > 0 ? baseBuilder.RequestedRefineries.Keys.First() : null;
+					var request = baseBuilder.GetRequestedRefinery(producer);
+					var requestRef = request?.Requester;
 
 					// Try and place the refinery near a resource field
 					if (resourceLayer != null)
 					{
 						// If we have failed to place to the requested refinery point, try and place it near the base center
 						var resourceBaseCenter = failCount > 0 ? baseCenter :
-							(requestRef != null ? baseBuilder.RequestedRefineries[requestRef].ConyardLoc : (baseBuilder.ResourceConyardCenter ?? baseCenter));
+							(request.HasValue ? request.Value.ConyardLoc : (baseBuilder.ResourceConyardCenter ?? baseCenter));
 
 						// If we have a ResourceMapModule, only consider the resource types it considers valuable
 						// Otherwise consider any resource type
@@ -724,7 +745,7 @@ namespace OpenRA.Mods.CA.Traits
 							resourcesShouldCheck = nearbyResources.Shuffle(world.LocalRandom).Take(baseBuilder.Info.MaxResourceCellsToCheck);
 						else if (requestRef != null)
 						{
-							resourcesShouldCheck = nearbyResources.OrderBy(c => (c - baseBuilder.RequestedRefineries[requestRef].ResourceLoc).LengthSquared)
+							resourcesShouldCheck = nearbyResources.OrderBy(c => (c - request.Value.ResourceLoc).LengthSquared)
 								.Take(baseBuilder.Info.MaxResourceCellsToCheck);
 						}
 						else
@@ -736,15 +757,10 @@ namespace OpenRA.Mods.CA.Traits
 							var found = findPos(actorType, distanceToBaseIsImportant, producer, resourceBaseCenter, r, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius);
 							if (found.Location != null)
 							{
-								if (baseBuilder.RequestedRefineries.Count > 0)
-									baseBuilder.RequestedRefineries.Remove(requestRef);
 								return found;
 							}
 						}
 					}
-
-					if (baseBuilder.RequestedRefineries.Count > 0)
-						baseBuilder.RequestedRefineries.Remove(requestRef);
 
 					// Try and find a free spot somewhere else in the base
 					return findPos(actorType, distanceToBaseIsImportant, producer, baseCenter, baseCenter, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius);

--- a/OpenRA.Mods.CA/Traits/BotModules/UnitBuilderBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/UnitBuilderBotModuleCA.cs
@@ -9,10 +9,12 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.CA.Traits
@@ -53,6 +55,33 @@ namespace OpenRA.Mods.CA.Traits
 		[Desc("Only queue construction of a new unit when above this requirement.")]
 		public readonly int MaximiseProductionCashRequirement = 10000;
 
+		[Desc("Bot types that preserve RecoveryCashReserve and use it as their queue-saturation threshold.")]
+		public readonly FrozenSet<string> ExcessCashBotTypes = FrozenSet<string>.Empty;
+
+		[Desc("Cash retained by ExcessCashBotTypes when choosing ordinary production.")]
+		public readonly int RecoveryCashReserve = 0;
+
+		[Desc("Bot types allowed to adapt production weights to an omniscient enemy composition sample.")]
+		public readonly FrozenSet<string> AdaptiveCounterBotTypes = FrozenSet<string>.Empty;
+
+		[Desc("Maximum percentage of production weight supplied by adaptive counter scoring.")]
+		public readonly int AdaptiveCounterWeight = 40;
+
+		[Desc("Ticks between composition samples.")]
+		public readonly int AdaptiveObservationInterval = 250;
+
+		[Desc("Ticks to retain the selected primary enemy before it may change.")]
+		public readonly int AdaptiveTargetLockDuration = 1500;
+
+		[Desc("Optional counter-score bonuses for specialist units whose capability is not obvious from weapons.")]
+		public readonly Dictionary<string, int> AdaptiveCounterOverrides = new();
+
+		[Desc("Explicit observed roles for ambiguous actor types. Values are comma-separated CombatRole names.")]
+		public readonly Dictionary<string, string> AdaptiveRoleOverrides = new();
+
+		[Desc("Explicit enemy roles countered by ambiguous specialist units.")]
+		public readonly Dictionary<string, string> AdaptiveCounterRoleOverrides = new();
+
 		[Desc("Maximum number of aircraft AI can build.",
 			"If MaintainAirSuperiority is true this only applies to units not listed in AirToAirUnits.")]
 		public readonly int MaxAircraft = 4;
@@ -75,6 +104,13 @@ namespace OpenRA.Mods.CA.Traits
 
 	public class UnitBuilderBotModuleCA : ConditionalTrait<UnitBuilderBotModuleCAInfo>, IBotTick, IBotNotifyIdleBaseUnits, IBotRequestUnitProduction, IGameSaveTraitData, IBotAircraftBuilder, INotifyActorDisposing
 	{
+		[Flags]
+		enum CombatRole { None = 0, Infantry = 1, LightVehicle = 2, HeavyArmor = 4, Artillery = 8, Aircraft = 16, Naval = 32, Stealth = 64, Support = 128 }
+
+		static readonly BitSet<TargetableType> InfantryTargets = new("Infantry");
+		static readonly BitSet<TargetableType> AircraftTargets = new("Air", "Aircraft");
+		static readonly BitSet<TargetableType> NavalTargets = new("Water", "Naval", "Ship");
+
 		public const int FeedbackTime = 30; // ticks; = a bit over 1s. must be >= netlag.
 
 		readonly World world;
@@ -83,13 +119,26 @@ namespace OpenRA.Mods.CA.Traits
 		readonly List<string> queuedBuildRequests = new List<string>();
 		readonly ActorIndex.OwnerAndNames unitsToBuild;
 		readonly Dictionary<string, int> activeUnitIntervals = new Dictionary<string, int>();
+		readonly Dictionary<string, int> observedEnemyValue = new Dictionary<string, int>();
 
 		IBotRequestPauseUnitProduction[] requestPause;
+		IBotRequestPauseUnitProductionForQueue[] requestQueuePause;
+		IBotCashReservation cashReservation;
 		int idleUnitCount;
 		int currentQueueIndex = 0;
 		PlayerResources playerResources;
 		BotLimits botLimits;
 		BaseBuilderBotModuleCA baseBuilder;
+		bool useExcessCashPolicy;
+		bool useAdaptiveCounters;
+		int adaptiveTargetClientIndex = -1;
+		int adaptiveTargetLockUntil;
+		int nextAdaptiveObservation;
+		int committedCashTick = -1;
+		int committedProductionCash;
+		int adaptiveSelections;
+		int totalWeightedSelections;
+		bool lastChoiceAdaptive;
 
 		int ticks;
 		int openingDefenseTicks;
@@ -112,6 +161,8 @@ namespace OpenRA.Mods.CA.Traits
 			// so we must query player traits from self, which refers
 			// for bot modules always to the Player actor.
 			requestPause = self.TraitsImplementing<IBotRequestPauseUnitProduction>().ToArray();
+			requestQueuePause = self.TraitsImplementing<IBotRequestPauseUnitProductionForQueue>().ToArray();
+			cashReservation = self.TraitsImplementing<IBotCashReservation>().FirstOrDefault();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
@@ -126,6 +177,8 @@ namespace OpenRA.Mods.CA.Traits
 			baseBuilder = player.PlayerActor.TraitsImplementing<BaseBuilderBotModuleCA>().FirstEnabledTraitOrDefault();
 			unitDelayModifier = botLimits?.Info.UnitDelayModifier ?? 100;
 			unitIntervalModifier = botLimits?.Info.UnitIntervalModifier ?? 100;
+			useExcessCashPolicy = Info.ExcessCashBotTypes.Contains(player.BotType);
+			useAdaptiveCounters = Info.AdaptiveCounterBotTypes.Contains(player.BotType);
 		}
 
 		void IBotNotifyIdleBaseUnits.UpdatedIdleBaseUnits(List<UnitWposWrapper> idleUnits)
@@ -135,10 +188,22 @@ namespace OpenRA.Mods.CA.Traits
 
 		void IBotTick.BotTick(IBot bot)
 		{
+			if (committedCashTick != world.WorldTick)
+			{
+				committedCashTick = world.WorldTick;
+				committedProductionCash = 0;
+			}
+
 			if (firstTick)
 			{
 				RefreshDifficultyTraits();
 				firstTick = false;
+			}
+
+			if (useAdaptiveCounters && world.WorldTick >= nextAdaptiveObservation)
+			{
+				nextAdaptiveObservation = world.WorldTick + Math.Max(1, Info.AdaptiveObservationInterval);
+				ObserveEnemyComposition();
 			}
 
 			// Decrement any active unit intervals, removing any that reach zero
@@ -170,8 +235,10 @@ namespace OpenRA.Mods.CA.Traits
 				var buildRequest = queuedBuildRequests.FirstOrDefault();
 				if (buildRequest != null)
 				{
-					BuildUnit(bot, buildRequest);
+					var requestQueued = BuildUnit(bot, buildRequest);
 					queuedBuildRequests.Remove(buildRequest);
+					if (requestQueued)
+						return;
 				}
 
 				// Don't produce if we don't have enough cash
@@ -189,7 +256,8 @@ namespace OpenRA.Mods.CA.Traits
 						// if AI gets enough cash, it can fill all of its queues with enough ticks
 						BuildUnit(bot, Info.UnitQueues[currentQueueIndex], idleUnitCount < Info.IdleBaseUnitsMaximum, false);
 
-						if (playerResources.Cash + playerResources.Resources < Info.MaximiseProductionCashRequirement)
+						var maximiseThreshold = useExcessCashPolicy ? Info.RecoveryCashReserve : Info.MaximiseProductionCashRequirement;
+						if (playerResources.Cash + playerResources.Resources < maximiseThreshold)
 							break;
 					}
 				}
@@ -253,7 +321,8 @@ namespace OpenRA.Mods.CA.Traits
 
 			for (var slot = 0; slot < slotsToFill; slot++)
 			{
-				var unit = buildRandom ?
+				lastChoiceAdaptive = false;
+				var unit = buildRandom && !(useAdaptiveCounters && observedEnemyValue.Count > 0) ?
 					ChooseRandomUnitToBuild(queue, excludeLimited) :
 					ChooseUnitToBuild(queue, excludeLimited);
 
@@ -270,24 +339,37 @@ namespace OpenRA.Mods.CA.Traits
 					return;
 				}
 
+				var cost = queue.GetProductionCost(unit);
+				if (!TryReserveCash(cost, useExcessCashPolicy ? Info.RecoveryCashReserve : 0))
+					return;
+
+				if (requestQueuePause.Any(rp => rp.PauseUnitProductionForQueue(category, unit)))
+					return;
+
 				SetUnitInterval(name);
 				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+				if (IsMobileCombatActor(unit))
+				{
+					totalWeightedSelections++;
+					if (lastChoiceAdaptive)
+						adaptiveSelections++;
+				}
 			}
 		}
 
 		// In cases where we want to build a specific unit but don't know the queue name (because there's more than one possibility)
-		void BuildUnit(IBot bot, string name)
+		bool BuildUnit(IBot bot, string name)
 		{
 			var actorInfo = world.Map.Rules.Actors[name];
 			if (actorInfo == null)
-				return;
+				return false;
 
 			var buildableInfo = actorInfo.TraitInfoOrDefault<BuildableInfo>();
 			if (buildableInfo == null)
-				return;
+				return false;
 
 			if (!ShouldBuild(name, true))
-				return;
+				return false;
 
 			ProductionQueue queue = null;
 			foreach (var pq in buildableInfo.Queue)
@@ -299,10 +381,33 @@ namespace OpenRA.Mods.CA.Traits
 
 			if (queue != null && queue.BuildableItems().Any(b => b.Name == name))
 			{
+				var cost = queue.GetProductionCost(actorInfo);
+				var externalReserve = useExcessCashPolicy ? Math.Min(Info.RecoveryCashReserve, 2500) : 0;
+				if (!TryReserveCash(cost, externalReserve))
+					return false;
+
+				if (requestQueuePause.Any(rp => rp.PauseUnitProductionForQueue(queue.Info.Type, actorInfo)))
+					return false;
+
 				SetUnitInterval(name);
 				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
 				AIUtils.BotDebug("AI: {0} decided to build {1} (external request)", queue.Actor.Owner, name);
+				return true;
 			}
+
+			return false;
+		}
+
+		bool TryReserveCash(int cost, int reserve)
+		{
+			if (cashReservation != null)
+				return cashReservation.TryReserveCash(cost, reserve);
+
+			if (playerResources.GetCashAndResources() - committedProductionCash - cost < reserve)
+				return false;
+
+			committedProductionCash += cost;
+			return true;
 		}
 
 		void SetUnitInterval(string name)
@@ -348,6 +453,7 @@ namespace OpenRA.Mods.CA.Traits
 
 		ActorInfo ChooseUnitToBuild(ProductionQueue queue, bool excludeLimited)
 		{
+			lastChoiceAdaptive = false;
 			var buildableThings = queue.BuildableItems();
 			if (!buildableThings.Any())
 				return null;
@@ -356,15 +462,178 @@ namespace OpenRA.Mods.CA.Traits
 				.ActorsHavingTrait<IPositionable>()
 				.Where(a => a.Owner == player)
 				.Select(a => a.Info.Name).ToList();
+			myUnits.AddRange(world.ActorsWithTrait<ProductionQueue>()
+				.Where(q => q.Actor.Owner == player && q.Trait.Enabled)
+				.SelectMany(q => q.Trait.AllQueued()).Select(q => q.Item)
+				.Where(name => world.Map.Rules.Actors.TryGetValue(name, out var actorInfo) && actorInfo.HasTraitInfo<IPositionableInfo>()));
+
+			var allowAdaptiveSelection = useAdaptiveCounters && totalWeightedSelections >= 2 &&
+				(adaptiveSelections + 1) * 100 <= (totalWeightedSelections + 1) * Math.Clamp(Info.AdaptiveCounterWeight, 0, 40);
+			if (allowAdaptiveSelection)
+			{
+				var adaptiveChoice = buildableThings
+					.Where(a => IsMobileCombatActor(a) && Info.UnitsToBuild.ContainsKey(a.Name) &&
+						(!excludeLimited || !Info.UnitLimits.ContainsKey(a.Name)) && ShouldBuild(a.Name, false))
+					.Select(a => new { Actor = a, Score = AdaptiveCounterScore(a) / (1 + myUnits.Count(n => n == a.Name)) })
+					.Where(x => x.Score > 0 && CanBuildMoreOfAircraft(x.Actor))
+					.OrderByDescending(x => x.Score).ThenBy(x => x.Actor.Name).FirstOrDefault();
+				if (adaptiveChoice != null)
+				{
+					lastChoiceAdaptive = true;
+					return adaptiveChoice.Actor;
+				}
+			}
 
 			foreach (var unit in Info.UnitsToBuild.Shuffle(world.LocalRandom))
 				if (buildableThings.Any(b => b.Name == unit.Key))
 					if (!excludeLimited || !Info.UnitLimits.ContainsKey(unit.Key))
-						if (myUnits.Count(a => a == unit.Key) * 100 < unit.Value * myUnits.Count)
+					{
+						if (myUnits.Count(a => a == unit.Key) * 100 < unit.Value * Math.Max(1, myUnits.Count))
 							if (CanBuildMoreOfAircraft(world.Map.Rules.Actors[unit.Key]))
 								return world.Map.Rules.Actors[unit.Key];
+					}
 
 			return null;
+		}
+
+		void ObserveEnemyComposition()
+		{
+			var enemies = world.Players.Where(p => p.WinState == WinState.Undefined &&
+				player.RelationshipWith(p) == PlayerRelationship.Enemy).OrderBy(p => p.ClientIndex).ToArray();
+			if (enemies.Length == 0)
+			{
+				observedEnemyValue.Clear();
+				adaptiveTargetClientIndex = -1;
+				return;
+			}
+
+			var target = world.WorldTick < adaptiveTargetLockUntil
+				? enemies.FirstOrDefault(p => p.ClientIndex == adaptiveTargetClientIndex)
+				: null;
+			if (target == null)
+			{
+				var previousTarget = adaptiveTargetClientIndex;
+				target = enemies.Select(p => new
+				{
+					Player = p,
+					Value = world.ActorsHavingTrait<IPositionable>().Where(a => a.Owner == p && !a.IsDead &&
+						IsObservedArmyActor(a.Info)).Sum(a => a.Info.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 1)
+				}).OrderByDescending(x => x.Value).ThenBy(x => x.Player.ClientIndex).First().Player;
+				adaptiveTargetClientIndex = target.ClientIndex;
+				adaptiveTargetLockUntil = world.WorldTick + Math.Max(1, Info.AdaptiveTargetLockDuration);
+				if (previousTarget >= 0 && previousTarget != adaptiveTargetClientIndex)
+					observedEnemyValue.Clear();
+			}
+
+			var current = world.ActorsHavingTrait<IPositionable>()
+				.Where(a => a.Owner == target && !a.IsDead && IsObservedArmyActor(a.Info))
+				.GroupBy(a => a.Info.Name).ToDictionary(g => g.Key,
+					g => g.Sum(a => a.Info.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 1));
+
+			foreach (var name in observedEnemyValue.Keys.Union(current.Keys).ToArray())
+			{
+				current.TryGetValue(name, out var value);
+				observedEnemyValue.TryGetValue(name, out var oldValue);
+				var smoothed = (oldValue * 3 + value) / 4;
+				if (smoothed > 0)
+					observedEnemyValue[name] = smoothed;
+				else
+					observedEnemyValue.Remove(name);
+			}
+		}
+
+		bool IsObservedArmyActor(ActorInfo actor) => actor.HasTraitInfo<AttackBaseInfo>() ||
+			actor.HasTraitInfo<CargoInfo>() || actor.HasTraitInfo<CloakInfo>();
+
+		bool IsMobileCombatActor(ActorInfo actor) => actor.HasTraitInfo<IPositionableInfo>() &&
+			actor.HasTraitInfo<AttackBaseInfo>() && !actor.HasTraitInfo<HarvesterInfo>();
+
+		int AdaptiveCounterScore(ActorInfo candidate)
+		{
+			var weapons = candidate.TraitInfos<ArmamentInfo>().Select(a => a.WeaponInfo).Where(w => w != null).ToArray();
+			var score = Info.AdaptiveCounterOverrides.TryGetValue(candidate.Name, out var bonus) ? bonus : 0;
+			if (weapons.Length == 0)
+				return score;
+
+			foreach (var enemy in observedEnemyValue)
+			{
+				if (!world.Map.Rules.Actors.TryGetValue(enemy.Key, out var enemyInfo))
+					continue;
+
+				var enemyTargets = enemyInfo.GetAllTargetTypes();
+				var roles = ClassifyRoles(enemyInfo);
+				var explicitCounterRoles = ParseRoleOverride(Info.AdaptiveCounterRoleOverrides, candidate.Name);
+				var weaponCoverage = weapons.Any(w => w.ValidTargets.Overlaps(enemyTargets) && !w.InvalidTargets.Overlaps(enemyTargets));
+				if (!weaponCoverage && (explicitCounterRoles & roles) == CombatRole.None)
+					continue;
+
+				var candidateCost = candidate.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 0;
+				var candidateRange = candidate.TraitInfos<ArmamentInfo>().Select(a => a.ModifiedRange.Length).DefaultIfEmpty(0).Max();
+				var candidateRoles = ClassifyRoles(candidate);
+				var multiplier = 1;
+				if (roles.HasFlag(CombatRole.Infantry) && candidateCost <= 1200)
+					multiplier++;
+				if (roles.HasFlag(CombatRole.LightVehicle) && candidateCost is >= 500 and <= 1600)
+					multiplier++;
+				if (roles.HasFlag(CombatRole.HeavyArmor) && candidateCost >= 1000)
+					multiplier++;
+				if (roles.HasFlag(CombatRole.Artillery) && (candidate.HasTraitInfo<AircraftInfo>() || candidateRange >= WDist.FromCells(7).Length))
+					multiplier++;
+				if (roles.HasFlag(CombatRole.Aircraft) && weapons.Any(w => w.ValidTargets.Overlaps(AircraftTargets)))
+					multiplier += 2;
+				if (roles.HasFlag(CombatRole.Naval) && (candidateRoles.HasFlag(CombatRole.Naval) || candidateRoles.HasFlag(CombatRole.Aircraft)))
+					multiplier++;
+				if (roles.HasFlag(CombatRole.Stealth) && candidate.HasTraitInfo<DetectCloakedInfo>())
+					multiplier += 2;
+				if (roles.HasFlag(CombatRole.Support) && (candidateRoles.HasFlag(CombatRole.Aircraft) || candidateRange >= WDist.FromCells(6).Length))
+					multiplier++;
+				if ((explicitCounterRoles & roles) != CombatRole.None)
+					multiplier += 3;
+
+				score += enemy.Value * multiplier;
+			}
+
+			return score;
+		}
+
+		CombatRole ClassifyRoles(ActorInfo actor)
+		{
+			var roles = CombatRole.None;
+			var targets = actor.GetAllTargetTypes();
+			var cost = actor.TraitInfoOrDefault<ValuedInfo>()?.Cost ?? 0;
+			var hp = actor.TraitInfoOrDefault<HealthInfo>()?.HP ?? 0;
+			if (actor.HasTraitInfo<AircraftInfo>())
+				roles |= CombatRole.Aircraft;
+			else if (targets.Overlaps(NavalTargets))
+				roles |= CombatRole.Naval;
+			else if (targets.Overlaps(InfantryTargets))
+				roles |= CombatRole.Infantry;
+			else if (cost >= 1400 || hp >= 100000)
+				roles |= CombatRole.HeavyArmor;
+			else
+				roles |= CombatRole.LightVehicle;
+
+			if (actor.TraitInfos<ArmamentInfo>().Any(a => a.ModifiedRange.Length >= WDist.FromCells(8).Length))
+				roles |= CombatRole.Artillery;
+			if (actor.HasTraitInfo<CloakInfo>())
+				roles |= CombatRole.Stealth;
+			if (actor.HasTraitInfo<CargoInfo>() || !actor.HasTraitInfo<AttackBaseInfo>())
+				roles |= CombatRole.Support;
+
+			return roles | ParseRoleOverride(Info.AdaptiveRoleOverrides, actor.Name);
+		}
+
+		static CombatRole ParseRoleOverride(Dictionary<string, string> overrides, string actorName)
+		{
+			if (!overrides.TryGetValue(actorName, out var configuredRoles))
+				return CombatRole.None;
+
+			var roles = CombatRole.None;
+			foreach (var role in configuredRoles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+				if (Enum.TryParse<CombatRole>(role, true, out var parsed))
+					roles |= parsed;
+
+			return roles;
 		}
 
 		bool IBotAircraftBuilder.CanBuildMoreOfAircraft(ActorInfo actorInfo)
@@ -412,7 +681,14 @@ namespace OpenRA.Mods.CA.Traits
 			return new List<MiniYamlNode>()
 			{
 				new("QueuedBuildRequests", FieldSaver.FormatValue(queuedBuildRequests.ToArray())),
-				new("IdleUnitCount", FieldSaver.FormatValue(idleUnitCount))
+				new("IdleUnitCount", FieldSaver.FormatValue(idleUnitCount)),
+				new("AdaptiveTargetClientIndex", FieldSaver.FormatValue(adaptiveTargetClientIndex)),
+				new("AdaptiveTargetLockUntil", FieldSaver.FormatValue(adaptiveTargetLockUntil)),
+				new("NextAdaptiveObservation", FieldSaver.FormatValue(nextAdaptiveObservation)),
+				new("ObservedEnemyTypes", FieldSaver.FormatValue(observedEnemyValue.Keys.ToArray())),
+				new("ObservedEnemyValues", FieldSaver.FormatValue(observedEnemyValue.Values.ToArray())),
+				new("AdaptiveSelections", FieldSaver.FormatValue(adaptiveSelections)),
+				new("TotalWeightedSelections", FieldSaver.FormatValue(totalWeightedSelections))
 			};
 		}
 
@@ -431,6 +707,33 @@ namespace OpenRA.Mods.CA.Traits
 			var idleUnitCountNode = data.NodeWithKeyOrDefault("IdleUnitCount");
 			if (idleUnitCountNode != null)
 				idleUnitCount = FieldLoader.GetValue<int>("IdleUnitCount", idleUnitCountNode.Value.Value);
+
+			var targetNode = data.NodeWithKeyOrDefault("AdaptiveTargetClientIndex");
+			if (targetNode != null)
+				adaptiveTargetClientIndex = FieldLoader.GetValue<int>("AdaptiveTargetClientIndex", targetNode.Value.Value);
+			var lockNode = data.NodeWithKeyOrDefault("AdaptiveTargetLockUntil");
+			if (lockNode != null)
+				adaptiveTargetLockUntil = FieldLoader.GetValue<int>("AdaptiveTargetLockUntil", lockNode.Value.Value);
+			var observationNode = data.NodeWithKeyOrDefault("NextAdaptiveObservation");
+			if (observationNode != null)
+				nextAdaptiveObservation = FieldLoader.GetValue<int>("NextAdaptiveObservation", observationNode.Value.Value);
+			var typesNode = data.NodeWithKeyOrDefault("ObservedEnemyTypes");
+			var valuesNode = data.NodeWithKeyOrDefault("ObservedEnemyValues");
+			if (typesNode != null && valuesNode != null)
+			{
+				var types = FieldLoader.GetValue<string[]>("ObservedEnemyTypes", typesNode.Value.Value);
+				var values = FieldLoader.GetValue<int[]>("ObservedEnemyValues", valuesNode.Value.Value);
+				observedEnemyValue.Clear();
+				for (var i = 0; i < Math.Min(types.Length, values.Length); i++)
+					observedEnemyValue[types[i]] = values[i];
+			}
+
+			var adaptiveSelectionsNode = data.NodeWithKeyOrDefault("AdaptiveSelections");
+			if (adaptiveSelectionsNode != null)
+				adaptiveSelections = FieldLoader.GetValue<int>("AdaptiveSelections", adaptiveSelectionsNode.Value.Value);
+			var totalSelectionsNode = data.NodeWithKeyOrDefault("TotalWeightedSelections");
+			if (totalSelectionsNode != null)
+				totalWeightedSelections = FieldLoader.GetValue<int>("TotalWeightedSelections", totalSelectionsNode.Value.Value);
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)

--- a/OpenRA.Mods.Cameo/Traits/BotGlobalUnitBudget.cs
+++ b/OpenRA.Mods.Cameo/Traits/BotGlobalUnitBudget.cs
@@ -5,6 +5,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -47,13 +48,18 @@ namespace OpenRA.Mods.Cameo.Traits
 		public override object Create(ActorInitializer init) => new BotGlobalUnitBudget(init.Self, this);
 	}
 
-	public class BotGlobalUnitBudget : ConditionalTrait<BotGlobalUnitBudgetInfo>, IBotRequestPauseUnitProduction
+	public class BotGlobalUnitBudget : ConditionalTrait<BotGlobalUnitBudgetInfo>, IBotRequestPauseUnitProductionForQueue, IBotCashReservation
 	{
 		readonly World world;
 		readonly OpenRA.Player player;
+		PlayerResources playerResources;
 
 		int lastTick = -1;
-		bool paused;
+		int cachedCombatCount;
+		int reservationTick = -1;
+		int pendingCombatReservations;
+		int cashReservationTick = -1;
+		int pendingCashReservations;
 
 		public BotGlobalUnitBudget(Actor self, BotGlobalUnitBudgetInfo info)
 			: base(info)
@@ -62,27 +68,71 @@ namespace OpenRA.Mods.Cameo.Traits
 			player = self.Owner;
 		}
 
-		bool IBotRequestPauseUnitProduction.PauseUnitProduction
+		protected override void Created(Actor self)
 		{
-			get
-			{
-				if (IsTraitDisabled || Info.GlobalUnitBudget <= 0)
-					return false;
-
-				// Throttle the recompute. Only ever queried on the host (bots run host-side), and the
-				// inputs are synced state, so the decision is deterministic for the orders it gates.
-				var tick = world.WorldTick;
-				if (lastTick < 0 || tick - lastTick >= Info.RecalculationInterval)
-				{
-					lastTick = tick;
-					paused = ComputePaused();
-				}
-
-				return paused;
-			}
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
-		bool ComputePaused()
+		bool IBotCashReservation.TryReserveCash(int cost, int minimumRemainingCash)
+		{
+			if (cashReservationTick != world.WorldTick)
+			{
+				cashReservationTick = world.WorldTick;
+				pendingCashReservations = 0;
+			}
+
+			if (playerResources.GetCashAndResources() - pendingCashReservations - cost < minimumRemainingCash)
+				return false;
+
+			pendingCashReservations += cost;
+			return true;
+		}
+
+		bool IBotRequestPauseUnitProductionForQueue.PauseUnitProductionForQueue(string queue, ActorInfo actorInfo)
+		{
+			if (IsTraitDisabled || Info.GlobalUnitBudget <= 0)
+				return false;
+
+			// Gate mobile combat actors, not the queue that happens to produce them. This keeps
+			// expansion MCVs, transports, upgrades and research available at the combat cap.
+			if (!IsCombatActor(actorInfo))
+				return false;
+
+			// Throttle the recompute. Only ever queried on the host (bots run host-side), and the
+			// inputs are synced state, so the decision is deterministic for the orders it gates.
+			var tick = world.WorldTick;
+			if (reservationTick != tick)
+			{
+				reservationTick = tick;
+				pendingCombatReservations = 0;
+			}
+
+			if (lastTick < 0 || tick - lastTick >= Info.RecalculationInterval)
+			{
+				lastTick = tick;
+				cachedCombatCount = ComputeCombatCount();
+			}
+
+			var cap = ComputeCap();
+			if (cachedCombatCount + pendingCombatReservations >= cap)
+				return true;
+
+			pendingCombatReservations++;
+			return false;
+		}
+
+		bool IsCombatActor(ActorInfo actorInfo)
+		{
+			if (actorInfo == null || Info.IgnoredActorTypes.Contains(actorInfo.Name))
+				return false;
+
+			if (Info.IgnoreHarvesters && actorInfo.HasTraitInfo<HarvesterInfo>())
+				return false;
+
+			return actorInfo.HasTraitInfo<AttackBaseInfo>();
+		}
+
+		int ComputeCap()
 		{
 			var livingBots = 0;
 			foreach (var p in world.Players)
@@ -98,35 +148,38 @@ namespace OpenRA.Mods.Cameo.Traits
 			if (cap < Info.MinUnitsPerBot)
 				cap = Info.MinUnitsPerBot;
 
-			// Count this bot's live mobile units (IPositionable excludes buildings) - same notion of
-			// "army" the unit builders use. Stop as soon as we reach the cap; no need to count further.
+			return cap;
+		}
+
+		int ComputeCombatCount()
+		{
+			// Count live and already queued mobile combat units. Including queues prevents several
+			// parallel factories from overshooting the shared cap before their units finish.
 			var count = 0;
-			var ignoreNames = Info.IgnoredActorTypes.Count > 0;
 			foreach (var a in world.ActorsHavingTrait<IPositionable>())
 			{
-				if (a.Owner != player || a.IsDead)
-					continue;
-
-				// Resource collectors don't count against the combat budget, so a lower budget
-				// never starves the economy.
-				if (Info.IgnoreHarvesters && a.Info.HasTraitInfo<HarvesterInfo>())
-					continue;
-
-				if (ignoreNames && Info.IgnoredActorTypes.Contains(a.Info.Name))
+				if (a.Owner != player || a.IsDead || !IsCombatActor(a.Info))
 					continue;
 
 				// When not logging, stop as soon as we reach the cap - no need to count further.
 				// With Debug on we count every unit so the log shows the true army size vs the cap.
 				count++;
-				if (!Info.Debug && count >= cap)
-					return true;
 			}
 
-			if (Info.Debug)
-				Log.Write("debug", $"BotBudget {player.InternalName}: livingBots={livingBots} " +
-					$"cap={cap} units={count} paused={count >= cap}");
+			foreach (var queue in world.ActorsWithTrait<ProductionQueue>()
+				.Where(q => q.Actor.Owner == player && q.Trait.Enabled).Select(q => q.Trait))
+				foreach (var item in queue.AllQueued())
+					if (world.Map.Rules.Actors.TryGetValue(item.Item, out var actorInfo) &&
+						actorInfo.HasTraitInfo<IPositionableInfo>() && IsCombatActor(actorInfo))
+						count++;
 
-			return count >= cap;
+			if (Info.Debug)
+			{
+				var cap = ComputeCap();
+				Log.Write("debug", $"BotBudget {player.InternalName}: cap={cap} units={count} paused={count >= cap}");
+			}
+
+			return count;
 		}
 	}
 }

--- a/mods/cameo/ai/ai.yaml
+++ b/mods/cameo/ai/ai.yaml
@@ -3147,6 +3147,31 @@ Player:
 		MinimumConstructionYardCount: 1
 		AdditionalConstructionYardCount: 1
 		BuildAdditionalMCVCashAmount: 4000
+		ExpeditionSitesByBotType:
+			hard: 2
+			veryhard: 2
+			brutal: 3
+			challenger: 3
+			unbeatable: 3
+			cameogod: 3
+		ConstructionYardLimitsByBotType:
+			hard: 3
+			veryhard: 3
+			brutal: 4
+			challenger: 5
+			unbeatable: 5
+			cameogod: 5
+		HarvesterLimitsByBotType:
+			hard: 15
+			veryhard: 18
+			brutal: 21
+			challenger: 24
+			unbeatable: 27
+			cameogod: 30
+		ExpeditionLaunchCash: 7500
+		ExpeditionRepeatCash: 5000
+		LaterExpansionCashStep: 5000
+		ExpeditionConfirmationRadius: 20
 		# Expand with a dedicated MCV. Existing conyards only relocate when recovering
 		# from a specific stuck building-placement request.
 		MoveConyardTick: 0
@@ -3475,7 +3500,9 @@ Player:
 		MinimumDefenseRadius: 10
 		MaximumDefenseRadius: 50
 		MaxResourceCellsToCheck: 5
-		NewProductionCashThreshold: 0
+		NewProductionCashThreshold: 7500
+		NewProductionBotTypes: hard, veryhard, brutal, challenger, unbeatable, cameogod
+		ExcessProductionRecoveryReserve: 4000
 		BuildingProductionMinCashRequirement: 1000
 		DefenseProductionMinCashRequirement: 1500
 		BuildingQueues: Building, RABuilding, BuildingAddons
@@ -4473,6 +4500,19 @@ Player:
 		IdleBaseUnitsMaximum: 50
 		ProductionMinCashRequirement: 1000
 		MaximiseProductionCashRequirement: 5000
+		ExcessCashBotTypes: hard, veryhard, brutal, challenger, unbeatable, cameogod
+		RecoveryCashReserve: 4000
+		AdaptiveCounterBotTypes: hard, veryhard, brutal, challenger, unbeatable, cameogod
+		AdaptiveCounterWeight: 40
+		AdaptiveObservationInterval: 250
+		AdaptiveTargetLockDuration: 1500
+		AdaptiveCounterRoleOverrides:
+			ra1_soviets_yakscoutplane: Infantry, LightVehicle
+			ra2_allies_aegiscruiser: Aircraft
+			ra2_soviets_flaktrack: Infantry, Aircraft
+			yuri_gatlingtank: Infantry, Aircraft
+			td_gdi_orca: HeavyArmor
+			futuretech_cryocopter: HeavyArmor, Support
 		# One immediately buildable basic combat unit for each barracks-first faction.
 		OpeningDefenseUnitTypes: td_gdi_minigunner, td_nod_minigunner, ra1_allies_rifleinfantry, ra1_soviets_rifleinfantry, ts_gdi_lightinfantry, ts_nod_lightinfantry, forgotten_mutant, cabal_cyborginfantry, ra2_allies_gi, ra2_soviets_conscript, yuri_initiate, asianalliance_asianmilitia, steelconsortium_clonetrooper, latinsyndicate_latinmilitia, naxis_naxiriflerecruit, schwarzermond_lunarsoldier, futuretech_enforcer, ixian_lightinfantry, ordos_lightinfantry, tkm_rifleman
 		MaxAircraft: 25

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -3822,22 +3822,22 @@
 		Multiplier: 100
 		Prerequisites: mediumbotplayer
 	ProductionTimeMultiplier@hardbotplayer:
-		Multiplier: 90
+		Multiplier: 100
 		Prerequisites: hardbotplayer
 	ProductionTimeMultiplier@veryhardbotplayer:
-		Multiplier: 80
+		Multiplier: 90
 		Prerequisites: veryhardbotplayer
 	ProductionTimeMultiplier@brutalbotplayer:
-		Multiplier: 70
+		Multiplier: 80
 		Prerequisites: brutalbotplayer
 	ProductionTimeMultiplier@challengerbotplayer:
-		Multiplier: 60
+		Multiplier: 70
 		Prerequisites: challengerbotplayer
 	ProductionTimeMultiplier@unbeatablebotplayer:
-		Multiplier: 50
+		Multiplier: 60
 		Prerequisites: unbeatablebotplayer
 	ProductionTimeMultiplier@cameogodbotplayer:
-		Multiplier: 40
+		Multiplier: 50
 		Prerequisites: cameogodbotplayer
 	ProductionCostMultiplier@easiestbotplayer:
 		Multiplier: 115
@@ -3852,22 +3852,22 @@
 		Multiplier: 100
 		Prerequisites: mediumbotplayer
 	ProductionCostMultiplier@hardbotplayer:
-		Multiplier: 95
+		Multiplier: 100
 		Prerequisites: hardbotplayer
 	ProductionCostMultiplier@veryhardbotplayer:
-		Multiplier: 90
+		Multiplier: 95
 		Prerequisites: veryhardbotplayer
 	ProductionCostMultiplier@brutalbotplayer:
-		Multiplier: 85
+		Multiplier: 90
 		Prerequisites: brutalbotplayer
 	ProductionCostMultiplier@challengerbotplayer:
-		Multiplier: 80
+		Multiplier: 85
 		Prerequisites: challengerbotplayer
 	ProductionCostMultiplier@unbeatablebotplayer:
-		Multiplier: 75
+		Multiplier: 80
 		Prerequisites: unbeatablebotplayer
 	ProductionCostMultiplier@cameogodbotplayer:
-		Multiplier: 70
+		Multiplier: 75
 		Prerequisites: cameogodbotplayer
 
 ^BaseBuilding:
@@ -6733,11 +6733,11 @@ CPQDEBUGDUMMY:
 		Interval: 1
 		Amount: 1
 		ShowTicks: False
-		RequiresCondition: (normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && mediumbotinsurance
+		RequiresCondition: (mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && mediumbotinsurance
 	ResourcePurifier@medium:
 		Modifier: 5
 		ShowTicks: False
-		RequiresCondition: (normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && mediumbotinsurance
+		RequiresCondition: (mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && mediumbotinsurance
 	BotInsurance@easy:
 		Condition: easybotinsurance
 		Threshold: 3000
@@ -6746,11 +6746,11 @@ CPQDEBUGDUMMY:
 		Interval: 1
 		Amount: 1
 		ShowTicks: False
-		RequiresCondition: (easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easybotinsurance
+		RequiresCondition: (easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easybotinsurance
 	ResourcePurifier@easy:
 		Modifier: 5
 		ShowTicks: False
-		RequiresCondition: (easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easybotinsurance
+		RequiresCondition: (easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easybotinsurance
 	BotInsurance@veryeasy:
 		Condition: veryeasybotinsurance
 		Threshold: 2000
@@ -6759,11 +6759,11 @@ CPQDEBUGDUMMY:
 		Interval: 1
 		Amount: 1
 		ShowTicks: False
-		RequiresCondition: (veryeasybot || easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && veryeasybotinsurance
+		RequiresCondition: (veryeasybot || easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && veryeasybotinsurance
 	ResourcePurifier@veryeasy:
 		Modifier: 5
 		ShowTicks: False
-		RequiresCondition: (veryeasybot || easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && veryeasybotinsurance
+		RequiresCondition: (veryeasybot || easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && veryeasybotinsurance
 	BotInsurance@easiest:
 		Condition: easiestbotinsurance
 		Threshold: 1000
@@ -6772,11 +6772,11 @@ CPQDEBUGDUMMY:
 		Interval: 1
 		Amount: 1
 		ShowTicks: False
-		RequiresCondition: (easiestbot || veryeasybot || easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easiestbotinsurance
+		RequiresCondition: (easiestbot || veryeasybot || easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easiestbotinsurance
 	ResourcePurifier@easiest:
 		Modifier: 5
 		ShowTicks: False
-		RequiresCondition: (easiestbot || veryeasybot || easybot || normalbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easiestbotinsurance
+		RequiresCondition: (easiestbot || veryeasybot || easybot || mediumbot || hardbot || veryhardbot || brutalbot || challengerbot || unbeatablebot || cameogodbot) && easiestbotinsurance
 
 ^Harvester:
 	Inherits@MC: ^MCImmune


### PR DESCRIPTION
## Summary

- make Hard AI production use standard 100% cost and build time, moving economy bonuses to Very Hard and above
- fix Medium bot insurance while preserving the existing stacked-insurance and permitted-economy behavior
- add staged Hard+ base expansion with dedicated refinery expeditions and construction-queue ownership
- add adaptive Hard+ counter-production with role/value weighting, smoothing, specialist overrides, and a 40% combat-selection ceiling
- add excess-cash spending with recovery reserves, extra factories, shared cash reservations, and mobile-combat unit-budget exceptions

## Why

Hard already has stronger skirmish strategy than Medium, so it should not also receive production cheats. The new strategic systems make higher difficulties stronger through better expansion, counter-production, and late-game spending, while retaining the existing insurance, economy permissions, and omniscience behavior requested for this balance pass.

## Engine dependency

Depends on cameo-mod/OpenRA#92: https://github.com/cameo-mod/OpenRA/pull/92

That engine PR adds the expansion and production-policy hooks used here. It must land and the Cameo engine pin must be updated before this PR is mergeable; this PR intentionally does not alter `ENGINE_VERSION` or `engine/VERSION`.

## Validation

- `tools/preflight-build.ps1` passed
- `make.cmd all` passed with zero warnings and errors
- Cameo rules-load/map-hash smoke passed (`302249bb8cab8aae3b394b8c33428de957de4bcc`)
- one game launch remained alive and responsive for 60 seconds, then closed cleanly with no new crash or exception log
- independent adversarial agent review completed; all identified P1/P2 blockers in the reviewed areas were addressed
- `git diff --check` passed
