### PR TITLE
docs: correct what #270 got wrong, and record how it passed verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ never for status.
 8. **Audit reports regenerate via `bash tools/audit/run_all.sh` only** (PowerShell `>` writes UTF-16),
    **and only from a COMPLETE tree** — `engine/` built, clone not shallow. Missing either makes a
    dozen audits scan a smaller corpus, report FEWER findings and still say PASS, so the commit
-   deletes real evidence with a green run (`unique_traits` 125 trait types → 11). `run_all` now
-   diverts to the untracked `docs/audit/degraded/` in that case and says why; `--force-latest`
+   deletes real evidence with a green run (`dead_warhead_fields` 27071 warhead nodes → 7014).
+   `run_all` diverts to the untracked `docs/audit/degraded/` in that case and says why; `--force-latest`
    overrides. Refresh `latest/` WHOLE, from one machine — path separators alone make a
    cross-platform diff dirty. (`tools/audit/environment.py`, `docs/LESSONS_LEARNED.md`.)
 8b. **The engine DROPS unknown yaml fields in silence.** `FieldLoader.Load` (FieldLoader.cs:676)
@@ -236,8 +236,9 @@ If your harness has a per-agent memory store, read the memory that covers a comm
 (build, engine sync, git) in full before running it.
 
 ⚠ **A memory is not a repository document.** It is private to one agent: nobody else —
-maintainer, co-maintainer, another agent — can open it, and 36 `memory <name>` citations
-already sit in the design docs pointing at things no reader can resolve. So:
+maintainer, co-maintainer, another agent — can open it. Thirty-six `memory <name>` citations
+once sat in the design docs pointing at things no reader could resolve; they were promoted
+out on 2026-08-23 and the live set now holds **zero**. Keep it that way. So:
 
 * treat a memory as **provenance, never authority**;
 * the moment a memory carries a rule, a number or a decision that others must follow,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -75,7 +75,9 @@ becomes a self-contained ContentPack. Runbook: [`MIGRATION.md`](MIGRATION.md).
 | pinned doc claims | **19 of 19 match** |
 | generator sync | drift **0** across 136 shared templates |
 | documentation structure (`audit_doc_health`, D1–D8) | **0** findings |
-| ⛔ **level-ladder ratchet** | **10 broken vs a ratchet of 9** — see §3.0 |
+| level-ladder ratchet | **9 broken, AT ratchet 9** — WARN, not FAIL. See §3.0a |
+| ⛔ **`audit_doc_health`** | **FAIL — D8 flags its own test fixtures**. See §3.0b |
+| ⛔ **`environment.py`** | **can never report a complete tree** — wrong CA path. See §3.0b |
 
 ⚠ The counts above were re-measured at `519175ae`; the per-class counts in
 [`audit/SUMMARY.md`](audit/SUMMARY.md) come from the last full suite run and carry the
@@ -180,69 +182,82 @@ not repeatedly.
 
 Crashes and player-visible regressions jump everything below.
 
-### 3.0 — DO THIS FIRST (the suite is red, and one item is not yours to fix)
+### 3.0 — DO THIS FIRST
 
-Two things, in this order. Neither is large; the first is a decision, the second is a chore that
-has to happen on a machine this container is not.
+**a. Nine broken damage ladders — WARN, and still unruled.**
 
-**a. `audit_level_ladder` is FAILING — 10 broken ladders against a ratchet of 9.**
+A family's damage must RISE with its level. Nine do not: seven are INVERTED (a heavier level hits
+softer than a lighter one) and two are FLAT. The measured table for all nine and the shapes they
+fall into are in [`design/ROADMAP.md`](design/ROADMAP.md) under **BROKEN LADDERS**.
 
