### PR TITLE
Add resource regrowth lobby option

### DIFF
--- a/OpenRA.Mods.Cameo/Traits/World/ResourceRegrowth.cs
+++ b/OpenRA.Mods.Cameo/Traits/World/ResourceRegrowth.cs
@@ -1,0 +1,117 @@
+#region Copyright & License Information
+/*
+ * Cameo mod
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits
+{
+	[TraitLocation(SystemActors.World)]
+	[Desc("Adds the synchronized resource regrowth rate dropdown to the lobby.")]
+	public class ResourceRegrowthInfo : TraitInfo, ILobbyOptions
+	{
+		const string OptionId = "resourceregrowth";
+
+		[FluentReference]
+		public readonly string DropdownLabel = "dropdown_resource_regrowth.label";
+
+		[FluentReference]
+		public readonly string DropdownDescription = "dropdown_resource_regrowth.description";
+
+		public readonly bool DropdownLocked = false;
+		public readonly bool DropdownVisible = true;
+		public readonly int DropdownDisplayOrder = 22;
+
+		static readonly Dictionary<string, string> Values = new()
+		{
+			{ "off", "dropdown_resource_regrowth.choice-off" },
+			{ "half", "dropdown_resource_regrowth.choice-half" },
+			{ "normal", "dropdown_resource_regrowth.choice-normal" },
+			{ "twice", "dropdown_resource_regrowth.choice-twice" },
+			{ "4x", "dropdown_resource_regrowth.choice-4x" }
+		};
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
+		{
+			yield return new LobbyOption(map, OptionId, DropdownLabel, DropdownDescription,
+				DropdownVisible, DropdownDisplayOrder, Values, "normal", DropdownLocked);
+		}
+
+		public override object Create(ActorInitializer init) { return new ResourceRegrowth(); }
+
+		public static int RateUnits(World world)
+		{
+			return world.LobbyInfo.GlobalSettings.OptionOrDefault(OptionId, "normal") switch
+			{
+				"off" => 0,
+				"half" => 1,
+				"twice" => 4,
+				"4x" => 8,
+				_ => 2
+			};
+		}
+	}
+
+	public class ResourceRegrowth { }
+
+	[Desc("Spreads a resource at the lobby-selected resource regrowth rate.")]
+	public class LobbyScaledSeedsResourceInfo : ConditionalTraitInfo
+	{
+		public readonly int Interval = 75;
+		public readonly string ResourceType = "Tiberium";
+		public readonly int MaxRange = 100;
+
+		public override object Create(ActorInitializer init) { return new LobbyScaledSeedsResource(init.Self, this); }
+	}
+
+	public class LobbyScaledSeedsResource : ConditionalTrait<LobbyScaledSeedsResourceInfo>, ITick, ISeedableResource
+	{
+		readonly LobbyScaledSeedsResourceInfo info;
+		readonly IResourceLayer resourceLayer;
+		readonly int threshold;
+		readonly int rateUnits;
+
+		[VerifySync]
+		int progress;
+
+		public LobbyScaledSeedsResource(Actor self, LobbyScaledSeedsResourceInfo info)
+			: base(info)
+		{
+			this.info = info;
+			resourceLayer = self.World.WorldActor.Trait<IResourceLayer>();
+			threshold = info.Interval * 2;
+			rateUnits = ResourceRegrowthInfo.RateUnits(self.World);
+			progress = threshold - rateUnits;
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitDisabled || rateUnits == 0)
+				return;
+
+			progress += rateUnits;
+			if (progress < threshold)
+				return;
+
+			progress -= threshold;
+			Seed(self);
+		}
+
+		public void Seed(Actor self)
+		{
+			var cell = Util.RandomWalk(self.Location, self.World.SharedRandom)
+				.Take(info.MaxRange)
+				.SkipWhile(p => resourceLayer.GetResource(p).Type == info.ResourceType && !resourceLayer.CanAddResource(info.ResourceType, p))
+				.Cast<CPos?>().FirstOrDefault();
+
+			if (cell != null && resourceLayer.CanAddResource(info.ResourceType, cell.Value))
+				resourceLayer.AddResource(info.ResourceType, cell.Value);
+		}
+	}
+}

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -11,6 +11,15 @@ dropdown_weather =
    .choice-none = None
    .choice-weather = Enabled
 
+dropdown_resource_regrowth =
+   .label = Resource Regrowth
+   .description = Controls how quickly blossom trees and resource mines spread resources.
+   .choice-off = No Growth
+   .choice-half = 0.5x (slower)
+   .choice-normal = Normal Growth
+   .choice-twice = 2x (faster)
+   .choice-4x = 4x (even faster)
+
 checkbox_crates =
    .label = Crates
    .description = Collect crates with units to receive random bonuses.

--- a/mods/cameo/rules/misc.yaml
+++ b/mods/cameo/rules/misc.yaml
@@ -793,7 +793,7 @@ MINE:
 	Inherits@1: ^TibTree
 	Tooltip:
 		Name: Ore Mine
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: Ore
 		Interval: 100
 		MaxRange: 200
@@ -813,7 +813,7 @@ MINE:
 
 SPLIT2:
 	Inherits: ^TibTree
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: Tiberium
 		Interval: 95
 		MaxRange: 180
@@ -833,7 +833,7 @@ SPLIT3:
 	Inherits: ^TibTree
 	RenderSprites:
 		Image: split2
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: Tiberium
 		Interval: 95
 		MaxRange: 180
@@ -853,7 +853,7 @@ SPLITBLUE:
 	Inherits: ^TibTree
 	RenderSprites:
 		Image: split3
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: BlueTiberium
 		Interval: 90
 		MaxRange: 160
@@ -873,7 +873,7 @@ SPLITBLUE:
 
 SPLITRED:
 	Inherits: ^TibTree
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: RedTiberium
 		Interval: 85
 		MaxRange: 140
@@ -893,7 +893,7 @@ SPLITRED:
 
 SPLITGOLD:
 	Inherits: ^TibTree
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: GoldTiberium
 		Interval: 80
 		MaxRange: 120
@@ -915,7 +915,7 @@ GMINE:
 	Inherits@1: ^TibTree
 	Tooltip:
 		Name: Gem Mine
-	SeedsResource:
+	LobbyScaledSeedsResource:
 		ResourceType: Gems
 		Interval: 75
 		MaxRange: 100

--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -941,6 +941,7 @@ World:
 			SNOW: weather-blizzard
 			RA_SNOW: weather-blizzard
 			WINTER: weather-blizzard
+	ResourceRegrowth:
 	WeatherOverlay@RAIN:
 		RequiresCondition: weather-rain
 		InitialParticlePercentage: 0


### PR DESCRIPTION
## What changed

- adds a synchronized Resource Regrowth lobby dropdown
- provides No Growth, 0.5x (slower), Normal Growth, 2x (faster), and 4x (even faster)
- applies the selected rate to ore mines, gem mines, and green, blue, red, and gold Tiberium blossom trees
- preserves each source's existing interval at Normal Growth

## Why

Players requested control over resource regeneration speed so matches can disable regrowth or tune it for slower and more resource-rich games.

## Implementation

The new Cameo trait reads the synchronized global lobby value and uses a deterministic accumulator. This keeps half and multiplied rates exact over time even when the original interval does not divide evenly. Other resource generators remain unchanged.

## Validation

- `tools\preflight-build.ps1` passed in the main checkout
- `./make all` passed with 0 warnings and 0 errors
- verified the new trait marker in `engine\bin\OpenRA.Mods.Cameo.dll`
- `git diff --check` passed
- clean PR worktree contains only the four intended files and matches the built source byte-for-byte

In-game lobby presentation and gameplay pacing still require restart/testing.