### PR TITLE
Increase shield hit opacity to 75 percent

### DIFF
--- a/docs/design/HEX_SHIELD_VISUALS.md
+++ b/docs/design/HEX_SHIELD_VISUALS.md
@@ -12,7 +12,7 @@ The retained visual decisions are:
 - camera-correct dome for buildings and defenses;
 - directional oval as an explicit geometry opt-in for elongated aircraft;
 - fixed faction colors: default/Protoss blue, Ixian silver, Yuri indigo, Consortium cyan;
-- Indexed8 art with transparent index 0 and 25% idle / 50% hit palettes.
+- Indexed8 art with transparent index 0 and 25% idle / 75% hit palettes.
 
 Actor-specific shield sizing is forbidden. Concrete actors must not define `Sequence` or
 `StartSequence` on the shield overlays. A concrete actor may override only `Image` when it

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/templates.yaml
@@ -140,7 +140,7 @@
 		Palette: ixianhexshield25
 		IsPlayerPalette: false
 	WithIdleOverlay@shield_damage:
-		Palette: ixianhexshield50
+		Palette: ixianhexshield75
 		IsPlayerPalette: false
 	GrantConditionOnPrerequisite@ixian_upgrade_advancedixiantechnology:
 		Condition: ixian_upgrade_advancedixiantechnology

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/templates.yaml
@@ -72,7 +72,7 @@
 		Palette: yurihexshield25
 		IsPlayerPalette: false
 	WithIdleOverlay@shield_damage:
-		Palette: yurihexshield50
+		Palette: yurihexshield75
 		IsPlayerPalette: false
 	DamageMultiplier@yuri_doctrine_psionicvehicleshields:
 		Modifier: 75

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Shared/yaml/templates.yaml
@@ -477,7 +477,7 @@
 		Palette: consortiumhexshield25
 		IsPlayerPalette: false
 	WithIdleOverlay@shield_damage:
-		Palette: consortiumhexshield50
+		Palette: consortiumhexshield75
 		IsPlayerPalette: false
 	DamageMultiplier@steelconsortium_upgrade_naniteinfusion:
 		RequiresCondition: steelconsortium_upgrade_naniteinfusion

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2495,7 +2495,7 @@
 	WithIdleOverlay@shield_damage:
 		Image: hexshield_sphere
 		Sequence: vehicle-standard
-		Palette: hexshield50
+		Palette: hexshield75
 		IsPlayerPalette: false
 	# Muzzle-flash glow for every ground vehicle; gated per-armament by MuzzleSequence, so only
 	# td_nod_gunturret/MG units flash (harvesters, MCVs, transports without a muzzle stay dark). Ships opt out
@@ -2843,7 +2843,7 @@
 	WithIdleOverlay@shield_damage:
 		Image: hexshield_sphere
 		Sequence: aircraft-standard
-		Palette: hexshield50
+		Palette: hexshield75
 		IsPlayerPalette: false
 	Inherits@ext: ^ExternalConditions
 	Inherits@IC: ^IronCurtainable
@@ -3459,7 +3459,7 @@
 	WithIdleOverlay@shield_damage:
 		Image: hexshield_infantry
 		Sequence: infantry-standard
-		Palette: hexshield50
+		Palette: hexshield75
 		IsPlayerPalette: false
 	WithIdleOverlay@shrouded:
 		Image: shrouded_overlay_small
@@ -7467,7 +7467,7 @@ CPQDEBUGDUMMY:
 		IsDecoration: True
 	WithIdleOverlay@shield_damage:
 		RequiresCondition: !disabled && shielded && shieldhit
-		Palette: hexshield50
+		Palette: hexshield75
 		IsPlayerPalette: false
 		IsDecoration: True
 	Targetable@Shielded:

--- a/mods/cameo/rules/palettes.yaml
+++ b/mods/cameo/rules/palettes.yaml
@@ -159,10 +159,10 @@
 		Name: hexshield25
 		BasePalette: hexshield
 		Alpha: 0.25
-	PaletteFromPaletteWithAlpha@hexshield50:
-		Name: hexshield50
+	PaletteFromPaletteWithAlpha@hexshield75:
+		Name: hexshield75
 		BasePalette: hexshield
-		Alpha: 0.5
+		Alpha: 0.75
 	FixedColorPalette@protosshexshield:
 		Base: playershieldbase
 		Name: protosshexshield