-A family's damage must RISE with its level. Ten families do not: seven are INVERTED (a heavier
-level hits softer than a lighter one) and three are FLAT (every level identical). The measured
-table for all ten, and the three distinct shapes they fall into, are in
-[`design/ROADMAP.md`](design/ROADMAP.md) under **RATCHET BREACH**.
+⚠ This was **10 and FAILING** on 2026-08-23 and came back to the ratchet without anyone ruling on
+anything: `a9f31258` (the RA1 Allies cryo conversion) moved `Demolition`'s Heavy rung 40000 →
+60000 as a side effect, taking it from FLAT to rising, and added a new measurable family. So the
+suite no longer exits 1 on this — but the count is not a progress metric. A family leaves the list
+by being fixed, by dropping below the measurability threshold, or by a conversion moving its rungs
+in passing. Read the table, not the number.
 
 ⛔ **Do not fix these by hand and do not raise the ratchet.** They are balance numbers
 (CLAUDE.md rule 3): the route is a maintainer ruling → `extract_stats` → ledger →
-`apply_balance --confirm`. `LADDER_BASELINE` in `tools/audit/audit_level_ladder.py` is
-LOWER-ONLY, and lowering it is how this closes.
+`apply_balance --confirm`. `LADDER_BASELINE` is LOWER-ONLY, and lowering it is how this closes.
 
-The ruling needed is small — for each family, which rung is wrong — but it is a **design**
-ruling, so it belongs to the maintainer. `MissileAP` (n=81) and `Tesla` (n=67) descend
-monotonically across well-populated rungs, which reads as a family built the wrong way round
-rather than a stray weapon; `CannonAP`, `Flak` and `Thermobaric` invert against a rung holding
-only two weapons, where the thin side is the likelier error; `Bullet` and `Demolition` are flat
-across 91 and 53 weapons, which is a different question again.
+The ruling needed is small — for each family, which rung is wrong — but it is a **design** ruling,
+so it belongs to the maintainer. `MissileAP` (n=80) and `Tesla` (n=67) descend monotonically
+across well-populated rungs, which reads as a family built the wrong way round rather than a stray
+weapon; `CannonAP`, `Flak` and `Thermobaric` invert against a rung holding only two weapons, where
+the thin side is the likelier error; `Bullet` is flat across 89 weapons, which is a different
+question again.
 
-⭐ **How it stayed hidden**, worth reading once: `latest/level_ladder.md` had not been
-regenerated since a commit PREDATING the change that exposed it, so a FAIL sat in the tree
-reporting itself as a WARN. A ratchet re-measured only when someone remembers is not a ratchet.
+**b. Three tooling defects are LIVE on master. Fixes were reported in flight on 2026-08-23 from a
+Windows session — check whether they landed before redoing them.**
 
-**b. `docs/audit/latest/` needs one clean regenerate, from a complete tree.**
+| defect | effect | fix |
+|---|---|---|
+| `tools/audit/environment.py` lists `engine/OpenRA.Mods.CA` | `OpenRA.Mods.CA` is **vendored at the repo root**, not under `engine/`, so that path can never exist and `incomplete()` returns a reason on EVERY machine — `latest/` is unwritable without `--force-latest`, even from a fully built tree | drop the `engine/` prefix on that one entry |
+| `tools/audit/audit_unique_traits.py` has the same wrong path in `SOURCE_ROOTS` | not a gate, so it just **under-reported in silence**: 125 trait types scanned instead of 139. Fourteen CA trait types had never been checked | same |
+| `audit_doc_health` D8 flags its own test fixtures | `tools/tests/test_audit_doc_health.py` asserts on a literal wrong-citation label, so **D8 reports 3 findings against its own unit tests and the suite exits 1 on a clean tree** | exclude `tools/tests/` — the same self-reference class already handled for D5 |
 
-It is currently a MIXTURE of two environments. A dozen audits read `engine/` C# or full git
-history; where those are missing the scripts scan a smaller corpus, report fewer findings and
-still say **PASS** — `unique_traits` 125 trait types → 11, `dead_warhead_fields` 27071 nodes →
-7014 — so alternating Windows and container runs have been overwriting each other's numbers.
+`audit_dead_warhead_fields.py` and `audit_code_duplication.py` already had the CA path right, and
+a sweep of `tools/**/*.py` finds no third instance — those two are the whole set.
 
