### PR TITLE
Update engine pin for global decoration scaling

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="cameo"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="26cab57a7e628a2e14c226a7fd04b7d2b49eed40"
+ENGINE_VERSION="1bc935bf86383f08c10b246c9e5171fbb9ceb4c9"
 
 ##############################################################################
 # Packaging


### PR DESCRIPTION
## Summary

- update the Cameo engine pin to `1bc935bf86383f08c10b246c9e5171fbb9ceb4c9`
- pick up the merged global zoom-aware half-scale defaults from cameo-mod/OpenRA#95
- retain the quarter-scale building repair exception merged in #253

## Validation

- confirmed the full SHA is contained by `upstream/cameo-engine`
- confirmed the GitHub engine archive returns HTTP 200
- updated local `engine/VERSION` to the same SHA for verification
- engine-pin preflight passed
- full `./make all` build passed with 0 warnings and 0 errors
- forced a fresh `OpenRA.Mods.Common.dll` build and confirmed its timestamp advanced
- found the unique decoration-scaling marker in the built DLL
- launched the repository Cameo instance and confirmed it remained alive and responsive for 90 seconds
- closed the game cleanly without forced termination

## Scope

The PR changes only `mod.config`.
