### PR TITLE
Fix superweapon limit consistency across factions

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Harkonnen/yaml/buildings.yaml
@@ -509,6 +509,7 @@ harkonnen_palace:
 	Inherits@shape: ^3x3Shape
 	Inherits@SW: ^PrimarySuperweapon
 	Buildable:
+		-BuildLimit:
 		Prerequisites: ~harkonnen_constructionyard, harkonnen_ixresearchcenter, !opalace, ~techlevel.superweapons
 	Tooltip:
 		Name: Harkonnen Palace

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
@@ -446,7 +446,8 @@ ixian_supercomputer:
 	Inherits@shape: ^4x3Shape
 	Inherits@SW: ^PrimarySuperweapon
 	Buildable:
-		Prerequisites: ~ixian_constructionyard, ixian_ixresearchcenter, !ixian_supercomputer, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~ixian_constructionyard, ixian_ixresearchcenter, !ixian_supercomputer_swlimit, ~techlevel.superweapons
 		Description: Provides a nuclear weapon support power.
 		IconPalette: player
 	Tooltip:
@@ -505,7 +506,7 @@ ixian_supercomputer:
 		Image: ixian_supercomputer
 		Palette: td_temperat
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: ixian_supercomputer
+		Prerequisite: ixian_supercomputer_swlimit
 	-WithCrumbleOverlay:
 
 # starport_smuggler:

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/buildings.yaml
@@ -661,6 +661,7 @@ ordos_palace:
 	Inherits@shape: ^3x3Shape
 	Inherits@SW: ^PrimarySuperweapon
 	Buildable:
+		-BuildLimit:
 		Queue: Building, RABuilding
 		Prerequisites: ~ordos_constructionyard, ordos_ixresearchcenter, !opalace, ~techlevel.superweapons
 		Description: This structure unlocks support powers.

--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/defenses.yaml
@@ -5,8 +5,9 @@ ra1_allies_chronosphere:
 	Inherits@ReinforcedStructures: ^ReinforcedStructures
 	Inherits@sell: ^RASpawnActorsOnSell
 	Buildable:
+		-BuildLimit:
 		Queue: Defence, RADefence
-		Prerequisites: ~ra1_allies_alliedtechcenter, ~techlevel.superweapons, !ra1_allies_chronosphere
+		Prerequisites: ~ra1_allies_alliedtechcenter, ~techlevel.superweapons, !ra1_allies_chronosphere_swlimit
 		Description: actor_pdox.description
 	Tooltip:
 		Name: Chronosphere
@@ -147,7 +148,7 @@ ra1_allies_chronosphere:
 		BeaconActor: BLASTRADIUS.super
 		CameraRange: 12345
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: ra1_allies_chronosphere
+		Prerequisite: ra1_allies_chronosphere_swlimit
 	RenderSprites:
 		PlayerPalette: raplayer
 	WithDeathAnimation:

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/defenses.yaml
@@ -7,7 +7,8 @@ japan_japaneseshrine:
 	Tooltip:
 		Name: Japanese Shrine
 	Buildable:
-		Prerequisites: ~japan_japanesetechcenter, ~techlevel.superweapons, !japan_japaneseshrine
+		-BuildLimit:
+		Prerequisites: ~japan_japanesetechcenter, ~techlevel.superweapons, !japan_japaneseshrine_swlimit
 		Description: actor_mslo.description
 	Building:
 		Footprint: xxx xxx ===
@@ -62,7 +63,7 @@ japan_japaneseshrine:
 		CameraRange: 10000
 	SupportPowerChargeBar:
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: japan_japaneseshrine
+		Prerequisite: japan_japaneseshrine_swlimit
 	RenderSprites:
 		Image: japan_japaneseshrine
 

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/defenses.yaml
@@ -8,6 +8,7 @@ ra1_soviets_missilesilo:
 	Tooltip:
 		Name: Soviet Missile Silo
 	Buildable:
+		-BuildLimit:
 		Prerequisites: ~ra1_soviets_techcenter, ~techlevel.superweapons, !abomb
 		Description: actor_mslo.description
 	Building:
@@ -67,8 +68,9 @@ ra1_soviets_ironcurtain:
 	Inherits@SW: ^Superweapon
 	Inherits@sell: ^RASovietSpawnActorsOnSell
 	Buildable:
