### PR TITLE
Switchable default Move <--> AttackMove

### DIFF
--- a/OpenRA.Mods.Cameo/Widgets/CustomFormationsCommandBarLogic.cs
+++ b/OpenRA.Mods.Cameo/Widgets/CustomFormationsCommandBarLogic.cs
@@ -24,6 +24,18 @@ namespace OpenRA.Mods.Cameo.Widgets
 	/// <summary>Contains all functions that are unit-specific.</summary>
 	public class CustomFormationsCommandBarLogic : ChromeLogic
 	{
+		[FluentReference]
+		const string AttackMoveTooltip = "button-command-bar-attack-move.tooltip";
+
+		[FluentReference]
+		const string AttackMoveTooltipDesc = "button-command-bar-attack-move.tooltipdesc";
+
+		[FluentReference]
+		const string AttackMoveAsMoveTooltip = "button-command-bar-attack-move-as-move.tooltip";
+
+		[FluentReference]
+		const string AttackMoveAsMoveTooltipDesc = "button-command-bar-attack-move-as-move.tooltipdesc";
+
 		readonly World world;
 
 		int selectionHash;
@@ -58,10 +70,28 @@ namespace OpenRA.Mods.Cameo.Widgets
 			var attackMoveButton = widget.GetOrNull<ButtonWidget>("ATTACK_MOVE");
 			if (attackMoveButton != null)
 			{
+				// The tooltip is repurposed depending on the AttackMoveIsDefault setting (see below),
+				// so it can't be bound statically from the yaml TooltipText/TooltipDesc keys - it needs
+				// to switch between the two behaviours at runtime. The icon stays the same in both cases
+				// (there is no dedicated "Move" icon in the command-icons sprite sheet).
 				WidgetUtils.BindButtonIcon(attackMoveButton);
 
+				var attackMoveTooltip = FluentProvider.GetMessage(AttackMoveTooltip);
+				var attackMoveTooltipDesc = FluentProvider.GetMessage(AttackMoveTooltipDesc);
+				var attackMoveAsMoveTooltip = FluentProvider.GetMessage(AttackMoveAsMoveTooltip);
+				var attackMoveAsMoveTooltipDesc = FluentProvider.GetMessage(AttackMoveAsMoveTooltipDesc);
+
+				attackMoveButton.GetTooltipText = () => Game.Settings.Game.AttackMoveIsDefault
+					? attackMoveAsMoveTooltip
+					: attackMoveTooltip;
+				attackMoveButton.GetTooltipDesc = () => Game.Settings.Game.AttackMoveIsDefault
+					? attackMoveAsMoveTooltipDesc
+					: attackMoveTooltipDesc;
+
 				attackMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return attackMoveDisabled; };
-				attackMoveButton.IsHighlighted = () => world.OrderGenerator is CustomFormationsAttackMoveOrderGenerator;
+				attackMoveButton.IsHighlighted = () => Game.Settings.Game.AttackMoveIsDefault
+					? world.OrderGenerator is MoveOrderGenerator
+					: world.OrderGenerator is CustomFormationsAttackMoveOrderGenerator;
 
 				void Toggle(bool allowCancel)
 				{
@@ -70,6 +100,8 @@ namespace OpenRA.Mods.Cameo.Widgets
 						if (allowCancel)
 							world.CancelInputMode();
 					}
+					else if (Game.Settings.Game.AttackMoveIsDefault)
+						world.OrderGenerator = new MoveOrderGenerator(world);
 					else
 						world.OrderGenerator = new CustomFormationsAttackMoveOrderGenerator(selectedActors, Game.Settings.Game.ResolveActionButton(MouseActionType.ConfirmOrder));
 				}

--- a/mods/cameo/fluent/en.ftl
+++ b/mods/cameo/fluent/en.ftl
@@ -201,7 +201,18 @@ button-command-bar-attack-move =
 
     Left-click icon then right-click on target location.
 
-button_command_bar_force_move =
+button-command-bar-attack-move-as-move =
+    .tooltip = Move
+    .tooltipdesc =
+    Selected units will move to the desired location
+    without automatically engaging enemies encountered en route.
+
+    Attack Move (attacking any enemies encountered en route)
+    is the default when no key is held.
+
+    Left-click icon then right-click on target location.
+
+button-command-bar-force-move =
    .tooltip = Force Move
    .tooltipdesc = Selected units will move to the desired location
      - Default activity for the target is suppressed


### PR DESCRIPTION
Allow use Attack Move for players they wanna to, instead default Move, as this is far more often used than Move command.

together with https://github.com/cameo-mod/OpenRA/pull/103