### PR TITLE
Reduce building repair decoration scale

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -310,7 +310,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.50
+		Scale: 0.25
 		ScaleWithZoom: True
 	-ActorPreviewPlaceBuildingPreview:
 	D2kActorPreviewPlaceBuildingPreview:

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -3969,7 +3969,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.50
+		Scale: 0.25
 		ScaleWithZoom: True
 	GrantCondition@disable:
 		Condition: disabled
@@ -4152,7 +4152,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 0.50
+		Scale: 0.25
 		ScaleWithZoom: True
 	GpsDot:
 		String: Forward


### PR DESCRIPTION
## Summary

- reduce generic building repair decorations from `Scale: 0.50` to `0.25`
- apply the same repair-icon exception to D2K buildings
- keep repair icons zoom-aware

## Why

Generic sprite decorations now default to zoom-aware half scale in cameo-mod/OpenRA#95. Building repair icons are intentionally smaller than other status and upgrade decorations, so Cameo keeps an explicit quarter-scale override.

Depends on cameo-mod/OpenRA#95.

## Validation

- YAML `git diff --check` passed
- engine-pin preflight passed
- full `./make all` build passed with 0 warnings and 0 errors against the corresponding engine change
- no engine pin change is included

Runtime visual confirmation remains a full Cameo restart and in-game zoom check.