+		-BuildLimit:
 		Queue: Defence, RADefence
-		Prerequisites: ~ra1_soviets_techcenter, ~techlevel.superweapons
+		Prerequisites: ~ra1_soviets_techcenter, ~techlevel.superweapons, !ra1_soviets_ironcurtain_swlimit
 		Description: actor_iron.description
 	Tooltip:
 		Name: Iron Curtain
@@ -110,6 +112,9 @@ ra1_soviets_ironcurtain:
 			1: __x__ _xxx_ xxxxx _xxx_ __x__
 		DisplayTimerRelationships: Ally, Neutral, Enemy
 		BlockedCursor: move-blocked
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: ra1_soviets_ironcurtain_swlimit
+		RequiresPrerequisites: global-swlimit
 	RenderSprites:
 		PlayerPalette: raplayer
 	WithDeathAnimation:

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/defenses.yaml
@@ -74,6 +74,7 @@ ra2_allies_weathercontrolcenter:
 	Inherits@shape: ^3x3Shape
 	Inherits@sell: ^RA2ASpawnActorsOnSell
 	Buildable:
+		-BuildLimit:
 		Prerequisites: ~ra2_allies_alliedconstructionyard, ra2_allies_alliedbattlelab, !weatherstorm, ~techlevel.superweapons
 		Description: actor_gaweat.description
 	Tooltip:
@@ -136,7 +137,8 @@ ra2_allies_chronosphere:
 	Inherits@shape: ^3x4Shape
 	Inherits@sell: ^RA2ASpawnActorsOnSell
 	Buildable:
-		Prerequisites: ~ra2_allies_alliedconstructionyard, ra2_allies_alliedbattlelab, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~ra2_allies_alliedconstructionyard, ra2_allies_alliedbattlelab, ~techlevel.superweapons, !ra2_allies_chronosphere_swlimit
 		Description: actor_pdox.description
 	Tooltip:
 		Name: Chronosphere
@@ -215,6 +217,9 @@ ra2_allies_chronosphere:
 		RequiresCondition: !build-incomplete
 	WithDeathAnimation:
 		DeathSequencePalette: playerra2
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: ra2_allies_chronosphere_swlimit
+		RequiresPrerequisites: global-swlimit
 
 ra2_allies_pillbox:
 	Inherits: ^RA2Defense

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/defenses.yaml
@@ -43,6 +43,7 @@ ra2_soviets_nuclearmissilesilo:
 	Tooltip:
 		Name: Nuclear Missile Silo
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 100
 		Prerequisites: ~ra2_soviets_constructionyard, ra2_soviets_battlelab, !ra2nuke, ~techlevel.superweapons
 		Queue: Defence, RADefence
@@ -110,7 +111,8 @@ ra2_soviets_ironcurtain:
 	Inherits@shape: ^3x3Shape
 	Inherits@sell: ^RA2SSpawnActorsOnSell
 	Buildable:
-		Prerequisites: ~ra2_soviets_constructionyard, ra2_soviets_battlelab, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~ra2_soviets_constructionyard, ra2_soviets_battlelab, ~techlevel.superweapons, !ra2_soviets_ironcurtain_swlimit
 		Description: actor_iron.description
 	Tooltip:
 		Name: Iron Curtain
@@ -156,6 +158,9 @@ ra2_soviets_ironcurtain:
 	SupportPowerChargeBar:
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: ra2_soviets_ironcurtain_swlimit
+		RequiresPrerequisites: global-swlimit
 
 ra2_soviets_battlebunker:
 	Inherits: ^RA2Defense

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/defenses.yaml
@@ -130,6 +130,7 @@ yuri_psychicdominator:
 	Tooltip:
 		Name: Psychic Dominator
 	Buildable:
+		-BuildLimit:
 		Prerequisites: ~yuri_constructionyard, yuri_battlelab, !psydom, ~techlevel.superweapons
 		Description: actor_yappet.description
 	Building:
@@ -195,7 +196,8 @@ yuri_geneticmutator:
 	Tooltip:
 		Name: Genetic Mutator
 	Buildable:
