### PR TITLE
Reduce building repair decoration scale to 0.40

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -310,7 +310,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 1.00
+		Scale: 0.40
 		ScaleWithZoom: True
 	-ActorPreviewPlaceBuildingPreview:
 	D2kActorPreviewPlaceBuildingPreview:

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -3971,7 +3971,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 1.00
+		Scale: 0.40
 		ScaleWithZoom: True
 	GrantCondition@disable:
 		Condition: disabled
@@ -4154,7 +4154,7 @@
 		Position: Center
 		Palette: player
 		IsPlayerPalette: True
-		Scale: 1.00
+		Scale: 0.40
 		ScaleWithZoom: True
 	GpsDot:
 		String: Forward


### PR DESCRIPTION
## What changed

- Reduced the zoom-aware building repair decoration scale from `1.00` to `0.40`.
- Updated the shared default, RA-style default, and D2K shared template consistently.
- Preserved the existing repair-decoration exception that does not declare an explicit scale.

## Why

The `1.00` value introduced by `a2397cc4a` renders the repair decoration too large in game. A `0.40` scale keeps it visible while reducing the obstruction.

## Validation

- Confirmed the diff contains exactly three `Scale` changes across two YAML files.
- `git diff --check` passes.
- Pure YAML change; no engine rebuild required. In-game visual review is still required.