### PR TITLE
Restore autogun projectile visuals

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="a8b9d79c4d68e5dbade7020dd6585848602fb2c2"
+ENGINE_VERSION="f7540efea90179998cffde8547f42f2c6b6d5cae"
 
 ##############################################################################
 # Packaging

--- a/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
@@ -295,7 +295,7 @@ harkonnen_autogunturret:
 		LocalOffset: 600,-100,500, 600,100,500
 		CasingWeapon: generic_bullet_casing
 		CasingSpawnLocalOffset: 100,-100,500, 100,100,500
-		CasingTargetOffset: 0,-900,0, 0,900,0
+		CasingTargetOffset: -900,-100,0, -900,100,0
 		MuzzleSequence: muzzle
 		MuzzlePalette: d2keffect
 	WithSpriteTurret:

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
@@ -588,7 +588,7 @@ ordos_autogunturret:
 		LocalOffset: 600,-100,500, 600,100,500
 		CasingWeapon: generic_bullet_casing
 		CasingSpawnLocalOffset: 100,-100,500, 100,100,500
-		CasingTargetOffset: 0,-900,0, 0,900,0
+		CasingTargetOffset: -900,-100,0, -900,100,0
 		MuzzleSequence: muzzle
 		MuzzlePalette: d2keffect
 	WithSpriteTurret:

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1016,7 +1016,7 @@ ordos_autogunturret:
 	Inherits: ^Warhead_Bullet_Light
 	Inherits@2: ^Warhead_Bullet_Medium
 	Inherits@3: ^Warhead_CannonHE_Heavy
-	Inherits@4: ^Projectile_Shell_Heavy
+	Inherits@4: ^Projectile_Bullet_Medium
 	Inherits@5: ^Effect_CannonHE_Heavy
 	ReloadDelay: 22
 	Burst: 4
@@ -1025,6 +1025,18 @@ ordos_autogunturret:
 	-Report:
 	StartBurstReport: autoguntrt.wav
 	ValidTargets: Ground, Water, Air
+	Projectile: Bullet
+		-Image:
+		ProjectileStreakLength: 1536
+		ProjectileStreakLengthVariation: 384
+		ProjectileStreakWidth: 32
+		ProjectileStreakColor: FFA32B
+		ContrailLength: 0
+		Speed: 4000
+	Warhead@Effect:
+		Explosions: piffs
+	Warhead@EffectWater:
+		Explosions: water_piffs
 	Warhead@CannonHE_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
@@ -349,7 +349,7 @@ yuri_gatlingcannon:
 		PauseOnCondition: lowpower || disabled
 	Armament@1:
 		Name: primary
-		Weapon: RA2GattlingMG1
+		Weapon: YuriGatlingCannonMG1
 		PauseOnCondition: gatling
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle
@@ -359,7 +359,7 @@ yuri_gatlingcannon:
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@2:
 		Name: primary
-		Weapon: RA2GattlingMG2
+		Weapon: YuriGatlingCannonMG2
 		PauseOnCondition: gatling != 1
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle-1
@@ -369,7 +369,7 @@ yuri_gatlingcannon:
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@3:
 		Name: primary
-		Weapon: RA2GattlingMG3
+		Weapon: YuriGatlingCannonMG3
 		PauseOnCondition: gatling < 2
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle-2
@@ -379,7 +379,7 @@ yuri_gatlingcannon:
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@1AA:
 		Name: secondary
-		Weapon: RA2GattlingMG1_AA
+		Weapon: YuriGatlingCannonMG1_AA
 		PauseOnCondition: gatling
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle
@@ -389,7 +389,7 @@ yuri_gatlingcannon:
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@2AA:
 		Name: secondary
-		Weapon: RA2GattlingMG2_AA
+		Weapon: YuriGatlingCannonMG2_AA
 		PauseOnCondition: gatling != 1
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle-1
@@ -399,7 +399,7 @@ yuri_gatlingcannon:
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@3AA:
 		Name: secondary