-`run_all` now refuses to write `latest/` from an incomplete tree, diverting to the untracked
-`docs/audit/degraded/` and saying why (`--force-latest` overrides). So this is a one-time
-cleanup, and it needs a machine with `engine/` built and a non-shallow clone:
+⭐ Both of the second and third defects were introduced by the change that added the gate, and both
+were "verified" before landing. How, is in [`LESSONS_LEARNED.md`](LESSONS_LEARNED.md): a grep whose
+filter excluded exactly the lines that would have disproved it, and a tracked-file scan run while
+the new file was still untracked.
+
+**c. `docs/audit/latest/` needs one clean regenerate, from a complete tree.**
+
+It is a MIXTURE of two environments. A dozen audits read `engine/` C# or full git history; where
+those are missing the scripts scan a smaller corpus, report fewer findings and still say **PASS** —
+`dead_warhead_fields` 27071 nodes → 7014 — so alternating Windows and container runs have been
+overwriting each other's numbers.
+
+`run_all` now diverts to the untracked `docs/audit/degraded/` instead (`--force-latest` overrides),
+so this is a one-time cleanup — **but it cannot succeed until defect (b)#1 above is fixed**, because
+the probe currently calls every tree incomplete. Then, on a machine with `engine/` built:
 
 ```sh
 git fetch --unshallow          # if the clone is shallow
 bash tools/audit/run_all.sh    # writes latest/ only from a complete tree
 ```
 
-Commit the result **whole**. Do not cherry-pick report files: Windows writes `mods\cameo\…`
-and Linux writes `mods/cameo/…`, so a cross-platform diff is dirty even between two complete
-trees. Full diagnosis: [`LESSONS_LEARNED.md`](LESSONS_LEARNED.md).
+Commit the result **whole**. Do not cherry-pick report files: Windows writes `mods\cameo\…` and
+Linux writes `mods/cameo/…`, so a cross-platform diff is dirty even between two complete trees.
 
 ⚠ The suite also rewrites TRACKED files **outside** `audit/latest/` — `docs/factions/MATRIX.md`
 and `tools/rename/rename_map_*.yaml` (`gen_rename_maps.py` writes those as a side effect of the
 naming report). So `git status` after a suite run is not expected to be clean, and those files
-belong in the same commit. Seven rename maps are currently stale against master's icon renames
-at `519175ae`; they regenerate from tracked yaml only, so any complete tree produces the same
-answer.
+belong in the same commit.
 