-		Prerequisites: ~yuri_constructionyard, yuri_battlelab, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~yuri_constructionyard, yuri_battlelab, ~techlevel.superweapons, !yuri_geneticmutator_swlimit
 		Description: actor_yagntc.description
 	Building:
 		Footprint: =x= xxx xxx
@@ -237,6 +239,9 @@ yuri_geneticmutator:
 		LaunchSound: sgenopen.wav
 		IncomingSound: sgenopen.wav
 	SupportPowerChargeBar:
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: yuri_geneticmutator_swlimit
+		RequiresPrerequisites: global-swlimit
 
 yuri_tankbunker:
 	Inherits@2: ^RA2Defense

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/buildings.yaml
@@ -1024,7 +1024,8 @@ asianalliance_advancedcommunicationcenter:
 	Inherits@shape: ^3x3Shape
 	Inherits@sell: ^AASpawnActorsOnSell
 	Buildable:
-		Prerequisites: ~asianalliance_asianconstructionyard, asianalliance_asianbattlelab, !asianalliance_advancedcommunicationcenter, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~asianalliance_asianconstructionyard, asianalliance_asianbattlelab, !asianalliance_advancedcommunicationcenter_swlimit, ~techlevel.superweapons
 		Description: actor_cgionc.description
 	Tooltip:
 		Name: Advanced Communication Center
@@ -1069,7 +1070,7 @@ asianalliance_advancedcommunicationcenter:
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: asianalliance_advancedcommunicationcenter
+		Prerequisite: asianalliance_advancedcommunicationcenter_swlimit
 
 asianalliance_chaosstorminductor:
 	Inherits: ^RA2Building
@@ -1080,7 +1081,8 @@ asianalliance_chaosstorminductor:
 	Tooltip:
 		Name: Chaos Storm Inductor
 	Buildable:
-		Prerequisites: ~asianalliance_asianconstructionyard, asianalliance_asianbattlelab, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~asianalliance_asianconstructionyard, asianalliance_asianbattlelab, ~techlevel.superweapons, !asianalliance_chaosstorminductor_swlimit
 		Description: actor_cgchao.description
 	Building:
 		Footprint: =x= xxx xxx
@@ -1120,6 +1122,9 @@ asianalliance_chaosstorminductor:
 		LaunchSound: sgenopen.wav
 		IncomingSound: sgenopen.wav
 	SupportPowerChargeBar:
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: asianalliance_chaosstorminductor_swlimit
+		RequiresPrerequisites: global-swlimit
 
 cgyard.asian:
 	Inherits: ^RA2Building

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/buildings.yaml
@@ -362,7 +362,8 @@ steelconsortium_orbitalcannonactivator:
 	Inherits@SteelConsortiumNaniteInfusion: ^SteelConsortiumNaniteInfusion
 	Inherits@SteelConsortiumFerrocrete: ^SteelConsortiumFerrocrete
 	Buildable:
-		Prerequisites: ~steelconsortium_consortiumconstructionyard, steelconsortium_consortiumbattlelab, !steelconsortium_orbitalcannonactivator, ~techlevel.superweapons
+		-BuildLimit:
+		Prerequisites: ~steelconsortium_consortiumconstructionyard, steelconsortium_consortiumbattlelab, !steelconsortium_orbitalcannonactivator_swlimit, ~techlevel.superweapons
 		Description: actor_cgionc.description
 	Tooltip:
 		Name: Orbital Cannon Activator
@@ -407,7 +408,7 @@ steelconsortium_orbitalcannonactivator:
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: steelconsortium_orbitalcannonactivator
+		Prerequisite: steelconsortium_orbitalcannonactivator_swlimit
 	WithIdleOverlay@lights:
 		Sequence: idle-lights
 		RequiresCondition: !build-incomplete
@@ -652,9 +653,11 @@ steelconsortium_bfg10000:
 	Buildable:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 70
-		BuildLimit: 1
-		Prerequisites: ~steelconsortium_consortiumconstructionyard, steelconsortium_consortiumbattlelab, ~techlevel.superweapons
+		Prerequisites: ~steelconsortium_consortiumconstructionyard, steelconsortium_consortiumbattlelab, ~techlevel.superweapons, !steelconsortium_bfg10000_swlimit
 		Description: actor_gun.description
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: steelconsortium_bfg10000_swlimit
+		RequiresPrerequisites: global-swlimit
 	Valued:
 		Cost: 10000
 	Tooltip:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
