### PR TITLE
Fix Gatling spin-up range oscillation

### DIFF
--- a/OpenRA.Mods.Cameo.Test/SynchronizesPhysicalStateWithConditionTest.cs
+++ b/OpenRA.Mods.Cameo.Test/SynchronizesPhysicalStateWithConditionTest.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using NUnit.Framework;
+using OpenRA.Mods.Cameo.Traits;
+
+namespace OpenRA.Mods.Cameo.Test
+{
+	[TestFixture]
+	public sealed class SynchronizesPhysicalStateWithConditionTest
+	{
+		[TestCase(0, 0)]
+		[TestCase(1, 10)]
+		[TestCase(5, 50)]
+		[TestCase(10, 100)]
+		public void ConditionLevelMapsDirectlyToSpinState(int conditionLevel, int expectedState)
+		{
+			Assert.That(
+				SynchronizesPhysicalStateWithCondition.ValueForConditionLevel(conditionLevel, 0, 10),
+				Is.EqualTo(expectedState));
+		}
+
+		[Test]
+		public void MissingOrNegativeConditionCannotCreateSpin()
+		{
+			Assert.That(SynchronizesPhysicalStateWithCondition.ValueForConditionLevel(-1, 0, 10), Is.Zero);
+		}
+	}
+}

--- a/OpenRA.Mods.Cameo/Traits/ModifiesCombatProportionalToPhysicalState.cs
+++ b/OpenRA.Mods.Cameo/Traits/ModifiesCombatProportionalToPhysicalState.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cameo.Traits
 {
-	[Desc("Scales reload, range, speed and firepower with a PhysicalState meter.",
+	[Desc("Scales reload, range, movement/turn speed, firepower, and damage taken with a PhysicalState meter.",
 		"The framework's missing half: every stock proportional trait only makes things WORSE",
 		"(SlowsProportionalToPhysicalState, DamageMultiplierProportionalToPhysicalState), so a",
 		"spin-UP meter had no way to express itself. This one is signed — put the better number",
@@ -50,6 +50,18 @@ namespace OpenRA.Mods.Cameo.Traits
 
 		[Desc("Movement-speed modifier at the meter's high end (percentage).")]
 		public readonly int SpeedTo = 100;
+
+		[Desc("Body turn-speed modifier at the meter's low end (percentage).")]
+		public readonly int TurnSpeedFrom = 100;
+
+		[Desc("Body turn-speed modifier at the meter's high end (percentage).")]
+		public readonly int TurnSpeedTo = 100;
+
+		[Desc("Turret turn-speed modifier at the meter's low end (percentage).")]
+		public readonly int TurretTurnSpeedFrom = 100;
+
+		[Desc("Turret turn-speed modifier at the meter's high end (percentage).")]
+		public readonly int TurretTurnSpeedTo = 100;
 
 		[Desc("Firepower modifier at the meter's low end (percentage).")]
 		public readonly int FirepowerFrom = 100;
@@ -89,7 +101,8 @@ namespace OpenRA.Mods.Cameo.Traits
 
 	public class ModifiesCombatProportionalToPhysicalState
 		: ConditionalTrait<ModifiesCombatProportionalToPhysicalStateInfo>,
-			IReloadModifier, IRangeModifier, ISpeedModifier, IFirepowerModifier,
+			IReloadModifier, IRangeModifier, ISpeedModifier, ITurnSpeedModifier,
+			ITurretTurnSpeedModifier, IFirepowerModifier,
 			IDamageModifier, INotifyPhysicalStateChanged
 	{
 		readonly PhysicalState physicalState;
@@ -97,6 +110,8 @@ namespace OpenRA.Mods.Cameo.Traits
 		int reload = 100;
 		int range = 100;
 		int speed = 100;
+		int turnSpeed = 100;
+		int turretTurnSpeed = 100;
 		int firepower = 100;
 		int damageTaken = 100;
 		int pitch = 100;
@@ -129,6 +144,8 @@ namespace OpenRA.Mods.Cameo.Traits
 			reload = Interpolate(Info.ReloadDelayFrom, Info.ReloadDelayTo, Intensity);
 			range = Interpolate(Info.RangeFrom, Info.RangeTo, Intensity);
 			speed = Interpolate(Info.SpeedFrom, Info.SpeedTo, Intensity);
+			turnSpeed = Interpolate(Info.TurnSpeedFrom, Info.TurnSpeedTo, Intensity);
+			turretTurnSpeed = Interpolate(Info.TurretTurnSpeedFrom, Info.TurretTurnSpeedTo, Intensity);
 			firepower = Interpolate(Info.FirepowerFrom, Info.FirepowerTo, Intensity);
 			damageTaken = Interpolate(Info.DamageTakenFrom, Info.DamageTakenTo, Intensity);
 			pitch = Interpolate(Info.PitchFrom, Info.PitchTo, Intensity);
@@ -179,6 +196,16 @@ namespace OpenRA.Mods.Cameo.Traits
 		int ISpeedModifier.GetSpeedModifier()
 		{
 			return IsTraitDisabled ? 100 : speed;
+		}
+
+		int ITurnSpeedModifier.GetTurnSpeedModifier()
+		{
+			return IsTraitDisabled ? 100 : turnSpeed;
+		}
+
+		int ITurretTurnSpeedModifier.GetTurretTurnSpeedModifier(string turretName)
+		{
+			return IsTraitDisabled ? 100 : turretTurnSpeed;
 		}
 
 		int IFirepowerModifier.GetFirepowerModifier(string armamentName)

--- a/OpenRA.Mods.Cameo/Traits/SynchronizesPhysicalStateWithCondition.cs
+++ b/OpenRA.Mods.Cameo/Traits/SynchronizesPhysicalStateWithCondition.cs
@@ -1,0 +1,81 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cameo.Traits
+{
+	[Desc("Synchronizes a PhysicalState value with the number of granted condition instances.")]
+	public class SynchronizesPhysicalStateWithConditionInfo : TraitInfo, Requires<PhysicalStateInfo>,
+		IObservesVariablesInfo, IRulesetLoaded
+	{
+		[FieldLoader.Require]
+		[ConsumedConditionReference]
+		[Desc("Condition whose instance count drives the PhysicalState.")]
+		public readonly string Condition = null;
+
+		[FieldLoader.Require]
+		[Desc("Name of the PhysicalState to update.")]
+		public readonly string PhysicalStateName = null;
+
+		[Desc("PhysicalState value contributed by each condition instance.")]
+		public readonly int ValuePerInstance = 1;
+
+		[Desc("PhysicalState value when no condition instances are granted.")]
+		public readonly int BaseValue = 0;
+
+		public override object Create(ActorInitializer init)
+		{
+			return new SynchronizesPhysicalStateWithCondition(init.Self, this);
+		}
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			if (ai.TraitInfos<PhysicalStateInfo>().Count(ps => ps.Name == PhysicalStateName) != 1)
+				throw new YamlException(
+					$"{nameof(SynchronizesPhysicalStateWithCondition)} requires exactly one PhysicalState with matching Name.");
+		}
+	}
+
+	public class SynchronizesPhysicalStateWithCondition : IObservesVariables
+	{
+		readonly SynchronizesPhysicalStateWithConditionInfo info;
+		readonly PhysicalState physicalState;
+
+		public SynchronizesPhysicalStateWithCondition(
+			Actor self, SynchronizesPhysicalStateWithConditionInfo info)
+		{
+			this.info = info;
+			physicalState = self.TraitsImplementing<PhysicalState>()
+				.Single(ps => ps.Name == info.PhysicalStateName);
+		}
+
+		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()
+		{
+			yield return new VariableObserver(ConditionsChanged, [info.Condition]);
+		}
+
+		void ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		{
+			conditions.TryGetValue(info.Condition, out var level);
+			physicalState.Value = ValueForConditionLevel(level, info.BaseValue, info.ValuePerInstance);
+		}
+
+		internal static int ValueForConditionLevel(int level, int baseValue, int valuePerInstance)
+		{
+			return checked(baseValue + Math.Max(0, level) * valuePerInstance);
+		}
+	}
+}

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -5803,21 +5803,23 @@
 	ExternalCondition@INVULNERABILITY:
 		Condition: invulnerability
 
-# W8 (2026-08-15) — the gatling spin-up, as a METER instead of a condition ladder.
+# W8 (2026-08-15) — the gatling spin-up, as a compact meter backed by the
+# existing condition ladder.
 # Replaces the three ^GatlingSpeedUp* templates, now deleted: 20 conditional
 # multipliers on the turret variant, 30 on the unit, 40 on the special unit, across
 # 43 actors — roughly 1300 trait objects — collapse into three traits per template
-# that move CONTINUOUSLY rather than in ten visible 5% steps.
+# whose value follows the ten condition stages.
 #
-# End-points reproduce the ladder EXACTLY, measured not assumed:
+# Rounded end-points preserve the previous ladder targets:
 #   reload  0.95^10 = 0.599 -> ReloadDelayTo 60   (lower = faster)
 #   range   1.02^10 = 1.219 -> RangeTo       122
 # The turret template has no speed term, so neither does this.
+# Intermediate stages retain the compact meter's linear interpolation; they are not
+# numerically identical to the old stack of compounded 95% / 102% modifier traits.
 #
-# The `gatling` condition is kept as the FILL TRIGGER rather than as ten thresholds:
-# GrantConditionOnAttack still counts shots, but only `>= 1` is read, so the elite
-# variant's faster stacking no longer needs a parallel ladder — it simply reaches the
-# trigger sooner and the meter does the rest.
+# The `gatling` condition count is the single source of truth for the meter. This keeps
+# normal/elite shot thresholds and staged decay while avoiding independent fill and
+# relaxation timers that can fight each other and make the range circle oscillate.
 ^GatlingSpinUpTurretBehavior:
 	PhysicalState@SpinUp:
 		Name: SpinUp
@@ -5825,15 +5827,10 @@
 		MaxValue: 100
 		RelaxedValue: 0
 		InitialValue: 0
-		RelaxationLinear: 10
-		RelaxationDelay: 30
-		RelaxationInterval: 1
-	ChangesPhysicalState@SpinUp:
+	SynchronizesPhysicalStateWithCondition@SpinUp:
+		Condition: gatling
 		PhysicalStateName: SpinUp
-		Amount: 10
-		Delay: 5
-		AffectedByModifiers: false
-		RequiresCondition: gatling >= 1
+		ValuePerInstance: 10
 	ModifiesCombatProportionalToPhysicalState@SpinUp:
 		PhysicalStateName: SpinUp
 		ReloadDelayFrom: 100
@@ -5872,6 +5869,10 @@
 	ModifiesCombatProportionalToPhysicalState@SpinUp:
 		SpeedFrom: 100
 		SpeedTo: 60
+		TurnSpeedFrom: 100
+		TurnSpeedTo: 60
+		TurretTurnSpeedFrom: 100
+		TurretTurnSpeedTo: 60
 
 # Special-unit variant: adds the DEFENSIVE term. DamageMultiplier < 100 means less
 # damage TAKEN, so a spun-up gatling is also harder to kill (0.95^10 = 0.599).


### PR DESCRIPTION
## Summary

- synchronize the Gatling `PhysicalState` directly with the granted `gatling` condition count
- remove the competing timer-based fill and relaxation paths that caused range to grow and shrink while firing
- restore the body-turn and turret-turn penalties lost during the compact meter conversion
- validate named physical-state references and cover the condition-to-meter mapping with focused tests

## Behavior

- continuous fire at maximum spin remains stable
- stopping now decays monotonically by one stage per token revoke (30 ticks normal, 15 ticks elite unless actor-specific rules override it)
- the compact meter keeps its existing linear intermediate curve and rounded 60% reload / 122% range endpoints

## Validation

- independent reviewer challenge: no blocking findings
- in-game normal Autogun attack-ground behavior approved
- all 39 active Gatling users audited (4 turret, 32 unit, 3 special)
- `tools\preflight-build.ps1`
- `./make all`
- `dotnet test OpenRA.Mods.Cameo.Test/OpenRA.Mods.Cameo.Test.csproj -c Release --no-restore` (29 passed)
- fresh `OpenRA.Mods.Cameo.dll` timestamp and synchronizer marker verified
- resolved-rules checks passed for turret, unit, and special representatives