### PR TITLE
balance: measure the compiler property instead of assuming it

### DIFF
--- a/docs/design/BALANCE_PIPELINE.md
+++ b/docs/design/BALANCE_PIPELINE.md
@@ -29,6 +29,24 @@ verify stage is clean it prints the command for the maintainer to type.
 Steps 2, 4 and 6 are human by definition — a balance decision is not a transformation —
 and the runner lists them as such instead of skipping them quietly.
 
+**The compiler property is measured, not assumed:**
+
+```sh
+python tools/balance/check_determinism.py                  # all ledgers
+python tools/balance/check_determinism.py --faction d2k_ordos
+python tools/balance/run_pipeline.py --determinism         # as a pipeline stage
+```
+
+It extracts twice in **separate processes** under different `PYTHONHASHSEED` and `TZ`,
+builds the ledgers in memory, and compares every artifact byte for byte. Separate
+processes are the point: inside one interpreter the hash seed is fixed, so set and dict
+iteration order is stable by accident and an ordering leak stays invisible.
+
+Nothing is written under `docs/balance/` — a tool that verifies the ledgers must never
+be able to be the thing that moved them. `serialize()` already writes `sort_keys=True`,
+so mapping order is safe; what this catches is a **list** built by iterating a set,
+plus timestamps, timezone-dependent values and absolute paths reaching an artifact.
+
 ```
 1. pull    yaml ──► JSON ledger          python tools/balance/extract_stats.py
 2. edit    change values in the ledger (or in the generated sheet)

--- a/docs/design/BALANCE_PIPELINE_GAPS.md
+++ b/docs/design/BALANCE_PIPELINE_GAPS.md
@@ -138,7 +138,7 @@ above it.
 | ~~**No orchestrator.**~~ **CLOSED** — `tools/balance/run_pipeline.py`. | It ran the documented order on its first real pass and immediately found what the gap predicted: 22 of 33 raw ledgers stale against yaml. See §3b. |
 | **No exception registry.** | Heroes, superweapons, harvesters, transports and promotion-only actors have no declared escape from class pricing, so each pass re-litigates them. |
 | **No constraint reporting.** | When a computed value exceeds what the engine can carry, nothing records *desired* alongside *implementable*. A silent clamp changes the model without saying so. |
-| **No determinism check.** | Ordering, locale and float behaviour are unverified; the compiler property (same inputs → same outputs) is intended but unmeasured. |
+| ~~**No determinism check.**~~ **CLOSED** — `tools/balance/check_determinism.py`. | Measured at `c653f160`: **65 artifacts byte-identical** across two hash seeds and two timezones. The property held; what changed is that it is now evidence rather than an assumption. See §3c. |
 | **Strategic layer absent.** | Counterplay, role coverage, tech reachability and economic tempo are not modelled anywhere, so a unit can price correctly and still be unhealthy. |
 
 ### 3b. What the orchestrator found on its first run
@@ -171,6 +171,32 @@ The first three are mechanical and can be built without touching a balance numbe
 are design work that must not run ahead of the W-board.
 
 ---
+
+### 3c. Determinism, measured
+
+`check_determinism.py` extracts twice in **separate processes** under different
+`PYTHONHASHSEED` and `TZ`, builds the ledgers in memory, and compares every artifact
+byte for byte. Separate processes are the design: inside one interpreter the hash seed
+is fixed, so set and dict iteration order is stable by accident and an ordering leak
+stays invisible. Nothing is written under `docs/balance/` — a tool that verifies the
+ledgers must never be able to be the thing that moved them.
+
+**Result at `c653f160`: 65 of 65 artifacts byte-identical.** Raw ledgers, derived
+sidecars and the model constants all reproduce.
+
+That is a good answer, and it is worth being precise about what it is worth. It shows
+those two configurations agree. It is not a theorem: a different OS, Python version,
+filesystem ordering or locale is a separate experiment, and nondeterminism that is
+stable within a process but varies by machine is invisible to it.
+
+⭐ **A checker that cannot fail is worse than no checker**, because it manufactures
+confidence. This one was proven against an injected fault before being trusted — a list
+built by iterating a set of eight strings, the exact bug class it claims to catch. It
+named the artifact, the line and both values, gave the right diagnosis, and exited 1.
+Do that to any gate before believing its green.
+
+`serialize()` already writes `sort_keys=True`, so mapping order was never the risk.
+Sorting keys does nothing for the order of a **list**, which is where a set leaks.
 
 ## 4. Design guidance worth keeping — non-binding
 

--- a/tools/balance/check_determinism.py
+++ b/tools/balance/check_determinism.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""check_determinism.py — does the extract produce the same ledgers twice?
+
+The balance pipeline is supposed to behave like a compiler: the same tree, the same
+model and the same tools produce the same numbers. `BALANCE_PIPELINE.md` rests on it —
+a raw-ledger diff is only allowed to mean "the game changed", and a derived diff only
+"the model changed". If extraction is not deterministic, both sentences are false and
+`audit_balance_drift` starts reporting noise as if it were a balance edit.
+
+Nothing measured that. This does.
+
+    python tools/balance/check_determinism.py
+    python tools/balance/check_determinism.py --faction ra1_soviets   # fast scope
+    python tools/balance/check_determinism.py --keep                  # keep the dumps
+
+HOW
+===
+
+Extraction runs twice, in SEPARATE PROCESSES with different `PYTHONHASHSEED` and `TZ`.
+Separate processes are the whole point: within one interpreter every run shares a hash
+seed, so set and dict iteration order is stable by accident and an ordering leak stays
+invisible. Across two seeds it shows up immediately.
+
+Each run builds the ledgers IN MEMORY and dumps them to its own temp directory. Nothing
+is written under `docs/balance/`, so this can never be the thing that moved a ledger.
+
+WHAT IT CATCHES
+===============
+
+  ordering   a list built by iterating a set or an unordered dict
+  hashing    anything whose output depends on `hash()` of a str/bytes/frozenset
+  time       a timestamp, date or timezone-dependent value reaching an artifact
+  paths      an absolute path baked into output
+
+`serialize()` already writes `sort_keys=True`, so mapping order is not at risk — but
+sorting keys does nothing for the order of a LIST, which is exactly where a set leaks.
+
+WHAT IT DOES NOT CATCH
+======================
+
+A single green run proves these two configurations agree. It does not prove the
+pipeline is deterministic everywhere: a different OS, Python version, filesystem
+ordering or locale is a different experiment. It also cannot see nondeterminism that
+is stable within a process but varies by machine. Report it as what it is — evidence,
+not a theorem.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# Runs the real extraction in-memory and dumps each artifact to $CAMEO_DUMP.
+# It deliberately reuses extract_stats' own serialize(), so a serialization change is
+# inside what is being tested rather than beside it.
+DRIVER = r"""
+import json, os, pathlib, sys
+sys.path.insert(0, str(pathlib.Path(os.environ["CAMEO_ROOT"]) / "tools" / "balance"))
+import extract_stats as es
+from cameo_model import Model
+
+out = pathlib.Path(os.environ["CAMEO_DUMP"]); out.mkdir(parents=True, exist_ok=True)
+only = os.environ.get("CAMEO_ONLY") or None
+
+ledgers, sidecars = es.build_both(Model(), only)
+for name, doc in ledgers.items():
+    (out / f"raw__{name}.json").write_text(es.serialize(doc), encoding="utf-8")
+for name, doc in sidecars.items():
+    (out / f"derived__{name}.json").write_text(es.serialize(doc), encoding="utf-8")
+(out / "model___model.json").write_text(es.serialize(es.model_constants()),
+                                        encoding="utf-8")
+"""
+
+
+def one_run(dump: pathlib.Path, seed: str, tz: str, only: str | None) -> None:
+    env = dict(os.environ,
+               PYTHONHASHSEED=seed,
+               TZ=tz,
+               LC_ALL="C",
+               PYTHONIOENCODING="utf-8",
+               CAMEO_ROOT=str(ROOT),
+               CAMEO_DUMP=str(dump))
+    if only:
+        env["CAMEO_ONLY"] = only
+    else:
+        env.pop("CAMEO_ONLY", None)
+    r = subprocess.run([sys.executable, "-c", DRIVER], cwd=ROOT, env=env)
+    if r.returncode != 0:
+        raise SystemExit(f"extraction failed under PYTHONHASHSEED={seed} "
+                         f"(exit {r.returncode}) — fix that before reading determinism")
+
+
+def digest(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def first_difference(a: pathlib.Path, b: pathlib.Path) -> str:
+    """The first line that differs, with its number — not just 'hashes differ'.
+
+    A hash mismatch alone sends someone hunting through a 40 000-line JSON file. The
+    line is usually enough to name the leaking field on sight.
+    """
+    la = a.read_text(encoding="utf-8").splitlines()
+    lb = b.read_text(encoding="utf-8").splitlines()
+    for i, (x, y) in enumerate(zip(la, lb), 1):
+        if x != y:
+            return f"line {i}\n      run A: {x.strip()[:100]}\n      run B: {y.strip()[:100]}"
+    if len(la) != len(lb):
+        return f"identical for {min(len(la), len(lb))} lines, then lengths differ " \
+               f"({len(la)} vs {len(lb)})"
+    return "no line differs — the bytes differ (line endings or trailing whitespace)"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--faction", help="ledger-name substring filter (much faster)")
+    ap.add_argument("--keep", action="store_true",
+                    help="keep both dump directories for inspection")
+    args = ap.parse_args()
+
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="cameo_determinism_"))
+    a, b = tmp / "runA", tmp / "runB"
+
+    print("# balance determinism\n")
+    print("Two extractions, separate processes, different hash seed and timezone.")
+    print("Nothing is written under `docs/balance/`.\n")
+    print("| run | PYTHONHASHSEED | TZ |")
+    print("|---|---|---|")
+    print("| A | 0 | UTC |")
+    print("| B | 524287 | Australia/Eucla |")
+    print()
+
+    try:
+        one_run(a, "0", "UTC", args.faction)
+        # A deliberately awkward zone: +8:45, so a half-hour assumption breaks too.
+        one_run(b, "524287", "Australia/Eucla", args.faction)
+
+        names = sorted({p.name for p in a.glob("*.json")} |
+                       {p.name for p in b.glob("*.json")})
+        if not names:
+            print("**FAIL** — the extraction produced no artifacts to compare.")
+            return 2
+
+        missing, differing = [], []
+        for n in names:
+            pa, pb = a / n, b / n
+            if not pa.exists() or not pb.exists():
+                missing.append(n)
+            elif digest(pa) != digest(pb):
+                differing.append(n)
+
+        print(f"Artifacts compared: **{len(names)}**\n")
+        if not missing and not differing:
+            print(f"**PASS** — all {len(names)} artifacts are byte-identical across "
+                  "both configurations.\n")
+            print("This is evidence, not a proof: it shows these two configurations "
+                  "agree.\nA different OS, Python version or filesystem ordering is a "
+                  "separate experiment.")
+            return 0
+
+        print("**FAIL** — extraction is not reproducible.\n")
+        for n in missing:
+            print(f"* `{n}` — produced by only one of the two runs")
+        for n in differing:
+            print(f"* `{n}` — differs at {first_difference(a / n, b / n)}")
+        print("\nA difference under a changed hash seed is almost always a LIST built "
+              "by iterating\na set or an unordered mapping. `serialize()` sorts dict "
+              "keys, so mapping order is\nalready safe — sort the list at the point it "
+              "is built, not at the point it is written.")
+        if not args.keep:
+            print(f"\n_Re-run with `--keep` to inspect both dumps._")
+        return 1
+    finally:
+        if args.keep:
+            print(f"\ndumps: {a}\n      {b}")
+        else:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/balance/run_pipeline.py
+++ b/tools/balance/run_pipeline.py
@@ -12,6 +12,7 @@ This runs the loop and stops where the law says to stop.
     python tools/balance/run_pipeline.py                 # verify: writes nothing
     python tools/balance/run_pipeline.py --extract       # + refresh the ledgers
     python tools/balance/run_pipeline.py --workbook      # + rebuild the workbooks
+    python tools/balance/run_pipeline.py --determinism   # + extract twice and compare
     python tools/balance/run_pipeline.py --faction ra1_soviets
 
 WHAT IT DELIBERATELY WILL NOT DO
@@ -100,6 +101,12 @@ def plan(args) -> list[Stage]:
     if args.workbook:
         stages.append(Stage("3", "build the faction/type workbooks",
                             [PYTHON, "tools/balance/build_workbook.py"], writes=True))
+    if args.determinism:
+        # Opt-in: it extracts twice, so it costs roughly two full runs. Last, because
+        # it answers "is the compiler property holding" rather than "is the tree sane",
+        # and there is no point asking that of a tree that already failed a gate.
+        stages.append(Stage("-", "determinism: same inputs, same ledgers",
+                            [PYTHON, "tools/balance/check_determinism.py", *fac]))
     return stages
 
 
@@ -118,6 +125,9 @@ def main() -> int:
     ap.add_argument("--workbook", action="store_true",
                     help="rebuild the faction/type workbooks (writes tracked files)")
     ap.add_argument("--faction", help="ledger-name substring filter")
+    ap.add_argument("--determinism", action="store_true",
+                    help="also extract twice under different hash seeds and compare "
+                         "(costs two full extractions)")
     ap.add_argument("--dry-run", action="store_true",
                     help="print the plan and run nothing")
     args = ap.parse_args()

--- a/tools/tests/test_check_determinism.py
+++ b/tools/tests/test_check_determinism.py
@@ -1,0 +1,115 @@
+"""Unit tests for tools/balance/check_determinism.py.
+
+The failure mode for a determinism checker is that it always says PASS. It runs, it
+looks green, and the property it claims to guard was never measured. So the tests here
+are mostly about the machinery that decides FAIL, plus the two design choices the whole
+thing rests on:
+
+  * two SEPARATE processes with different `PYTHONHASHSEED`. Within one interpreter the
+    seed is fixed, so set and dict iteration order is stable by accident and an
+    ordering leak is invisible. One process = a checker that cannot fail.
+  * nothing written under `docs/balance/`. A tool that verifies the ledgers must never
+    be able to be the thing that moved them.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+import _bootstrap  # noqa: F401 — sys.path side effect
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "balance"))
+import check_determinism as cd  # noqa: E402
+
+
+class Design(unittest.TestCase):
+    def test_the_driver_never_writes_into_the_tracked_ledgers(self):
+        # It dumps to $CAMEO_DUMP, a temp dir. If this ever gained a docs/balance
+        # path the verifier could corrupt what it verifies.
+        self.assertIn("CAMEO_DUMP", cd.DRIVER)
+        self.assertNotIn("docs/balance", cd.DRIVER)
+        self.assertNotIn("docs\\balance", cd.DRIVER)
+
+    def test_the_driver_reuses_the_real_serializer(self):
+        # Serialization must be inside what is tested, not beside it — otherwise a
+        # change to how ledgers are written is invisible to the check.
+        self.assertIn("es.serialize", cd.DRIVER)
+        self.assertIn("build_both", cd.DRIVER)
+
+    def test_it_covers_raw_derived_and_model(self):
+        for prefix in ("raw__", "derived__", "model___model"):
+            self.assertIn(prefix, cd.DRIVER)
+
+
+class FirstDifference(unittest.TestCase):
+    """The report has to name a line. 'Hashes differ' sends someone hunting."""
+
+    def setUp(self):
+        self.tmp = pathlib.Path(tempfile.mkdtemp())
+
+    def write(self, name, text):
+        p = self.tmp / name
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def test_names_the_first_differing_line(self):
+        a = self.write("a", "same\nsame\nALPHA\nsame\n")
+        b = self.write("b", "same\nsame\nBRAVO\nsame\n")
+        out = cd.first_difference(a, b)
+        self.assertIn("line 3", out)
+        self.assertIn("ALPHA", out)
+        self.assertIn("BRAVO", out)
+
+    def test_reports_a_length_difference_when_the_prefix_matches(self):
+        a = self.write("a", "one\ntwo\n")
+        b = self.write("b", "one\ntwo\nthree\n")
+        out = cd.first_difference(a, b)
+        self.assertIn("lengths differ", out)
+        self.assertIn("2", out)
+        self.assertIn("3", out)
+
+    def test_byte_difference_with_no_differing_line(self):
+        # Trailing-newline / line-ending differences produce equal splitlines().
+        a = self.write("a", "one\ntwo\n")
+        b = self.write("b", "one\ntwo")
+        self.assertIn("bytes differ", cd.first_difference(a, b))
+
+    def test_identical_files_have_equal_digests(self):
+        a = self.write("a", "identical\n")
+        b = self.write("b", "identical\n")
+        self.assertEqual(cd.digest(a), cd.digest(b))
+
+    def test_different_files_have_different_digests(self):
+        a = self.write("a", "left\n")
+        b = self.write("b", "right\n")
+        self.assertNotEqual(cd.digest(a), cd.digest(b))
+
+
+class SeedVariation(unittest.TestCase):
+    """The seeds must actually differ, or the check is theatre."""
+
+    def test_the_two_documented_runs_use_different_seeds_and_zones(self):
+        src = pathlib.Path(cd.__file__).read_text(encoding="utf-8")
+        self.assertIn('one_run(a, "0", "UTC"', src)
+        # Any second seed is fine; it must not be 0, and the zone must not be UTC.
+        self.assertRegex(src, r'one_run\(b, "(?!0")\d+", "(?!UTC")[\w/]+"')
+
+    def test_a_run_pins_the_environment_it_claims_to_pin(self):
+        import inspect
+        src = inspect.getsource(cd.one_run)
+        for key in ("PYTHONHASHSEED", "TZ", "LC_ALL", "PYTHONIOENCODING"):
+            self.assertIn(key, src)
+
+    def test_a_failed_extraction_is_not_reported_as_determinism(self):
+        # If extraction itself breaks, saying "not reproducible" would be a lie about
+        # which property failed.
+        import inspect
+        src = inspect.getsource(cd.one_run)
+        self.assertIn("extraction failed", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_run_pipeline.py
+++ b/tools/tests/test_run_pipeline.py
@@ -29,7 +29,8 @@ import run_pipeline as rp  # noqa: E402
 
 
 def args(**kw):
-    ns = argparse.Namespace(extract=False, workbook=False, faction=None, dry_run=False)
+    ns = argparse.Namespace(extract=False, workbook=False, faction=None,
+                            dry_run=False, determinism=False)
     for k, v in kw.items():
         setattr(ns, k, v)
     return ns
@@ -93,6 +94,21 @@ class PlanOrder(unittest.TestCase):
         self.assertTrue(passing)
         for c in passing:
             self.assertIn("extract_stats.py", c)
+
+
+class DeterminismStage(unittest.TestCase):
+    def test_off_by_default(self):
+        self.assertTrue(all("check_determinism" not in " ".join(s.cmd)
+                            for s in rp.plan(args())))
+
+    def test_runs_last_when_asked_for(self):
+        # It answers "is the compiler property holding", which is not worth asking of
+        # a tree that already failed a structural gate.
+        p = rp.plan(args(determinism=True, workbook=True))
+        self.assertIn("check_determinism", " ".join(p[-1].cmd))
+
+    def test_it_writes_nothing(self):
+        self.assertFalse(rp.plan(args(determinism=True))[-1].writes)
 
 
 class ExitCode(unittest.TestCase):


### PR DESCRIPTION
The whole balance architecture rests on one sentence: **the same tree, the same model and the same tools produce the same numbers.** `BALANCE_PIPELINE.md` leans on it hard — a raw ledger diff is only allowed to mean *"the game changed"*, a derived diff only *"the model changed"*. If extraction is not reproducible, both sentences are false and `audit_balance_drift` starts reporting noise as though it were a balance edit.

Nothing had ever measured it.

```sh
python tools/balance/check_determinism.py
python tools/balance/check_determinism.py --faction d2k_ordos
python tools/balance/run_pipeline.py --determinism
```

## Result: 65 of 65 artifacts byte-identical at `c653f160`

Raw ledgers, derived sidecars and the model constants all reproduce. **The property was holding** — what changed is that it is now evidence rather than an assumption.

Worth being precise about what that is worth. It shows two configurations agree. It is *not* a theorem: a different OS, Python version, filesystem ordering or locale is a separate experiment, and nondeterminism that is stable within a process but varies by machine is invisible to it. The report says so rather than printing an unqualified green.

## How, and why that shape

Two extractions in **separate processes** under different `PYTHONHASHSEED` and `TZ`.

Separate processes are the entire point: inside one interpreter the hash seed is fixed, so set and dict iteration order is stable *by accident* and an ordering leak stays invisible. **A single-process version of this check could not fail.**

Each run builds the ledgers in memory and dumps to its own temp directory. Nothing is written under `docs/balance/` — a tool that verifies the ledgers must never be able to be the thing that moved them. A test pins that the driver contains no `docs/balance` path.

The driver calls `extract_stats`' own `build_both()` and `serialize()`, so serialization is *inside* what is being tested rather than beside it.

`serialize()` already writes `sort_keys=True`, so mapping order was never the risk. Sorting keys does nothing for the order of a **list**, which is exactly where a set leaks — so that is what the failure message names.

## Proven against an injected fault before being trusted

A checker that cannot fail is worse than no checker, because it manufactures confidence. This one was tested by injecting the exact bug class it claims to catch — a list built by iterating a set of eight strings — into a scratch copy:

```
* `raw__leaky.json` — differs at line 3
      run A: "alpha",
      run B: "charlie",
```

Right artifact, right line, both values, right diagnosis, exit 1. **Only then was its PASS worth anything.**

The failure report names the artifact *and* the first differing line with both values, because "hashes differ" sends someone hunting through a 40 000-line JSON file.

## Orchestrator

Wired as an opt-in stage, **last**: it answers "is the compiler property holding" rather than "is the tree sane", and there is no point asking that of a tree that already failed a structural gate. Off by default because it costs two full extractions.

## Verification

```
check_determinism        PASS — 65/65 byte-identical, at c653f160
injected-fault proof     FAIL, correct artifact/line/diagnosis, exit 1
python -m unittest       500 tests, all green (11 skipped) — 14 new
audit_doc_health         PASS, D1–D8
run_pipeline --dry-run   determinism stage last, writes nothing
```

**Boot gate: not run, not applicable.** Tooling and documentation only — no `mods/` yaml, no C#, no `mod.config`. Nothing here writes a balance number, and the new tool cannot write to `docs/balance/` at all.

---

Gap status after this: orchestrator **closed**, determinism **closed**. Exception registry remains seedable-but-not-urgent (its value lands at pricing, blocked on W11). Constraint reporting stays **blocked** until engine limits are written down — still not inventing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7)_