-		Weapon: RA2GattlingMG3_AA
+		Weapon: YuriGatlingCannonMG3_AA
 		PauseOnCondition: gatling < 2
 		LocalOffset: 500,140,400, 500,-150,400
 		MuzzleSequence: muzzle-2
@@ -416,7 +416,7 @@ yuri_gatlingcannon:
 		Armaments: secondary
 	WithMuzzleOverlay:
 	WithMuzzleSmoke:
-		Weapons: RA2GattlingMG1, RA2GattlingMG2, RA2GattlingMG3, RA2GattlingMG1_AA, RA2GattlingMG2_AA, RA2GattlingMG3_AA
+		Weapons: YuriGatlingCannonMG1, YuriGatlingCannonMG2, YuriGatlingCannonMG3, YuriGatlingCannonMG1_AA, YuriGatlingCannonMG2_AA, YuriGatlingCannonMG3_AA
 	BodyOrientation:
 		QuantizedFacings: 16
 	WithVoxelTurret:

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
@@ -664,6 +664,31 @@ YRBoomerTorpedo:
 		ExplosionPalette: ra2effect
 		ImpactSounds: gexpwasa.wav
 
+^YuriGatlingCannonProjectileStreak:
+	Projectile: Bullet
+		Image:
+		ProjectileStreakLength: 1536
+		ProjectileStreakLengthVariation: 384
+		ProjectileStreakWidth: 32
+		ProjectileStreakColor: FFA32B
+		ContrailLength: 0
+
+YuriGatlingCannonMG1:
+	Inherits: RA2GattlingMG1
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
+
+YuriGatlingCannonMG1_AA:
+	Inherits: RA2GattlingMG1_AA
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
+
+YuriGatlingCannonMG2:
+	Inherits: RA2GattlingMG2
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
+
+YuriGatlingCannonMG2_AA:
+	Inherits: RA2GattlingMG2_AA
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
+
 RA2GattlingMG3:
 	Inherits: RA2GattlingMG1
 	Range: 5500
@@ -686,6 +711,14 @@ RA2GattlingMG3_AA:
 	Warhead@Bullet_Medium_Percentage: HealthPercentageDamage
 		ValidTargets: Air
 		Damage: 2
+
+YuriGatlingCannonMG3:
+	Inherits: RA2GattlingMG3
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
+
+YuriGatlingCannonMG3_AA:
+	Inherits: RA2GattlingMG3_AA
+	Inherits@ProjectileStreak: ^YuriGatlingCannonProjectileStreak
 
 RA2GattlingInf:
 	Inherits: ^RA2SmallArms


### PR DESCRIPTION
## Engine dependency

Pins the engine to merged cameo-mod/OpenRA#93 (`f7540efea90179998cffde8547f42f2c6b6d5cae`).

## Summary

- restore the Ordos/Harkonnen Autogun Turret to a bullet projectile after the weapon 3-way split
- use a short orange streak that moves with the projectile, with the inherited contrail and `50CAL` sprite disabled
- restore the historical small `piffs`/`water_piffs` impact visuals while retaining the recovered impact sounds
- eject Ordos/Harkonnen Autogun casings toward the rear of the turret
- give all three ground and three anti-air Yuri Gatling Cannon stages turret-specific moving streaks without changing the Gatling Tank or Gatling Trooper

## Root cause

The 3-way weapon split removed the old `^SmallArms` and `^Chaingun` inheritance from `ordos_autogunturret` while leaving the heavy shell projectile/effect. This changed both the visible projectile and the resolved ground impact from the old small bullet effect to a large cannon explosion.

Conventional contrails were not suitable for these high-speed rounds: tick-based trails either became long stationary lines or disappeared. The engine dependency adds a projectile-attached streak that interpolates between simulation ticks and vanishes at impact.

## Validation

- `git diff --check`
- `tools/preflight-build.ps1`
- `./make all` — 0 warnings, 0 errors
- verified the rebuilt `OpenRA.Mods.Common.dll` contains the moving-streak implementation
- loaded Cameo rules and `debug.oramap` headlessly from a clean upstream-based worktree
- runtime-tested the D2k Autogun Turret and all Yuri Gatling Cannon firing stages