-⚠ **The previous items here are DONE.** The 9 drifted balance ledgers were fixed by master in
-`31e649b8`, and the 4 drifted doc claims were cleared on 2026-08-23 —
-`audit_doc_claims` is now **19 of 19**, and `ledgers_drifted` is pinned in the registry so a
-recurrence goes red immediately instead of being found by accident weeks later.
+⚠ **Previous items here are DONE.** The 9 drifted balance ledgers (`31e649b8`), the 4 drifted doc
+claims (`audit_doc_claims` is **19 of 19**), and the memory-citation promotion — **zero**
+`memory <name>` pointers remain in the live document set; the two load-bearing ones were inlined
+into `weapon_classes.yaml`'s header and `BALANCE_PROGRAM_PLAN.md` §7.
 
 ```sh
-python tools/audit/audit_level_ladder.py   # the red one
-python tools/audit/audit_doc_claims.py     # documented vs measured, all 19
+python tools/audit/audit_level_ladder.py   # WARN 9, at the ratchet
+python tools/audit/audit_doc_health.py     # FAIL until (b)#3 lands
+python tools/audit/environment.py          # should print "complete" on a built tree
 ```
 
 ### 3.1 — The weapon rebuild (the main line)

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -76,6 +76,7 @@ win — **unless the artifact says otherwise, and then the artifact wins and you
 - [OpenRA Lua `Map` API: there is no `Map.Contains` (2026-07-31)](#openra-lua-map-api-there-is-no-mapcontains-2026-07-31)
 - [Between-cell movement responsiveness (2026-08-11)](#between-cell-movement-responsiveness-2026-08-11)
 - [`docs/audit/latest/` is environment-bound — an incomplete tree reports LESS and still says PASS (2026-08-23)](#docsauditlatest-is-environment-bound--an-incomplete-tree-reports-less-and-still-says-pass-2026-08-23)
+- [Two ways a gate passes its own verification and is still broken (2026-08-23)](#two-ways-a-gate-passes-its-own-verification-and-is-still-broken-2026-08-23)
 
 ---
 
@@ -763,11 +764,13 @@ Measured in a cloud container on 2026-08-23, one `git add` away from being commi
 
 | report | complete tree | incomplete tree | why |
 |---|--:|--:|---|
-| `unique_traits.md` | 125 trait types | **11** | no `engine/**/*.cs` to resolve `.Trait<T>()` |
+| `unique_traits.md` | 125 trait types † | **11** | no `engine/**/*.cs` to resolve `.Trait<T>()` |
 | `dead_warhead_fields.md` | 27071 warhead nodes | **7014** | no C# field sets, so most types are "not checked" |
 | `fluent.md` | 5235 messages | **3640** | the engine ships fluent files too |
 | `assets.md` | 8780 WAVs | **4390** | the engine's own mods are not there |
 | `recent_changes.md` | 663 files touched | **31523** | shallow clone: the grafted boundary commit looks like it touched the world |
+
+† 125 was itself an under-report. `audit_unique_traits.py` looked for CA under `engine/OpenRA.Mods.CA`, but `OpenRA.Mods.CA` is **vendored at the repo root** — so 14 CA trait types had never been scanned on ANY machine. The complete-tree figure is **139**. A denominator can be wrong on the good tree too.
 
 `git log` showed `latest/` had been ping-ponging between a Windows checkout and a container for
 several commits — each run overwriting the other's numbers, `unique_traits.md` flipping 125 ↔ 11
@@ -793,6 +796,57 @@ not file by file.
 `tools/rename/rename_map_*.yaml`, which `gen_rename_maps.py` emits as a side effect of the
 naming report. `git status` after a suite run is therefore *expected* to be dirty in places the
 run never mentions — check what moved before assuming a stray edit.
+
+
+## Two ways a gate passes its own verification and is still broken (2026-08-23)
+
+The commit that added `tools/audit/environment.py` and the D8 citation check shipped with two
+defects, both in the new code, both "verified" before landing. The verifications were real —
+they were just aimed slightly off the thing that mattered.
+
+**1. A grep whose filter excluded exactly the counter-evidence.**
+
+`environment.py` needed the list of assemblies whose C# the audits read. The list was copied in
+spirit from `audit_unique_traits.py`, then sanity-checked with:
+
+    grep -n "engine" tools/audit/audit_dead_warhead_fields.py
+
+which printed the `AS`, `Cnc`, `D2k` and `Common` rows and looked like confirmation. It was not.
+`audit_dead_warhead_fields.py`'s table is:
+
+    ("AS",     "engine/OpenRA.Mods.AS"),
+    ("CA",     "OpenRA.Mods.CA"),        <- no "engine", so the grep hid it
+    ("Cameo",  "OpenRA.Mods.Cameo"),     <- likewise
+    ("Cnc",    "engine/OpenRA.Mods.Cnc"),
+
+**`OpenRA.Mods.CA` and `OpenRA.Mods.Cameo` are VENDORED AT THE REPO ROOT**, not under `engine/`.
+The two rows that disproved the assumption were precisely the two the filter removed, and the
+filter was the word the assumption was built on. So the new gate listed `engine/OpenRA.Mods.CA`,
+a path that cannot exist on any machine, and `incomplete()` returned a reason even on a fully
+built Windows tree — the gate could never say "complete", and diverted a legitimate run's 65
+reports to `degraded/`. The same wrong path had been sitting in `audit_unique_traits.py` for
+much longer, silently: 125 trait types scanned instead of 139.
+
+⭐ **When you grep for the word your belief is made of, matches confirm nothing** — the
+counter-examples are the lines that lack the word. Either read the whole structure, or grep for
+the FIELD (`OpenRA.Mods`) rather than the value you expect (`engine`). `ls` would also have
+settled it in one call.
+
+**2. A tracked-file scan run while the new file was still untracked.**
+
+`audit_doc_health` enumerates files with `git ls-files`. The D8 check was added along with
+`tools/tests/test_audit_doc_health.py`, whose fixtures deliberately contain a wrong citation
+label so the detector can be tested against the real bug. Running the audit at that moment
+reported **0 findings** and exit 0 — correctly, because the test file was still UNTRACKED and
+therefore invisible to `git ls-files`. `git add` made it visible; the very next run of the suite
+reported 3 findings and exited 1 on a clean tree.
+
+⭐ **Any check that enumerates via `git ls-files` must be re-run AFTER staging**, never before.
+Otherwise the last thing you verify is a tree that does not contain your change. This is the
+third instance of the self-reference class in this one audit — D5 needed the same exclusion for
+its own `GONE` table, and D4 for its own example anchor. A detector that scans the repository
+will eventually scan itself and its tests; write the exclusion when you add the check, not after
+it fires.
 
 ## `Inherits` POSITION is semantic, not cosmetic (2026-08-16)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,8 +133,8 @@ its audit list out of `run_all.sh`, so the two cannot drift apart.
 
 ⚠ **`audit/latest/` can only be regenerated from a COMPLETE tree** — one with `engine/` built and
 a full (non-shallow) clone. Without them a dozen audits scan a smaller corpus, report fewer
-findings and still say PASS, so a regenerate silently deletes real evidence (`unique_traits`
-125 trait types → 11). Both runners now check first and divert to the untracked
+findings and still say PASS, so a regenerate silently deletes real evidence
+(`dead_warhead_fields` 27071 warhead nodes → 7014). Both runners now check first and divert to the untracked
 `docs/audit/degraded/` instead, printing why; `--force-latest` overrides. Details and the
 measured table: [`LESSONS_LEARNED.md`](LESSONS_LEARNED.md). Refresh `latest/` **whole, from one
 machine** — path separators alone make a cross-platform diff dirty.

--- a/docs/audit/SUMMARY.md
+++ b/docs/audit/SUMMARY.md
@@ -11,8 +11,8 @@ Recurring code-health audits and their cadence: [`PERIODIC.md`](PERIODIC.md) +
 
 ⚠ **`latest/` is currently a MIXTURE of two environments and is owed one clean regenerate.**
 A dozen audits read `engine/` C# or full git history — neither of which exists in a fresh
-clone — and they respond by reporting *less* and still saying PASS (`unique_traits` 125 trait
-types → 11, `dead_warhead_fields` 27071 nodes → 7014). Alternating Windows and container runs
+clone — and they respond by reporting *less* and still saying PASS (`dead_warhead_fields` 27071
+warhead nodes → 7014, `fluent` 5235 messages → 3640). Alternating Windows and container runs
 have been overwriting each other's numbers. `run_all` now refuses to write `latest/` from an
 incomplete tree (it diverts to the untracked `docs/audit/degraded/`; `--force-latest`
 overrides), so this is a one-time cleanup: **run the suite once on a complete tree and commit
@@ -73,7 +73,7 @@ regenerate).
 
 | check | state | what to do |
 |---|---|---|
-| **level ladder** | **FAIL — 10 broken vs ratchet 9** (7 inverted, 3 flat) | blocked on a maintainer ruling. Full measured table + the diagnosis: [`../design/ROADMAP.md`](../design/ROADMAP.md) "RATCHET BREACH". These are balance numbers: pipeline only, and **never raise the ratchet**. |
+| **level ladder** | **WARN — 9 broken, at ratchet 9** (7 inverted, 2 flat) | no longer failing: `a9f31258` fixed `Demolition`. Still blocked on a maintainer ruling. Full measured table + the diagnosis: [`../design/ROADMAP.md`](../design/ROADMAP.md) "BROKEN LADDERS". These are balance numbers: pipeline only, and **never raise the ratchet**. |
 | duplicate keys D1 | 88 dropped inherits | each one silently drops a template — same family as the `Parent type X was already inherited` boot crash |
 | warhead-split ratchet | at baseline | pre-existing W24 debt, not a regression; lower the baseline as W24 lands |
 
@@ -101,8 +101,9 @@ so they cannot rot in prose again.
 
 1. **One clean suite run on a complete tree** — cheapest, and until `latest/` stops mixing two
    environments no count on this page can be fully trusted.
-2. **The 10 broken level ladders** — a heavier level dealing less damage than a lighter one is
-   player-visible nonsense, and the ratchet is red until it is ruled on.
+2. **The 9 broken level ladders** — a heavier level dealing less damage than a lighter one is
+   player-visible nonsense. Back at the ratchet rather than over it, so it no longer fails the
+   suite, but nothing about the nine has been ruled on.
 3. **B2b duplicate inherit paths / D1 dropped inherits** — the class that produces
    `Parent type X was already inherited` boot crashes and silently-dropped templates. Only the
    boot and `audit_duplicate_inherits` can see it.

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -122,9 +122,11 @@ Documented in `PHYSICAL_STATE_SYSTEM.md` §5 but not built: **Sonic → `Resonan
 new C#), **Hex** (Magic: −firepower/−accuracy/disable specials), **ArmorBreach**, **Knockback**
 (needs new C#). Only **Temperature** (98.6% exposure) and **Corrosion** (45.0%) exist today.
 
-## ⛔ RATCHET BREACH — `audit_level_ladder` 10 vs ratchet 9 (found 2026-08-23)
+## ⛔ BROKEN LADDERS — `audit_level_ladder` 9 vs ratchet 9 (breached at 10 on 2026-08-23)
 
-The suite exits 1 on this. **It is ours, from tick tank commit `f9b71bffa`**, and it stayed
+The suite exited 1 on this until `a9f31258` brought it back to the ratchet; the nine below are
+still broken and still need a ruling. **The breach was ours, from tick tank commit
+`f9b71bffa`**, and it stayed
 invisible because `docs/audit/latest/level_ladder.md` had not been regenerated since `52b364cb5`,
 which PREDATES that commit — so a FAIL sat in the tree reporting itself as a WARN at baseline.
 
@@ -139,11 +141,11 @@ measurable for the first time. What it measured:
 ⚠ The tick tank change did not CREATE this; it EXPOSED it. `CannonAP_Light` was already at 48000
 while the weapons now on `CannonAP_Medium` sit at 6000. One of the two rungs is wrong.
 
-### All ten, so they can be ruled on in one pass
+### All nine, so they can be ruled on in one pass
 
 `CannonAP` is the family that crossed the measurability threshold, but it is not the only broken
-ladder — it is the tenth. The full report (`python tools/audit/audit_level_ladder.py`, measured at
-`519175ae`) reads:
+ladder. The full report (`python tools/audit/audit_level_ladder.py`, re-measured at `3b320c89`)
+reads:
 
 | family | Light | Medium | Heavy | Super | verdict |
 |---|--:|--:|--:|--:|---|
@@ -151,17 +153,25 @@ ladder — it is the tenth. The full report (`python tools/audit/audit_level_lad
 | `Chemical` | 20000 _(n=9)_ | 32000 _(n=9)_ | 30000 _(n=3)_ | — | ⛔ INVERTED |
 | `Flak` | 32000 _(n=2)_ | 8000 _(n=15)_ | — | — | ⛔ INVERTED |
 | `Inferno` | 6000 _(n=5)_ | 10000 _(n=4)_ | 6000 _(n=5)_ | — | ⛔ INVERTED |
-| `MissileAP` | 20000 _(n=23)_ | 12000 _(n=26)_ | 11000 _(n=32)_ | — | ⛔ INVERTED |
+| `MissileAP` | 20000 _(n=23)_ | 12000 _(n=26)_ | 12000 _(n=31)_ | — | ⛔ INVERTED |
 | `Tesla` | — | — | 12000 _(n=47)_ | 6500 _(n=20)_ | ⛔ INVERTED |
 | `Thermobaric` | — | 24000 _(n=2)_ | 18000 _(n=2)_ | — | ⛔ INVERTED |
-| `Bullet` | 4000 _(n=51)_ | 4000 _(n=40)_ | — | — | ⚠ FLAT |
-| `Demolition` | 40000 _(n=36)_ | — | 40000 _(n=17)_ | — | ⚠ FLAT |
+| `Bullet` | 4000 _(n=49)_ | 4000 _(n=40)_ | — | — | ⚠ FLAT |
 | `MissileFire` | 24000 _(n=2)_ | 24000 _(n=2)_ | — | — | ⚠ FLAT |
 
-Rising correctly: `CannonHE`, `Flame`, `Laser`, `MissileChem`, `MissileHE`. Sixteen more families
-are still too thin to judge (fewer than 2 rungs with 2+ weapons), so this list can only grow as
-W23/W24 adoption fills the rungs — which is an argument for ruling on the shape of the ladder
-rather than on ten separate pairs of numbers.
+Rising correctly: `BulletCryo`, `CannonHE`, `Demolition`, `Flame`, `Laser`, `MissileChem`,
+`MissileHE`. Fifteen more families are still too thin to judge (fewer than 2 rungs with 2+
+weapons), so this list can move in either direction as W23/W24 adoption fills the rungs — which
+is an argument for ruling on the SHAPE of the ladder rather than on nine separate pairs of
+numbers.
+
+⚠ **It was ten on 2026-08-23 and the count fell without anyone ruling on anything.** The RA1
+Allies cryo conversion (`a9f31258`) took `Demolition` from FLAT to rising by moving its Heavy
+rung 40000 → 60000, and added a new measurable family (`BulletCryo`, rising). So the audit is
+back to **WARN 9 against ratchet 9** and the suite no longer exits 1 on it. Two things follow:
+the pressure is off, and the count is not a progress metric — a family can leave this list
+because it was fixed, because it fell below the measurability threshold, or because a
+conversion moved its rungs as a side effect. Read the table, not the number.
 
 Three shapes are visible, and they may not want the same answer:
 
@@ -366,8 +376,9 @@ The blockers previously listed here were measured with a broken hand parser that
    It is now applied to every family, after the tilt (`edd1c4597`). Ratchet **0**.
 5. The broken DAMAGE ladders (`audit_level_ladder.py`) — unaffected by the parser bug, since
    that audit reads `Damage` through the resolver. Still a balance restat needing
-   `apply_balance --confirm`. **Now 10 against a ratchet of 9**, so the audit is FAILING; the
-   measured table and the three distinct shapes are in the RATCHET BREACH section above.
+   `apply_balance --confirm`. **Now 9 against a ratchet of 9 — WARN, not FAIL** (it was 10 and
+   failing on 2026-08-23; `a9f31258` fixed `Demolition`). The measured table and the three
+   distinct shapes are in the RATCHET BREACH section above.
 
 ## ▶ ACTIVE — CAMEO CONTENT INSTALLER
 

--- a/docs/design/WEAPON_HEAVINESS.md
+++ b/docs/design/WEAPON_HEAVINESS.md
@@ -489,7 +489,7 @@ lives in `OpenRA.Mods.Cameo`.
 
 ### 5. ⛔ BLOCKER — the ladder must be fixed first
 
-`audit_level_ladder.py` (ratchet 9 — currently BREACHED at 10, see `ROADMAP.md`; in
+`audit_level_ladder.py` (ratchet 9 — 9 broken today, see `ROADMAP.md`; in
 `run_all.sh`) measures the EFFECTIVE ladder — median damage
 of the real weapons on each rung:
 
@@ -548,7 +548,7 @@ Every number here was measured on the resolved ruleset via `tools/audit/miniyaml
 read from a summary. Guards added while investigating:
 
 - `tools/audit/audit_tier_weapon_class.py` — TYPES × LEVELS budget, ratchet 218.
-- `tools/audit/audit_level_ladder.py` — effective ladder monotonicity, ratchet 9 (breached: 10).
+- `tools/audit/audit_level_ladder.py` — effective ladder monotonicity, ratchet 9 (at 9: WARN).
 
 ⚠ Three earlier versions of these audits measured the WRONG SURFACE — source instead of resolved,
 override instead of addition, template placeholder instead of effective value — and each produced


### PR DESCRIPTION
A Windows session re-measured #270 on a complete tree and found two defects in the gate it added. Both confirmed here against the artifacts. **The code fixes are theirs and in flight — this is the documentation half only.**

## What #270 got wrong

**1. `environment.py` could never report a complete tree.** It listed `engine/OpenRA.Mods.CA`, but `OpenRA.Mods.CA` is **vendored at the repo root** (181 `.cs` files), like `OpenRA.Mods.Cameo`. That path cannot exist on any machine, so `incomplete()` returned a reason even on a fully built Windows tree — and diverted a legitimate run's 65 reports to `degraded/`. The diversion mechanism was right; the predicate was not.

**2. D8 flags its own test fixtures.** `tools/tests/test_audit_doc_health.py` asserts on a literal wrong-citation label, so once tracked, D8 reports 3 findings against its own unit tests. Verified: 3 findings, all from that file, exit 1. **Live on master right now** — `run_all.sh` exits 1 on a clean tree.

`audit_unique_traits.py` carries the same wrong CA path. Not a gate, so it under-reported in silence: 125 trait types instead of 139; 14 CA trait types never scanned. Swept `tools/**/*.py` — `audit_dead_warhead_fields.py` and `audit_code_duplication.py` already had it right, and there is no third instance.

## How both passed verification — the point of this PR

* The assembly list was sanity-checked with `grep -n "engine" audit_dead_warhead_fields.py`. That table's `CA` and `Cameo` rows contain no `"engine"`, so the grep removed exactly the two lines that would have disproved the assumption and printed the four that appeared to confirm it. **When you grep for the word your belief is made of, matches confirm nothing** — the counter-examples are the lines that lack the word.
* D8 was verified while the test file was still **untracked**, so `git ls-files` could not see it and the audit honestly reported 0. `git add` made it visible. **Any check enumerating via `git ls-files` must be re-run after staging.** Third self-reference in this one audit (D4 and D5 needed the same) — write the exclusion when you add the check.

Both are now a LESSONS_LEARNED section.

## Ladders: 9, not 10 — and nobody ruled on anything

Re-measured at `3b320c89`: **WARN 9 against ratchet 9, exit 0.** No longer failing.

The peer reported that `Demolition` had left the measurable list. The artifact says otherwise, and the mechanism matters: `a9f31258` (RA1 Allies cryo) moved `Demolition`'s Heavy rung **40000 → 60000**, taking it from FLAT to *rising*, and added a new measurable family (`BulletCryo`, rising). So 16 families are measurable now, not 15.

A family leaves that list by being **fixed**, by dropping **below the threshold**, or by a conversion **moving its rungs in passing** — opposite meanings. The count is not a progress metric and the docs now say so. The nine that remain (7 inverted, 2 flat) still need the per-family ruling; no damage number touched, ratchet unmoved.

## Other corrections

* The headline illustration of the degraded-evidence trap moves from `unique_traits` 125 → 11 to `dead_warhead_fields` 27071 → 7014 (CLAUDE.md, README, SUMMARY). 125 was itself an under-report, so it was a poor figure to teach with; LESSONS_LEARNED keeps the row with a footnote. **A denominator can be wrong on the good tree too.**
* CLAUDE.md's "36 `memory <name>` citations already sit in the design docs" is retired — the promotion pass landed and the live set holds **zero**, verified by grep.
* HANDOFF §3.0 rewritten around what is actually true: (a) nine unruled ladders at WARN, (b) the three live tooling defects **with their one-line fixes**, so anyone can apply them if the in-flight fixes don't land, (c) the clean `latest/` regenerate — which **cannot succeed until (b)#1 is fixed**, because the probe currently calls every tree incomplete.

## Not done here, deliberately

The three code fixes. The Windows session reported them done locally and is mid-run on the clean regenerate; duplicating would collide on files it holds (rule 6). They are **not on any remote branch yet**, so until that push lands `run_all.sh` exits 1 and `latest/` cannot be regenerated. HANDOFF §3.0b carries each fix verbatim.

## Verification

```
audit_level_ladder        WARN 9 / ratchet 9, exit 0 — full table captured
audit_consistency_report  exit 0
audit_doc_health          D1–D7 clean; D8 = 3, all from the test file, pre-existing
                          and covered above. No finding comes from this commit.
grep OpenRA.Mods.CA       2 wrong paths, both named; no third instance
grep memory citations     0 in the live document set
```

**Boot gate: not run, not applicable.** Documentation only — no `mods/` yaml, no C#, no `mod.config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7)_