### PR TITLE
Tune Gatling projectile streak visuals

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -888,10 +888,10 @@ ordos_autogunturret:
 	ValidTargets: Ground, Water, Air
 	Projectile: Bullet
 		-Image:
-		ProjectileStreakLength: 1536
-		ProjectileStreakLengthVariation: 384
-		ProjectileStreakWidth: 32
-		ProjectileStreakColor: FFA32B
+		ProjectileStreakLength: 1280
+		ProjectileStreakLengthVariation: 128
+		ProjectileStreakWidth: 40
+		ProjectileStreakColor: FFF4C2
 		ContrailLength: 0
 		Speed: 4000
 	Warhead@Effect:

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
@@ -649,10 +649,10 @@ YRBoomerTorpedo:
 ^YuriGatlingCannonProjectileStreak:
 	Projectile: Bullet
 		Image:
-		ProjectileStreakLength: 1536
-		ProjectileStreakLengthVariation: 384
-		ProjectileStreakWidth: 32
-		ProjectileStreakColor: FFA32B
+		ProjectileStreakLength: 1280
+		ProjectileStreakLengthVariation: 128
+		ProjectileStreakWidth: 40
+		ProjectileStreakColor: FFF4C2
 		ContrailLength: 0
 
 YuriGatlingCannonMG1:


### PR DESCRIPTION
## Summary

- shorten and stabilize the cosmetic streak length (`1280`, variation `128`)
- use a slightly thicker `40`-unit streak for the affected Gatling turrets
- replace the old orange `FFA32B` with a uniformly bright, opaque `FFF4C2`

## Affected weapons

- Ordos Autogun Turret and the inheriting Harkonnen Autogun Turret
- Yuri Gatling Cannon ground and anti-air weapons at all three spin levels

## Maintenance choice

This is intentionally YAML-only and uses projectile-streak fields already supported by the current Cameo engine. It no longer depends on cameo-mod/OpenRA#101.

The separate 4-unit tail/head widths, 256-unit leading taper, and tail color gradient were removed to avoid carrying another engine customization. This also accepts the current brief near-impact interpolation gap.

## Validation

- rebased onto current upstream `master`
- both edited weapon files are active through `mods/cameo/mod.yaml`
- no engine-only projectile-streak fields or engine pin changes remain
- `git diff --check` passed
- content-pack audit exited 0
- empty-warhead audit: 0
- independent review found no blocker and confirmed the two-file diff is engine-independent

No engine build is required for these YAML-only changes; restart the game to test them.