@@ -172,10 +172,10 @@
 		Name: protosshexshield25
 		BasePalette: protosshexshield
 		Alpha: 0.25
-	PaletteFromPaletteWithAlpha@protosshexshield50:
-		Name: protosshexshield50
+	PaletteFromPaletteWithAlpha@protosshexshield75:
+		Name: protosshexshield75
 		BasePalette: protosshexshield
-		Alpha: 0.5
+		Alpha: 0.75
 	FixedColorPalette@ixianhexshield:
 		Base: playershieldbase
 		Name: ixianhexshield
@@ -185,10 +185,10 @@
 		Name: ixianhexshield25
 		BasePalette: ixianhexshield
 		Alpha: 0.25
-	PaletteFromPaletteWithAlpha@ixianhexshield50:
-		Name: ixianhexshield50
+	PaletteFromPaletteWithAlpha@ixianhexshield75:
+		Name: ixianhexshield75
 		BasePalette: ixianhexshield
-		Alpha: 0.5
+		Alpha: 0.75
 	FixedColorPalette@consortiumhexshield:
 		Base: playershieldbase
 		Name: consortiumhexshield
@@ -198,10 +198,10 @@
 		Name: consortiumhexshield25
 		BasePalette: consortiumhexshield
 		Alpha: 0.25
-	PaletteFromPaletteWithAlpha@consortiumhexshield50:
-		Name: consortiumhexshield50
+	PaletteFromPaletteWithAlpha@consortiumhexshield75:
+		Name: consortiumhexshield75
 		BasePalette: consortiumhexshield
-		Alpha: 0.5
+		Alpha: 0.75
 	FixedColorPalette@yurihexshield:
 		Base: playershieldbase
 		Name: yurihexshield
@@ -211,10 +211,10 @@
 		Name: yurihexshield25
 		BasePalette: yurihexshield
 		Alpha: 0.25
-	PaletteFromPaletteWithAlpha@yurihexshield50:
-		Name: yurihexshield50
+	PaletteFromPaletteWithAlpha@yurihexshield75:
+		Name: yurihexshield75
 		BasePalette: yurihexshield
-		Alpha: 0.5
+		Alpha: 0.75
 	PaletteFromFile@staticterrain-jungle:
 		Name: staticterrain
 		Tileset: JUNGLE

--- a/mods/cameo/rules/starcraft.yaml
+++ b/mods/cameo/rules/starcraft.yaml
@@ -705,7 +705,7 @@ SCSCIENCEFACILITYM:
 		Palette: protosshexshield25
 		IsPlayerPalette: false
 	WithIdleOverlay@shield_damage:
-		Palette: protosshexshield50
+		Palette: protosshexshield75
 		IsPlayerPalette: false
 	Shielded:
 		InitialPercentageStrength: 100

--- a/tools/audit/audit_hex_shield_routing.py
+++ b/tools/audit/audit_hex_shield_routing.py
@@ -32,11 +32,11 @@ SHAPE_SEQUENCES = {
 ALLOWED_ROUTES.update(("hexshield_dome", sequence) for sequence in SHAPE_SEQUENCES.values())
 
 ALLOWED_PALETTES = {
-    ("hexshield25", "hexshield50"),
-    ("protosshexshield25", "protosshexshield50"),
-    ("ixianhexshield25", "ixianhexshield50"),
-    ("yurihexshield25", "yurihexshield50"),
-    ("consortiumhexshield25", "consortiumhexshield50"),
+    ("hexshield25", "hexshield75"),
+    ("protosshexshield25", "protosshexshield75"),
+    ("ixianhexshield25", "ixianhexshield75"),
+    ("yurihexshield25", "yurihexshield75"),
+    ("consortiumhexshield25", "consortiumhexshield75"),
 }
 
 


### PR DESCRIPTION
## Summary

- increase recolorable shield hit opacity from 50% to 75%
- rename all fixed hit palettes from `*hexshield50` to `*hexshield75`
- migrate default, Protoss, Ixian, Yuri, and Consortium consumers
- retain idle shields at 25%

## Validation

- exact 50% versus 75% Scrin Reactor preview reviewed and approved
- `audit_hex_shield_routing.py`: 1,603 shield receivers, 0 errors
- all five approved fixed idle/hit palette pairs resolve
- no stale `hexshield50` references remain
- Python compilation and `git diff --check` pass

YAML/documentation/audit only; no build required.