### PR TITLE
Shorten D2K Starport batch timing

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/faction.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/faction.yaml
@@ -30,8 +30,8 @@ Player:
 		BuildDurationModifier: 50
 		ParallelProductionSlots: 3
 		InfiniteBuildLimit: 10
-		CollectionDelay: 1500
-		DispatchDelay: 750
+		CollectionDelay: 1000
+		DispatchDelay: 500
 		MaxBatchSize: 20
 		MaxPendingBatches: 3
 	ExternalCondition@BuildingsOwned:


### PR DESCRIPTION
## Summary

- shorten the D2K Starport collection window from 60 seconds to 40 seconds
- shorten the dispatch delay from 30 seconds to 20 seconds
- consequently shorten the shared post-delivery dispatch cooldown to 20 seconds

## Why

The current 60-second collection and 30-second dispatch phases make Starport deliveries take too long before the frigate is sent. A 40+20 timing keeps the rolling-batch behavior while reducing the fixed wait before delivery.

## Validation

- `git diff --check`
- confirmed the PR contains only `mods/cameo/ContentPacks/D2k/Shared/yaml/faction.yaml`

YAML-only change; no engine build required. Runtime timing should be checked after restarting Cameo.
