### PR TITLE
balance: add the pipeline orchestrator, which immediately found the ledgers stale

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -334,6 +334,37 @@ and reported fourteen phantom FAILEDs. Latent for as long as the file has had co
 because nobody ever diffed the fallback against the canonical path. Fixed, with a regression test
 in `tools/tests/test_audit_run_all_parser.py`.
 
+### 3.0e — ⛔ The balance ledgers are stale on master (found 2026-08-28)
+
+`python tools/balance/run_pipeline.py` — the new orchestrator — came back FAIL on its
+first real run against `4643c3ee`:
+
+| stage | result |
+|---|--:|
+| drift — yaml vs committed ledger | **FAIL: 22 of 33 raw ledgers stale, 5 model** |
+| multiplier modifiers integer | PASS |
+| generator reproduces every family | PASS — drift 0 across 139 templates |
+| empty warhead types | PASS — 0 of 2839 |
+
+`CLAUDE.md` rule 3 already warns that `audit_balance_drift` "only helps if someone
+LOOKS", and that it had gone red twice for exactly this. **This is the third time.**
+The last commit to re-extract was #293; something after it moved yaml without running
+step 1.
+
+**The remedy is one command**, and it belongs to whoever lands the next balance commit
+rather than to a drive-by — the weapon-consolidation flow already re-extracts, and a
+single commit that skipped it left 22 ledgers stale:
+
+```sh
+python tools/balance/extract_stats.py     # or: run_pipeline.py --extract
+```
+
+then commit the ledgers together with the yaml that moved them.
+
+⚠ Do not read this as licence to hand-edit a ledger number. Re-extraction regenerates
+the ledger *from* yaml — the sanctioned direction. Editing a ledger to make drift go
+away inverts the pipeline and is exactly what rule 3 forbids.
+
 ### 3.0d — Read before proposing pipeline architecture
 
 [`design/BALANCE_PIPELINE_GAPS.md`](design/BALANCE_PIPELINE_GAPS.md) records what a single

--- a/docs/design/BALANCE_PIPELINE.md
+++ b/docs/design/BALANCE_PIPELINE.md
@@ -12,6 +12,23 @@ the same pipeline.
 
 ## 0. The core loop (maintainer's target workflow)
 
