### PR TITLE
Fix post-consolidation weapon edge cases

### DIFF
--- a/docs/balance/redalert2mod_consortium.json
+++ b/docs/balance/redalert2mod_consortium.json
@@ -5912,7 +5912,7 @@
       "pricing": true,
       "range": "6200",
       "reloaddelay": "8",
-      "requires": "!rank-elite",
+      "requires": "!rank-elite && !steelconsortium_upgrade_resonanceammo",
       "slot": "Armament@PRIMARY",
       "versus_templates": [
        "^TeslaWeapon",
@@ -5996,7 +5996,7 @@
       "pricing": true,
       "range": "7200",
       "reloaddelay": "8",
-      "requires": "rank-elite",
+      "requires": "rank-elite && !steelconsortium_upgrade_resonanceammo",
       "slot": "Armament@ELITE",
       "versus_templates": [
        "SteelRunnerPistols"
@@ -6079,7 +6079,7 @@
       "pricing": false,
       "range": "6200",
       "reloaddelay": "8",
-      "requires": "!rank-elite",
+      "requires": "!rank-elite && !steelconsortium_upgrade_resonanceammo",
       "slot": "Armament@GARRISONED",
       "versus_templates": [
        "^TeslaWeapon",
@@ -6164,7 +6164,7 @@
       "pricing": false,
       "range": "7200",
       "reloaddelay": "8",
-      "requires": "rank-elite",
+      "requires": "rank-elite && !steelconsortium_upgrade_resonanceammo",
       "slot": "Armament@GARRISONEDELITE",
       "versus_templates": [
        "SteelRunnerPistols"

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
@@ -1089,16 +1089,16 @@ AsianQuasarBoatAG:
 	Inherits: AsianPhotonCannon
 	ValidTargets: Ground, Water
 	ReloadDelay: 22
-	Range: 8000
+	Range: 7168
 	Burst: 3
 	BurstDelays: 3
 	Projectile: Missile
-		RangeLimit: 12000
+		RangeLimit: 12c0
 		MinimumLaunchAngle: 75
-		MaximumLaunchAngle: 125
-		MaximumLaunchSpeed: 200
-		MinimumLaunchSpeed: 200
-		Inaccuracy: 500
+		MaximumLaunchAngle: 128
+		MaximumLaunchSpeed: 192
+		MinimumLaunchSpeed: 192
+		Inaccuracy: 512
 
 AsianQuasarBoatAG_EMP:
 	Inherits: AsianQuasarBoatAG
@@ -1109,15 +1109,15 @@ AsianQuasarBoat_AA:
 	Inherits: AsianPhotonCannon
 	ValidTargets: Air
 	ReloadDelay: 22
-	Range: 12000
+	Range: 7168
 	Burst: 3
 	BurstDelays: 3
 	Projectile: Missile
-		RangeLimit: 12000
+		RangeLimit: 12c0
 		MinimumLaunchAngle: 75
-		MaximumLaunchAngle: 125
-		MaximumLaunchSpeed: 250
-		MinimumLaunchSpeed: 250
+		MaximumLaunchAngle: 128
+		MaximumLaunchSpeed: 256
+		MinimumLaunchSpeed: 256
 		Inaccuracy: 250
 
 AsianQuasarBoat_EMP_AA:
@@ -1295,33 +1295,6 @@ AsianChemicalBombs:
 		Palette: ra2effect
 		Weapon: RA2Cloud
 		InvalidTargets: Water
-
-AsianQuasarBoatAG:
-	Inherits: AsianPhotonCannon
-	ValidTargets: Ground, Water
-	ReloadDelay: 22
-	Burst: 3
-	Range: 7168
-	Projectile: Missile
-		RangeLimit: 12c0
-		MinimumLaunchAngle: 75
-		MaximumLaunchAngle: 128
-		MaximumLaunchSpeed: 192
-		MinimumLaunchSpeed: 192
-		Inaccuracy: 512
-
-AsianQuasarBoat_AA:
-	Inherits: AsianPhotonCannon
-	ValidTargets: Air
-	ReloadDelay: 22
-	Burst: 3
-	Range: 7168
-	Projectile: Missile
-		RangeLimit: 12c0
-		MinimumLaunchAngle: 75
-		MaximumLaunchAngle: 128
-		MaximumLaunchSpeed: 256
-		MinimumLaunchSpeed: 256
 
 AsianHowitzerCannon:
 	Inherits: ^RA2MediumCannon

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/infantry.yaml
@@ -448,20 +448,20 @@ steelconsortium_steelrunner:
 	Passenger:
 	Armament@PRIMARY:
 		Weapon: SteelRunnerPistols
-		RequiresCondition: !rank-elite
+		RequiresCondition: !rank-elite && !steelconsortium_upgrade_resonanceammo
 		LocalOffset: 128,0,256
 	Armament@ELITE:
 		Weapon: SteelRunnerPistols_elite
-		RequiresCondition: rank-elite
+		RequiresCondition: rank-elite && !steelconsortium_upgrade_resonanceammo
 		LocalOffset: 128,0,256
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: SteelRunnerPistols
-		RequiresCondition: !rank-elite
+		RequiresCondition: !rank-elite && !steelconsortium_upgrade_resonanceammo
 	Armament@GARRISONEDELITE:
 		Name: garrisoned
 		Weapon: SteelRunnerPistols_elite
-		RequiresCondition: rank-elite
+		RequiresCondition: rank-elite && !steelconsortium_upgrade_resonanceammo
 	Armament@UpgradePRIMARY:
 		Weapon: SteelRunnerPistolsResonance
 		RequiresCondition: !rank-elite && steelconsortium_upgrade_resonanceammo

--- a/tools/audit/audit_impact_glow_preservation.py
+++ b/tools/audit/audit_impact_glow_preservation.py
@@ -78,6 +78,11 @@ NON_EMISSIVE_EFFECT_ROOTS = {
 	"^Effect_Bullet_Light",
 	"^Effect_Bullet_Medium",
 	"^Effect_Bullet_Heavy",
+	# These templates historically had no impact glow.  The cryo effect also
+	# needs a dedicated cold-colour tier before it can glow without turning orange.
+	"^Effect_Cryo",
+	"^Effect_Demolition_Heavy_D2K_Orni",
+	"^Effect_MissileAP_Heavy_D2K_ORocket",
 	"^Effect_Sniper_Light",
 }
 
@@ -109,6 +114,10 @@ def sprite_root(
 		ruleset: Ruleset, name: str, sprite_effects: set[str], stack: tuple[str, ...] = ()) -> str:
 	if name.lower() in {item.lower() for item in stack}:
 		return name
+	# An explicitly classified descendant is a semantic effect boundary even if
+	# it inherits a broader sprite-bearing effect and removes/replaces that art.
+	if name in EMISSIVE_EFFECT_ROOTS or name in NON_EMISSIVE_EFFECT_ROOTS:
+		return name
 	parents = [parent for parent in direct_parents(ruleset, name) if parent in sprite_effects]
 	if not parents:
 		return name
@@ -122,6 +131,9 @@ def tier_path_count(
 	if key in memo:
 		return memo[key]
 	if key in {item.lower() for item in stack}:
+		return 0
+	if name in NON_EMISSIVE_EFFECT_ROOTS:
+		memo[key] = 0
 		return 0
 	total = 0
 	for parent in direct_parents(ruleset, name):

--- a/tools/tests/test_weapon_correctness_followups.py
+++ b/tools/tests/test_weapon_correctness_followups.py
@@ -1,0 +1,87 @@
+"""Regression checks for the post-consolidation weapon correctness fixes."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "audit"))
+
+import audit_impact_glow_preservation as glow_audit
+from miniyaml import Ruleset, load
+
+
+def child(node, key):
+    return next((item for item in node.children if item.key == key), None)
+
+
+class WeaponCorrectnessFollowupTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = Ruleset(ROOT)
+
+    def test_steel_runner_base_and_resonance_armaments_are_exclusive(self):
+        actor = self.rules.resolve("steelconsortium_steelrunner")
+        armaments = [node for node in actor.children if node.key.startswith("Armament@")]
+        runner = [node for node in armaments
+                  if (node.get("Weapon") or "").startswith("SteelRunnerPistols")]
+        self.assertEqual(8, len(runner))
+
+        for armament in runner:
+            weapon = armament.get("Weapon")
+            condition = armament.get("RequiresCondition") or ""
+            if "Resonance" in weapon:
+                self.assertIn("steelconsortium_upgrade_resonanceammo", condition)
+                self.assertNotIn("!steelconsortium_upgrade_resonanceammo", condition)
+            else:
+                self.assertIn("!steelconsortium_upgrade_resonanceammo", condition)
+
+    def test_quasar_weapons_have_one_definition_and_keep_merged_values(self):
+        path = (ROOT / "mods" / "cameo" / "ContentPacks" / "RedAlert2Mod" /
+                "AsianAlliance" / "yaml" / "weapons.yaml")
+        keys = [node.key for node in load(path)]
+        self.assertEqual(1, keys.count("AsianQuasarBoatAG"))
+        self.assertEqual(1, keys.count("AsianQuasarBoat_AA"))
+
+        expected = {
+            "AsianQuasarBoatAG": ("7168", "3", "512", "192"),
+            "AsianQuasarBoatAG_EMP": ("7168", "3", "512", "192"),
+            "AsianQuasarBoat_AA": ("7168", "3", "250", "256"),
+            "AsianQuasarBoat_EMP_AA": ("7168", "3", "250", "256"),
+        }
+        for name, (range_value, burst_delay, inaccuracy, launch_speed) in expected.items():
+            weapon = self.rules.resolve_weapon(name)
+            projectile = child(weapon, "Projectile")
+            self.assertEqual(range_value, weapon.get("Range"), name)
+            self.assertEqual(burst_delay, weapon.get("BurstDelays"), name)
+            self.assertEqual(inaccuracy, projectile.get("Inaccuracy"), name)
+            self.assertEqual(launch_speed, projectile.get("MaximumLaunchSpeed"), name)
+
+    def test_new_effect_roots_are_explicitly_non_emissive(self):
+        names = {
+            "^Effect_Cryo",
+            "^Effect_Demolition_Heavy_D2K_Orni",
+            "^Effect_MissileAP_Heavy_D2K_ORocket",
+        }
+        self.assertTrue(names <= glow_audit.NON_EMISSIVE_EFFECT_ROOTS)
+        effects = {
+            name for name in self.rules.weapons if name.startswith("^Effect")
+        }
+        sprite_effects = {
+            name for name in effects
+            if glow_audit.has_impact_sprite(self.rules.resolve_weapon(name))
+        }
+        tier_memo = {}
+        for name in names:
+            resolved = self.rules.resolve_weapon(name)
+            self.assertFalse(glow_audit.has_impact_glow(resolved), name)
+            self.assertEqual(
+                name, glow_audit.sprite_root(self.rules, name, sprite_effects), name)
+            self.assertEqual(
+                0, glow_audit.tier_path_count(self.rules, name, tier_memo), name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make Steel Runner base and resonance armaments mutually exclusive after the resonance upgrade
- collapse the duplicated Quasar Boat definitions into their exact previously merged runtime form
- classify three historically non-glowing effect roots explicitly and support descendant effect boundaries in the glow audit
- add focused regression coverage and refresh the affected Consortium balance ledger

## Gameplay impact
Steel Runner no longer fires its normal and resonance weapons simultaneously after purchasing the resonance upgrade. Quasar Boat combat behavior is unchanged. The glow classifications preserve existing visuals; no new glow is added. Pricing and the parked percentage-damage runtime fix are excluded.

## Verification
- 453 tests passed, 11 skipped
- all 2,345 resolved weapons preserve main and percentage damage versus merged PR #289
- 32 balance ledgers match the live rules
- impact-glow, empty-warhead, physical-state, duplicate-key, and retired-root audits pass
- independent adversarial review: merge-ready, no blocker
- exact runtime tree launched cleanly for 90 seconds; test process closed; no new exception log