### PR TITLE
Improve bullet casing ejection

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
@@ -355,7 +355,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@2:
 		Name: primary
@@ -365,7 +365,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle-1
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@3:
 		Name: primary
@@ -375,7 +375,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle-2
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@1AA:
 		Name: secondary
@@ -385,7 +385,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@2AA:
 		Name: secondary
@@ -395,7 +395,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle-1
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	Armament@3AA:
 		Name: secondary
@@ -405,7 +405,7 @@ yuri_gatlingcannon:
 		MuzzleSequence: muzzle-2
 		MuzzlePalette: ra2effect
 		CasingWeapon: generic_bullet_casing
-		CasingSpawnLocalOffset: 250,140,400, 250,-150,400
+		CasingSpawnLocalOffset: 100,140,400, 100,-150,400
 		CasingTargetOffset: 0,740,0, 0,-750,0
 	RangeMultiplier@GatlingBuff:
 		Modifier: 150

--- a/mods/cameo/weapons/weapons.yaml
+++ b/mods/cameo/weapons/weapons.yaml
@@ -11981,9 +11981,10 @@ SpiceExplosion:
 generic_bullet_casing:
 	Range: 1c0
 	Projectile: Bullet
-		Speed: 48
+		Speed: 24, 72
 		Blockable: false
-		LaunchAngle: 100
+		LaunchAngle: 55, 145
+		Inaccuracy: 384
 		Image: generic_bullet_casing
 		Sequences: idle
 		Palette: d2keffect


### PR DESCRIPTION
## What changed

- Randomize the shared bullet-casing ejection speed, launch angle, and landing point.
- Move the Yuri Gatling Cannon casing spawn point farther behind the muzzle for all ground and anti-air firing stages.
- Preserve every actor's existing casing ejection direction, including the rearward Ordos and Harkonnen Autogun offsets.

## Why

The previous shared casing projectile used one fixed speed and launch angle, making repeated ejections look mechanically identical. The Yuri Gatling Cannon also spawned its casings too far forward along the barrels.

## Impact

Actors using `generic_bullet_casing` now produce a more natural spread while retaining their actor-specific direction. Yuri Gatling Cannon casings originate closer to the weapon body.

## Validation

- Approved through in-game visual testing.
- `git diff --check`
- Confirmed the PR contains only the two intended YAML files.