+**One command runs the verifying half of this loop in order:**
+
+```sh
+python tools/balance/run_pipeline.py              # verify — writes nothing
+python tools/balance/run_pipeline.py --extract    # + step 1, refresh the ledgers
+python tools/balance/run_pipeline.py --workbook   # + step 3, rebuild the workbooks
+python tools/balance/run_pipeline.py --dry-run    # print the plan, run nothing
+```
+
+It executes steps 1, 3, 7 and 8 plus the structural gates, reports each stage's real
+exit code, and **stops at step 6**. It cannot apply: there is no flag that reaches
+`--confirm`, because an approval gate a tool can open by itself is not a gate. When the
+verify stage is clean it prints the command for the maintainer to type.
+
+Steps 2, 4 and 6 are human by definition — a balance decision is not a transformation —
+and the runner lists them as such instead of skipping them quietly.
+
 ```
 1. pull    yaml ──► JSON ledger          python tools/balance/extract_stats.py
 2. edit    change values in the ledger (or in the generated sheet)
@@ -44,12 +61,13 @@ that cannot work as stated — four independently-writable copies of the
 same numbers is how drift is CREATED, not prevented. The goal (never
 manually checking mirrors) is kept, but through two rules:
 
-- **Single writer at any moment.** A tiny state file
-  (`docs/balance/.session`) records which representation is "open"
-  (yaml | ledger | sheet). Pipeline commands move values in ONE
-  direction and flip the state; running a command against a stale
-  state aborts with instructions. Mirrors are verified at rest, not
-  hoped for during writes.
+- **Single writer at any moment.** ⚠ **PROPOSED, NEVER BUILT.** The v2 plan called for
+  a state file (`docs/balance/.session`) recording which representation is "open"
+  (yaml | ledger | sheet), so a command run against a stale state would abort. No such
+  file exists and no tool reads one — this paragraph described it in the present tense
+  for long enough that it read as shipped. What actually enforces the invariant is the
+  weaker but real pair below: one direction per command, and the drift audit catching
+  disagreement after the fact rather than preventing it during the write.
 - **The workbook is a WORKBENCH, not a source.** xlsx is binary —
   concurrent agents + git = unmergeable conflicts. The committed
   truths are exactly two: yaml (runtime) and the JSON ledger (balance).

--- a/docs/design/BALANCE_PIPELINE_GAPS.md
+++ b/docs/design/BALANCE_PIPELINE_GAPS.md
@@ -135,11 +135,37 @@ above it.
 
 | gap | why it matters |
 |---|---|
-| **No orchestrator.** 50+ scripts in `tools/balance/`, no `run_pipeline`-style entry point. | Every run is a hand-sequenced chain, so the order is tribal knowledge and a skipped re-extract goes unnoticed until `audit_balance_drift` catches it later. |
+| ~~**No orchestrator.**~~ **CLOSED** — `tools/balance/run_pipeline.py`. | It ran the documented order on its first real pass and immediately found what the gap predicted: 22 of 33 raw ledgers stale against yaml. See §3b. |
 | **No exception registry.** | Heroes, superweapons, harvesters, transports and promotion-only actors have no declared escape from class pricing, so each pass re-litigates them. |
 | **No constraint reporting.** | When a computed value exceeds what the engine can carry, nothing records *desired* alongside *implementable*. A silent clamp changes the model without saying so. |
 | **No determinism check.** | Ordering, locale and float behaviour are unverified; the compiler property (same inputs → same outputs) is intended but unmeasured. |
 | **Strategic layer absent.** | Counterplay, role coverage, tech reachability and economic tempo are not modelled anywhere, so a unit can price correctly and still be unhealthy. |
+
+### 3b. What the orchestrator found on its first run
+
+`run_pipeline.py` executes steps 1, 3, 7 and 8 plus the structural gates, reports each
+stage's real exit code, and stops at step 6. It cannot apply — no flag reaches
+`--confirm`, because a gate a tool can open by itself is not a gate.
+
+Its first real run came back **FAIL**, on the oldest known failure mode in this
+programme:
+
+| stage | result |
+|---|--:|
+| drift — yaml vs committed ledger | **FAIL**: 22 of 33 raw ledgers stale, 5 model |
+| multiplier modifiers integer | PASS |
+| generator reproduces every family | PASS — drift 0 across 139 templates |
+| empty warhead types | PASS — 0 of 2839 |
+
+`CLAUDE.md` already warns that `audit_balance_drift` "only helps if someone LOOKS", and
+that it had gone red twice for exactly this reason. This is the third time. The last
+commit to re-extract was #293; something after it moved yaml without re-running step 1.
+
+⭐ The remedy is one command — `python tools/balance/extract_stats.py`, then commit the
+ledgers with the yaml — and it belongs to whoever lands the next balance commit, not to
+a drive-by. The weapon-consolidation work already re-extracts as part of its flow; a
+single commit that skipped it left 22 ledgers stale. That is the argument for a runner
+in the documented order rather than a discipline nobody can see failing.
 
 The first three are mechanical and can be built without touching a balance number. The last two
 are design work that must not run ahead of the W-board.

--- a/tools/balance/run_pipeline.py
+++ b/tools/balance/run_pipeline.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""run_pipeline.py — the single entry point for the balance pipeline.
+
+`BALANCE_PIPELINE.md` §0 defines the loop as nine numbered steps plus two extra
+proposal steps for a class rebalance. Every step already has a tool. What did not
+exist was anything that runs them **in the documented order**, so the order lived in
+prose and in whoever had read it most recently — which is how a commit lands with the
+yaml moved and the ledger not re-extracted, and `audit_balance_drift` finds it later.
+
+This runs the loop and stops where the law says to stop.
+
+    python tools/balance/run_pipeline.py                 # verify: writes nothing
+    python tools/balance/run_pipeline.py --extract       # + refresh the ledgers
+    python tools/balance/run_pipeline.py --workbook      # + rebuild the workbooks
+    python tools/balance/run_pipeline.py --faction ra1_soviets
+
+WHAT IT DELIBERATELY WILL NOT DO
+================================
+
+It never calls `apply_balance.py --confirm`, and there is no flag that makes it.
+
+That is not timidity, it is the approval gate: CLAUDE.md rule 3 puts `--confirm`
+behind an explicit maintainer order, and a wrapper that can reach it turns "a human
+decided" into "a script was run". When the verify stage is clean the runner prints the
+exact command to type; typing it stays the maintainer's act.
+
+The same reasoning bars a `--yes`-style escape. An approval gate a tool can open on
+its own is not a gate.
+
+EXIT CODE
+=========
+
+The runner's exit code is the worst stage result, and a stage's result is that
+subprocess's real return code. It is never the exit code of an `echo` that happened to
+follow it — that mistake once had the suite reported green for a week while it was
+exiting 1 on every run (`HANDOFF.md` §3.0c).
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "audit"))
+import environment  # noqa: E402  (must follow the sys.path insert)
+
+PYTHON = sys.executable
+
+# Force UTF-8 out of every child regardless of the console codepage. A Windows console
+# defaults to cp1252 and silently writes `—` as 0x97, which is how a tracked report
+# ended up not being valid UTF-8 (CLAUDE.md rule 8).
+CHILD_ENV = dict(__import__("os").environ, PYTHONIOENCODING="utf-8")
+
+
+class Stage:
+    """One documented step: what it is, what it runs, and whether it may write."""
+
+    def __init__(self, step: str, name: str, cmd: list[str], *, writes: bool = False,
+                 blocking: bool = True):
+        self.step, self.name, self.cmd = step, name, cmd
+        self.writes, self.blocking = writes, blocking
+        self.code: int | None = None
+        self.skipped = ""
+
+
+def plan(args) -> list[Stage]:
+    """The stages, in BALANCE_PIPELINE.md §0 order.
+
+    Steps 2, 4 and 6 are human steps — edit the ledger, tune the sheet, order the
+    apply. They are not automatable by definition, so they appear in the report as
+    gaps rather than being silently skipped.
+    """
+    fac = ["--faction", args.faction] if args.faction else []
+    stages = [
+        Stage("7", "drift: yaml vs committed ledger",
+              [PYTHON, "tools/balance/extract_stats.py", "--check", *fac]),
+        Stage("8", "multiplier modifiers are integer percentages",
+              [PYTHON, "tools/audit/audit_multiplier_modifiers.py"]),
+        Stage("-", "balance-drift audit (the run_all gate)",
+              [PYTHON, "tools/audit/audit_balance_drift.py"]),
+        Stage("-", "generator reproduces every ^Warhead_ family",
+              [PYTHON, "tools/balance/verify_generator_sync.py"]),
+        Stage("-", "no empty warhead types (the boot-NRE class)",
+              [PYTHON, "tools/audit/find_empty_warhead.py"]),
+    ]
+    if args.extract:
+        # ⚠ Step 1 runs AFTER the step-7 drift check, not before it. `--check`
+        # re-extracts in memory and diffs against the ledger ON DISK, so extracting
+        # first overwrites the very thing the check compares against and the check
+        # can never fail. Running the check first answers the question that matters —
+        # "was the ledger stale?" — and the extract then fixes it.
+        stages.insert(1, Stage("1", "extract: yaml -> raw + derived ledgers",
+                               [PYTHON, "tools/balance/extract_stats.py", *fac],
+                               writes=True))
+        # A stale ledger is precisely what --extract exists to repair, so the check
+        # reports it without failing the run. Every stage after the extract still gates.
+        stages[0].blocking = False
+    if args.workbook:
+        stages.append(Stage("3", "build the faction/type workbooks",
+                            [PYTHON, "tools/balance/build_workbook.py"], writes=True))
+    return stages
+
+
+def run(stage: Stage, dry: bool) -> None:
+    if dry:
+        stage.skipped = "dry-run"
+        return
+    stage.code = subprocess.run(stage.cmd, cwd=ROOT, env=CHILD_ENV).returncode
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--extract", action="store_true",
+                    help="refresh docs/balance/*.json from yaml (writes tracked files)")
+    ap.add_argument("--workbook", action="store_true",
+                    help="rebuild the faction/type workbooks (writes tracked files)")
+    ap.add_argument("--faction", help="ledger-name substring filter")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the plan and run nothing")
+    args = ap.parse_args()
+
+    print("# balance pipeline\n")
+
+    reasons = environment.incomplete()
+    if reasons:
+        print("⚠ **Incomplete environment.** These stages read only tracked files and are")
+        print("unaffected, but a full `run_all.sh` from this tree would under-report:\n")
+        for r in reasons:
+            print(f"  * {r}")
+        print()
+
+    stages = plan(args)
+    for s in stages:
+        run(s, args.dry_run)
+
+    print("| step | stage | writes | result |")
+    print("|---|---|---|---|")
+    worst = 0
+    for s in stages:
+        if s.skipped:
+            result = f"_{s.skipped}_"
+        elif s.code == 0:
+            result = "PASS"
+        else:
+            result = f"**FAIL ({s.code})**"
+            if s.blocking:
+                worst = max(worst, s.code or 1)
+        print(f"| {s.step} | {s.name} | {'yes' if s.writes else 'no'} | {result} |")
+
+    print("\n## Steps this cannot do for you\n")
+    print("| step | why |")
+    print("|---|---|")
+    print("| 2 · edit the ledger | a balance decision, not a transformation |")
+    print("| 4 · tune Cost in the sheet | same |")
+    print("| 5 · import the sheet | only meaningful after step 4; "
+          "`import_workbook.py --workbook faction\\|type` |")
+    print("| 6 · apply to yaml | **the approval gate** — see below |")
+
+    if args.dry_run:
+        print("\n_Dry run: nothing was executed._")
+        return 0
+
+    print()
+    if worst:
+        print(f"**FAIL** — the pipeline is not in a state to propose from. Fix the "
+              f"failing stages above first; a target computed on a tree whose ledger "
+              f"already disagrees with its yaml is a target for a game that does not "
+              f"exist.")
+        return worst
+
+    print("**PASS** — yaml and the ledger agree, and the structural gates are clean.\n")
+    print("Applying is the maintainer's act, not this runner's. When a target has been")
+    print("written into the ledger and signed off (W11), the command is:\n")
+    fac = f" --faction {args.faction}" if args.faction else " --faction <name>"
+    print(f"    python tools/balance/apply_balance.py{fac} --confirm\n")
+    print("then re-run this to verify, run `bash tools/audit/run_all.sh`, and boot-gate")
+    print("before committing the yaml and the ledger together.")
+    print("\n⚠ Signed-off class anchors today: check `docs/balance/class_anchors.json`. "
+          "While that count is 0, `--confirm` is a no-op and no price in the tree is final.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_pipeline.py
+++ b/tools/tests/test_run_pipeline.py
@@ -1,0 +1,124 @@
+"""Unit tests for tools/balance/run_pipeline.py.
+
+The runner's whole value is that it executes BALANCE_PIPELINE.md §0 in the documented
+order instead of leaving that order in prose. Two properties have to hold or it is worse
+than nothing:
+
+  1. It can NEVER apply. CLAUDE.md rule 3 puts `apply_balance --confirm` behind an
+     explicit maintainer order. A wrapper able to reach it converts "a human decided"
+     into "a script ran", and the gate stops being a gate. This is asserted against the
+     built plan AND against the module source, because the dangerous version of this
+     regression is someone adding a convenience flag later.
+
+  2. Its exit code is the worst REAL stage code. Reporting a wrapper's success instead
+     of the thing it wrapped is how the audit suite was believed green for a week while
+     exiting 1 on every run (HANDOFF §3.0c).
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import unittest
+
+import _bootstrap  # noqa: F401 — sys.path side effect
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "balance"))
+import run_pipeline as rp  # noqa: E402
+
+
+def args(**kw):
+    ns = argparse.Namespace(extract=False, workbook=False, faction=None, dry_run=False)
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+class NeverApplies(unittest.TestCase):
+    def test_no_planned_stage_can_apply(self):
+        for a in (args(), args(extract=True), args(workbook=True),
+                  args(extract=True, workbook=True, faction="ra1_soviets")):
+            for stage in rp.plan(a):
+                joined = " ".join(stage.cmd)
+                self.assertNotIn("apply_balance", joined)
+                self.assertNotIn("--confirm", joined)
+
+    def test_the_module_never_names_confirm_as_an_argument(self):
+        # A future `--confirm` / `--yes` flag would defeat the gate. The string may
+        # appear in prose and in the command the runner PRINTS for the maintainer to
+        # type, but never as something argparse accepts.
+        src = pathlib.Path(rp.__file__).read_text(encoding="utf-8")
+        for flag in ('add_argument("--confirm"', "add_argument('--confirm'",
+                     'add_argument("--yes"', 'add_argument("--apply"'):
+            self.assertNotIn(flag, src)
+
+
+class PlanOrder(unittest.TestCase):
+    def test_verify_default_writes_nothing(self):
+        self.assertTrue(all(not s.writes for s in rp.plan(args())))
+
+    def test_the_drift_check_runs_BEFORE_the_extract(self):
+        """The ordering that makes the check mean anything.
+
+        `extract_stats.py --check` re-extracts in memory and diffs against the ledger
+        ON DISK. Extract first and the check compares the file it just wrote against
+        itself: it passes unconditionally and the runner reports a clean tree while
+        the ledger was stale. Check first and it answers the real question.
+        """
+        p = rp.plan(args(extract=True))
+        steps = [s.step for s in p]
+        self.assertLess(steps.index("7"), steps.index("1"))
+        extract = p[steps.index("1")]
+        self.assertTrue(extract.writes)
+        self.assertNotIn("--check", " ".join(extract.cmd))
+
+    def test_a_stale_ledger_does_not_fail_a_repair_run(self):
+        # A stale ledger is the condition --extract exists to fix, so the diagnostic
+        # check reports without gating. Everything after the extract still gates.
+        repair = rp.plan(args(extract=True))
+        self.assertFalse(repair[0].blocking)
+        self.assertTrue(all(s.blocking for s in repair[1:]))
+        # Without --extract nothing is being repaired, so the same stage gates.
+        self.assertTrue(rp.plan(args())[0].blocking)
+
+    def test_workbook_is_last(self):
+        p = rp.plan(args(workbook=True))
+        self.assertTrue(p[-1].writes)
+        self.assertIn("build_workbook.py", " ".join(p[-1].cmd))
+
+    def test_faction_filter_reaches_the_tools_that_accept_it(self):
+        cmds = [" ".join(s.cmd) for s in rp.plan(args(extract=True, faction="d2k_ordos"))]
+        passing = [c for c in cmds if "d2k_ordos" in c]
+        self.assertTrue(passing)
+        for c in passing:
+            self.assertIn("extract_stats.py", c)
+
+
+class ExitCode(unittest.TestCase):
+    """The runner reports the worst real stage code, never a wrapper's."""
+
+    def worst(self, codes):
+        stages = rp.plan(args())
+        for s, c in zip(stages, codes):
+            s.code = c
+        return max((s.code for s in stages if s.blocking and s.code), default=0)
+
+    def test_all_clean(self):
+        self.assertEqual(self.worst([0, 0, 0, 0, 0]), 0)
+
+    def test_one_failure_surfaces(self):
+        self.assertEqual(self.worst([0, 1, 0, 0, 0]), 1)
+
+    def test_worst_of_several_wins(self):
+        self.assertEqual(self.worst([1, 0, 2, 0, 0]), 2)
+
+    def test_a_dry_run_stage_is_not_a_pass(self):
+        s = rp.plan(args())[0]
+        rp.run(s, dry=True)
+        self.assertIsNone(s.code)
+        self.assertEqual(s.skipped, "dry-run")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`BALANCE_PIPELINE.md` §0 defines the loop as nine numbered steps. Every step already had a tool. What did not exist was anything that ran them **in the documented order** — so the order lived in prose, and in whoever had read it most recently.

```sh
python tools/balance/run_pipeline.py              # verify — writes nothing
python tools/balance/run_pipeline.py --extract    # + step 1, refresh the ledgers
python tools/balance/run_pipeline.py --workbook   # + step 3, rebuild the workbooks
python tools/balance/run_pipeline.py --dry-run    # print the plan, run nothing
```

## It cannot apply, and there is no flag that makes it

Rule 3 puts `apply_balance --confirm` behind an explicit maintainer order. A wrapper able to reach it turns "a human decided" into "a script ran". When verify is clean the runner prints the command for the maintainer to type; typing it stays their act.

Two tests pin this — one over the built plan, one over the **module source**, because the dangerous regression is a convenience flag added six months from now.

Steps 2, 4 and 6 are human by definition — a balance decision is not a transformation — so the runner lists them as gaps rather than skipping them quietly.

## What it found on its first real run

**FAIL**, on the oldest known failure mode in this programme:

| stage | result |
|---|--:|
| drift — yaml vs committed ledger | **FAIL: 22 of 33 raw stale, 5 model** |
| multiplier modifiers integer | PASS |
| generator reproduces every family | PASS — drift 0 across 139 templates |
| empty warhead types | PASS — 0 of 2839 |

`CLAUDE.md` already warns that `audit_balance_drift` *"only helps if someone LOOKS"*, and that it had gone red twice for exactly this. **This is the third time.** The last commit to re-extract was #293; something after it moved yaml without running step 1.

Recorded in HANDOFF §3.0e with the one-command remedy — which belongs to whoever lands the next balance commit, not to a drive-by. The weapon-consolidation flow already re-extracts as part of its cycle; a single commit that skipped it left 22 ledgers stale. **That is the argument for a runner rather than a discipline nobody can watch failing.**

## A bug I put in and took back out before shipping

The first version ran step 1 before the step-7 drift check, following the document's numbering. That is wrong here.

`extract_stats.py --check` re-extracts in memory and diffs against the ledger **on disk** — so extracting first overwrites the very thing the check compares against. It passes unconditionally, and the runner reports a clean tree while the ledger is stale: a green light produced by the tool that exists to catch exactly that.

The check now runs first, and in `--extract` mode it reports **without gating**, because a stale ledger is the condition `--extract` exists to repair. Everything after the extract still gates.

The document's 1→7 order isn't wrong — it's the order of the *full* loop, where step 7 verifies after step 6 has changed yaml. A verify-only runner is a different traversal of the same graph.

## Also fixed: a documented file that was never built

`BALANCE_PIPELINE.md` §1 described `docs/balance/.session` — a state file recording which representation is "open", so a command run against a stale state aborts — **in the present tense**. No such file exists and no tool reads one. It has read as shipped for long enough to be worth saying plainly. What actually holds the invariant is the weaker but real pair below it: one direction per command, plus a drift audit that catches disagreement after the fact rather than preventing it during the write.

## Verification

```
python -m unittest        486 tests, all green (11 skipped) — 11 new
audit_doc_health          PASS, D1–D8
run_pipeline --dry-run    plan order asserted: 7 → 1 → 8 → gates → 3
real run                  exit 1, correctly, on the drift above
```

**Boot gate: not run, not applicable.** Tooling and documentation only — no `mods/` yaml, no C#, no `mod.config`. Nothing here writes a balance number.

**Ownership:** `tools/balance/` is actively worked by Blackrobe (W23/W24 consolidation). This adds two new files and modifies none of theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7)_