@@ -699,10 +699,11 @@ naxis_naxirocketsilo:
 	Tooltip:
 		Name: Naxi Rocket Silo
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 100
 		BuildDuration: 1500
 		BuildDurationModifier: 100
-		Prerequisites: ~naxis_constructionyard, naxis_techcenter, !naxis_naxirocketsilo, ~techlevel.superweapons
+		Prerequisites: ~naxis_constructionyard, naxis_techcenter, !naxis_naxirocketsilo_swlimit, ~techlevel.superweapons
 		Queue: Defence, RADefence
 		Description: actor_nax_rocket.description
 	Building:
@@ -756,7 +757,7 @@ naxis_naxirocketsilo:
 	SupportPowerChargeBar:
 	WithSupportPowerActivationAnimation:
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: naxis_naxirocketsilo
+		Prerequisite: naxis_naxirocketsilo_swlimit
 
 ####################################################################################################
 #		Red Alert 2 Moon Naxis Structures

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/buildings.yaml
@@ -378,8 +378,9 @@ schwarzermond_meteortractionray:
 	Tooltip:
 		Name: Meteor Traction Ray
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 100
-		Prerequisites: ~schwarzermond_constructionyard, schwarzermond_techcenter, !schwarzermond_meteortractionray, ~techlevel.superweapons
+		Prerequisites: ~schwarzermond_constructionyard, schwarzermond_techcenter, !schwarzermond_meteortractionray_swlimit, ~techlevel.superweapons
 		Queue: Defence, RADefence
 		Description: actor_namisl.description
 	Building:
@@ -436,7 +437,7 @@ schwarzermond_meteortractionray:
 	SupportPowerChargeBar:
 	WithSupportPowerActivationAnimation:
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: schwarzermond_meteortractionray
+		Prerequisite: schwarzermond_meteortractionray_swlimit
 
 # nax2_chrono:
 # 	Inherits: ^RA2Building

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
@@ -483,6 +483,7 @@ latinsyndicate_topolsilo:
 	Tooltip:
 		Name: Topol Silo
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 100
 		BuildDuration: 1500
 		BuildDurationModifier: 100

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/buildings.yaml
@@ -580,6 +580,7 @@ protoss_fleetbeacon:
 		Name: Fleet Beacon
 	ProvidesPrerequisite@buildingname:
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 130
 		Prerequisites: ~protoss_nexus, protoss_stargate, !SCPurifierStrike
 		Queue: Building, RABuilding

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/defenses.yaml
@@ -193,7 +193,8 @@ terran_missilesilo:
 	Power:
 		Amount: 0
 	Buildable:
-		Prerequisites: ~terran_commandcenter, terran_sciencefacility, ~techlevel.superweapons, !terran_missilesilo
+		-BuildLimit:
+		Prerequisites: ~terran_commandcenter, terran_sciencefacility, ~techlevel.superweapons, !terran_missilesilo_swlimit
 		Description: actor_mslo.description
 	Building:
 		Footprint: xx xx
@@ -246,7 +247,7 @@ terran_missilesilo:
 	# WithSupportPowerActivationAnimation:
 	# 	RequiresCondition: !build-incomplete
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: terran_missilesilo
+		Prerequisite: terran_missilesilo_swlimit
 	Voiced:
 		VoiceSet: SCNuclearSiloVoice
 	RenderSprites:

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/buildings.yaml
@@ -529,6 +529,7 @@ cabal_core:
 	HitShape:
 		TargetableOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	Buildable:
+		-BuildLimit:
 		Queue: Building, RABuilding
 		BuildPaletteOrder: 150
 		Prerequisites: ~cabal_constructionyard, cabal_techcenter
@@ -566,6 +567,9 @@ cabal_core:
 			cabalcore_silo: !build-incomplete && !cabalnuke
 	ProvidesPrerequisite@cabalnuke:
 		Prerequisite: cabalnuke
