### PR TITLE
Scale veterancy and repair decorations with zoom

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -302,7 +302,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 	-ActorPreviewPlaceBuildingPreview:
 	D2kActorPreviewPlaceBuildingPreview:

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -302,6 +302,8 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
+		Scale: 0.25
+		ScaleWithZoom: True
 	-ActorPreviewPlaceBuildingPreview:
 	D2kActorPreviewPlaceBuildingPreview:
 		TilesetPalettes:

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/templates.yaml
@@ -34,30 +34,40 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 1 && !rank-elite
 	WithDecoration@RANK-2:
 		Image: ra2rank
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 2 && !rank-elite
 	WithDecoration@RANK-3:
 		Image: ra2rank
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 3 && !rank-elite
 	WithDecoration@RANK-4:
 		Image: ra2rank
 		Sequence: rank-veteran-4
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 4 && !rank-elite
 	WithDecoration@RANK-ELITE:
 		Image: ra2rank
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-elite
 	DamageMultiplier@RANK-1:
 		Modifier: 90
@@ -691,4 +701,3 @@
 	ActorStatValues:
 		Upgrades: yuri_upgrade_geneticmodificationboost
 	ProvidesPrerequisite:
-

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/templates.yaml
@@ -34,7 +34,7 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 1 && !rank-elite
 	WithDecoration@RANK-2:
@@ -42,7 +42,7 @@
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 2 && !rank-elite
 	WithDecoration@RANK-3:
@@ -50,7 +50,7 @@
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 3 && !rank-elite
 	WithDecoration@RANK-4:
@@ -58,7 +58,7 @@
 		Sequence: rank-veteran-4
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 4 && !rank-elite
 	WithDecoration@RANK-ELITE:
@@ -66,7 +66,7 @@
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-elite
 	DamageMultiplier@RANK-1:

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -333,24 +333,32 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 1 && !rank-elite
 	WithDecoration@RANK-2:
 		Image: rank
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 2 && !rank-elite
 	WithDecoration@RANK-3:
 		Image: rank
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 3 && !rank-elite
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: rank-elite
 	ExternalCondition@crate-armor:
 		Condition: crate-armor
@@ -3963,6 +3971,8 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
+		Scale: 0.25
+		ScaleWithZoom: True
 	GrantCondition@disable:
 		Condition: disabled
 		RequiresCondition: (empdisable || superfreeze || chronobeamed || diskdrain || being-captured) && !invulnerability
@@ -4144,6 +4154,8 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
+		Scale: 0.25
+		ScaleWithZoom: True
 	GpsDot:
 		String: Forward
 	RenderSprites:
@@ -6133,24 +6145,32 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 1 && !city-elite
 	WithDecoration@RANK-2:
 		Image: rank
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 2 && !city-elite
 	WithDecoration@RANK-3:
 		Image: rank
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 3 && !city-elite
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
+		Scale: 0.25
+		ScaleWithZoom: True
 		RequiresCondition: city-elite
 
 ^PowerMultiplier:

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -333,7 +333,7 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 1 && !rank-elite
 	WithDecoration@RANK-2:
@@ -341,7 +341,7 @@
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 2 && !rank-elite
 	WithDecoration@RANK-3:
@@ -349,7 +349,7 @@
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-veteran == 3 && !rank-elite
 	WithDecoration@RANK-ELITE:
@@ -357,7 +357,7 @@
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: rank-elite
 	ExternalCondition@crate-armor:
@@ -3971,7 +3971,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 	GrantCondition@disable:
 		Condition: disabled
@@ -4154,7 +4154,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 	GpsDot:
 		String: Forward
@@ -6145,7 +6145,7 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 1 && !city-elite
 	WithDecoration@RANK-2:
@@ -6153,7 +6153,7 @@
 		Sequence: rank-veteran-2
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 2 && !city-elite
 	WithDecoration@RANK-3:
@@ -6161,7 +6161,7 @@
 		Sequence: rank-veteran-3
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: city-veteran == 3 && !city-elite
 	WithDecoration@RANK-ELITE:
@@ -6169,7 +6169,7 @@
 		Sequence: rank-elite
 		Palette: effect
 		Position: BottomRight
-		Scale: 0.25
+		Scale: 0.50
 		ScaleWithZoom: True
 		RequiresCondition: city-elite
 


### PR DESCRIPTION
## Summary

- set generic, Red Alert 2, and city veterancy badges to a base scale of 0.50
- set standard and Dune 2000 building repair wrenches to a base scale of 0.50
- scale both decorations with the player's current viewport zoom
- confirm inherited settings for TD GDI, RA2, and D2K actors

## Dependency

Depends on cameo-mod/OpenRA#94. This PR intentionally does not update `ENGINE_VERSION`; the engine pin should be updated after the engine PR lands.

## Validation

- Cameo preflight passed
- `./make all` completed with 0 warnings and 0 errors
- direct Cameo map-hash completed successfully
- resolved-rules checks confirmed:
  - TD GDI veterancy decorations
  - RA2 veterancy decorations
  - D2K repair decoration
- `git diff --check` passed

## Visual testing

Requires a full game restart and in-game review at multiple zoom levels.