+		RequiresCondition: cabalnuke
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: cabalnuke_swlimit
 		RequiresCondition: cabalnuke
 	NukePowerCA:
 		OrderName: CabalMagicNuke

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
@@ -56,7 +56,7 @@ cabal_missilesilo:
 		BuildPaletteOrder: 100
 		BuildDuration: 1500
 		BuildDurationModifier: 100
-		Prerequisites: ~cabal_core, cabal_core, !cabalnuke, ~techlevel.superweapons
+		Prerequisites: ~cabal_core, cabal_core, !cabalnuke_swlimit, ~techlevel.superweapons
 		Description: actor_cabal_missilesilo.description
 	Power:
 		Amount: -100

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/defenses.yaml
@@ -51,10 +51,11 @@ forgotten_veinhole:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Buildable:
+		-BuildLimit:
 		Description: actor_forgotten_veinhole.description
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 140
-		Prerequisites: ~forgotten_constructionyard, forgotten_church, ~techlevel.superweapons, !forgotten_veinhole
+		Prerequisites: ~forgotten_constructionyard, forgotten_church, ~techlevel.superweapons, !forgotten_veinhole_swlimit
 	Tooltip:
 		Name: actor_forgotten_veinhole.name
 	Armor:
@@ -117,7 +118,7 @@ forgotten_veinhole:
 	# 	RequiresCondition: !build-incomplete
 	# 	Sequence: smoke
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: forgotten_veinhole
+		Prerequisite: forgotten_veinhole_swlimit
 	SupportPowerChargeBar:
 	RenderSprites:
 		PlayerPalette: player

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/buildings.yaml
@@ -600,7 +600,7 @@ ts_gdi_ioncannonuplink:
 		BuildPaletteOrder: 10
 		BuildDuration: 1500
 		BuildDurationModifier: 100
-		Prerequisites: ~ts_gdi_upgradecenter, !ionc, !droppod, ~techlevel.superweapons
+		Prerequisites: ~ts_gdi_upgradecenter, !ionc, !droppod, !tsionc, ~techlevel.superweapons
 		Description: Unlocks the Ion Cannon superweapon.
 	Plug:
 		Type: ioncannon
@@ -640,9 +640,10 @@ ts_gdi_upgradecenter:
 	Inherits@SW: ^PrimarySuperweapon
 	Inherits@plugproducer: ^BuildingPlugProducer
 	Buildable:
+		-BuildLimit:
 		Queue: Building, RABuilding
 		BuildPaletteOrder: 160
-		Prerequisites: ~ts_gdi_constructionyard, ts_gdi_techcenter, !tsionc, ~techlevel.superweapons
+		Prerequisites: ~ts_gdi_constructionyard, ts_gdi_techcenter, ~techlevel.superweapons
 		Description: actor_ts_gdi_upgradecenter.description
 	Tooltip:
 		Name: Upgrade Center
@@ -727,6 +728,7 @@ ts_gdi_upgradecenter:
 		TargetCircleColor: ff000080
 	ProvidesPrerequisite@swlimit:
 		Prerequisite: tsionc
+		RequiresCondition: ionc
 	RenderSprites:
 		PlayerPalette: playerra2
 

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
@@ -47,9 +47,10 @@ ts_nod_missilesilo:
 	Selectable:
 		Bounds: 2048, 2048
 	Buildable:
+		-BuildLimit:
 		Queue: Defence, RADefence
 		BuildPaletteOrder: 140
-		Prerequisites: ~ts_nod_constructionyard, ts_nod_techcenter, !ts_nod_missilesilo, ~techlevel.superweapons
+		Prerequisites: ~ts_nod_constructionyard, ts_nod_techcenter, !ts_nod_missilesilo_swlimit, ~techlevel.superweapons
 		Description: actor_ts_nod_missilesilo.description
 	Tooltip:
 		Name: Missile Silo
@@ -181,7 +182,7 @@ ts_nod_missilesilo:
 		RequiresCondition: !build-incomplete
 		Sequence: smoke
 	ProvidesPrerequisite@swlimit:
-		Prerequisite: ts_nod_missilesilo
+		Prerequisite: ts_nod_missilesilo_swlimit
 	SupportPowerChargeBar:
 	RenderSprites:
 		PlayerPalette: playerra2

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/buildings.yaml
@@ -488,9 +488,12 @@ wc2_humans_magetower:
 	Tooltip:
 		Name: Mage Tower
 	Buildable:
-		Prerequisites: ~wc2_humans_townhall, wc2_humans_castle
+		-BuildLimit:
+		Prerequisites: ~wc2_humans_townhall, wc2_humans_castle, !wc2_humans_magetower_swlimit
 		Queue: Building, RABuilding
 		Description: Teaches men in arcane magicks.\nTrains Mages.\nUnlocks Blizzard superweapon.
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: wc2_humans_magetower_swlimit
 	SpawnActorsOnSell:
 		ActorTypes: wc2_humans_footman
 	Voiced:

--- a/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/buildings.yaml
@@ -434,9 +434,12 @@ wc2_orcs_templeofthedamned:
 	Tooltip:
 		Name: Temple of the Damned
 	Buildable:
-		Prerequisites: ~wc2_orcs_greathall, wc2_orcs_fortress
+		-BuildLimit:
+		Prerequisites: ~wc2_orcs_greathall, wc2_orcs_fortress, !wc2_orcs_templeofthedamned_swlimit
 		Queue: Building, RABuilding
 		Description: Terrible rituals are performed here.\nTrains Death Knights and raise Skeletons.\nUnlocks Death & Decay superweapon.
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: wc2_orcs_templeofthedamned_swlimit
 	SpawnActorsOnSell:
 		ActorTypes: wc2_orcs_grunt
 	Voiced:

--- a/mods/cameo/rules/outpost2.yaml
+++ b/mods/cameo/rules/outpost2.yaml
@@ -1133,10 +1133,13 @@ EDEN_SPACEPORT:
 	ProvidesPrerequisite:
 		Prerequisite: EDEN_SPACEPORT
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 130
 		Queue: Building, RABuilding
-		Prerequisites: ~eden_factory_structure, EDEN_LAB_ADVANCED
+		Prerequisites: ~eden_factory_structure, EDEN_LAB_ADVANCED, !eden_spaceport_swlimit
 		Description: eden_spaceport.description
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: eden_spaceport_swlimit
 
 EDEN_SOLAR_ARRAY:
 	Inherits: ^OP2BaseSolarArray
@@ -2307,10 +2310,13 @@ PLYMOUTH_SPACEPORT:
 	ProvidesPrerequisite:
 		Prerequisite: PLYMOUTH_SPACEPORT
 	Buildable:
+		-BuildLimit:
 		BuildPaletteOrder: 130
 		Queue: Building, RABuilding
-		Prerequisites: ~PLYMOUTH_STRUCTURE_FACTORY,PLYMOUTH_LAB_ADVANCED
+		Prerequisites: ~PLYMOUTH_STRUCTURE_FACTORY,PLYMOUTH_LAB_ADVANCED, !plymouth_spaceport_swlimit
 		Description: plymouth_spaceport.description
+	ProvidesPrerequisite@swlimit:
+		Prerequisite: plymouth_spaceport_swlimit
 
 PLYMOUTH_SOLARARRAY:
 	Inherits: ^OP2BaseSolarArray


### PR DESCRIPTION
## Summary
- remove inherited hard `BuildLimit` values from affected superweapon structures so the **Unlimited** lobby setting permits multiple copies
- gate per-structure prerequisite markers behind the existing `global-swlimit` option so **Limited** still restricts each superweapon structure to one
- cover special cases including TS GDI/CABAL add-ons, Warcraft II tech structures, Outpost 2 spaceports, and the Consortium BFG

## Scope
- Cameo YAML only: 24 active rules files
- no Cameo-engine, engine pin, C#, asset, or lobby-default changes

## Verification
- `git diff --check` passes after rebasing onto current `upstream/master`
- active include coverage and limited/unlimited prerequisite polarity independently reviewed with no logic blockers
- in-game: default lobby setting observed as Unlimited
- in-game Unlimited: two Eden Spaceports placed and the build icon remained available
- in-game Limited: the first Eden Spaceport placed and a second could not be purchased
- clean user-run retest passed on current `upstream/master` using a freshly built runtime at the pinned engine commit `462fc1fc4bfc490c42b88b429670c7f0c64c7aca`