### PR TITLE
docs: recover the two files the compaction lost for real

### DIFF
--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -82,6 +82,7 @@ win — **unless the artifact says otherwise, and then the artifact wins and you
 - [Between-cell movement responsiveness (2026-08-11)](#between-cell-movement-responsiveness-2026-08-11)
 - [`docs/audit/latest/` is environment-bound — an incomplete tree reports LESS and still says PASS (2026-08-23)](#docsauditlatest-is-environment-bound--an-incomplete-tree-reports-less-and-still-says-pass-2026-08-23)
 - [Two ways a gate passes its own verification and is still broken (2026-08-23)](#two-ways-a-gate-passes-its-own-verification-and-is-still-broken-2026-08-23)
+- ["Regenerable" is a claim about a tool, and it needs running (2026-08-28)](#regenerable-is-a-claim-about-a-tool-and-it-needs-running-2026-08-28)
 
 ---
 
@@ -1031,6 +1032,51 @@ its own `GONE` table, and D4 for its own example anchor. A detector that scans t
 will eventually scan itself and its tests; write the exclusion when you add the check, not after
 it fires.
 
+
+## "Regenerable" is a claim about a tool, and it needs running (2026-08-28)
+
+The 83→43 documentation compaction deleted 40 files. Its commit message said **nothing was
+summarised away** and that every merged file's content lines had been checked for presence
+in the target — verified mechanically, 0 lines lost.
+
+That claim was true, and it covered the wrong set.
+
+It described the files that were **merged**. Alongside them, fifteen files were **deleted
+outright** on the grounds that they were generated and could be rebuilt on demand. That
+second claim was asserted, not tested.
+
+Re-checking it later, by diffing every deleted file's content lines against the whole live
+corpus:
+
+| outcome | count |
+|---|--:|
+| carried across into a merge target | 24 |
+| deleted, regeneration **verified by running the generator** | 13 |
+| deleted, **not regenerable** | 2 |
+
+The two that were not:
+
+* `docs/balance/BALANCE_AUDIT.md` — a per-unit formula-price-vs-cost delta report. Its
+  generator, `tools/balance/_balance_audit_report.py`, raises `ModuleNotFoundError: No
+  module named 'scout_rebalance_proposal_final'`. The module was removed long ago;
+  `propose_class_rebalance.py` even carries a comment saying those modules no longer
+  exist. The script is dead, nothing runs it, and nobody noticed because nobody ran it.
+* `docs/balance/proposal_vehicle_defense_anchors.md` — deleted with thirteen
+  `proposal_*.md` siblings, but it is not one of them. The proposer writes
+  `proposal_<class>_infantry.md`; this name matches no pattern and a repo-wide search
+  finds no generator at all. It was deleted by resemblance.
+
+Both are restored under `docs/history/balance/` with banners, because their numbers
+predate W24 and are provenance rather than current truth.
+
+⭐ **Deleting a generated artifact is safe exactly when the generator runs.** That is one
+command, and skipping it converts a reversible cleanup into permanent loss that a green
+verification report actively conceals — the check that ran measured merges, and the files
+at risk were the ones it did not cover. Run the generator, or keep the file.
+
+⭐ **Group deletions inherit the safety of the group's weakest member.** Fourteen files
+were removed under one justification; thirteen deserved it. A filename that merely looks
+like the others is the one to check individually, because resemblance is not provenance.
 ## `Inherits` POSITION is semantic, not cosmetic (2026-08-16)
 
 **The last node wins, and `Inherits` is a node.** `MiniYaml` walks a definition's children

--- a/docs/history/balance/BALANCE_AUDIT.md
+++ b/docs/history/balance/BALANCE_AUDIT.md
@@ -1,0 +1,51 @@
+> ⚠ **ARCHIVED — provenance, not current truth.**
+>
+> Deleted by the 83→43 documentation compaction (`20f15194`) and restored here on
+> 2026-08-28 after a mechanical re-check found it was **not regenerable**, unlike the
+> thirteen `proposal_*.md` reports deleted alongside it. Its generator, `tools/balance/_balance_audit_report.py`, raises `ModuleNotFoundError: No module named 'scout_rebalance_proposal_final'` — a module removed long ago. The script is dead and nothing runs it.
+>
+> Its numbers are a snapshot of a **pre-W24 tree**: the weapon rebuild has moved damage
+> structure since, so read it for method and for what was measured at the time, never as
+> a current statement about the roster.
+
+# Infantry Rebalance Delta Audit
+
+This audit lists every unit whose formula price does not match its target cost
+within +/- 1 credit.  The range solver is used to identify whether the mismatch
+can be fixed by a simple range adjustment or whether the cost/stat/tech combination
+is inconsistent with the class band.
+
+## scout
+
+- Total units: 17
+- Units with |Δ| > 1: 13
+
+| actor | HP | spd | current rng | cost | formula price | Δ | required rng | in band | min price in band | max price in band | recommendation |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `asianalliance_asianmilitia` | 24000 | 53 | 5500 | 110 | 64 | -46 | 1710.9 | False | 127 | 132 | cost too high for band; lower cost to ~132 or raise hp/dps |
+| `ixian_lightinfantry` | 32000 | 56 | 4580 | 150 | 157 | +7 | 667.0 | False | 222 | 236 | cost too high for band; lower cost to ~236 or raise hp/dps |
+| `ordos_lightinfantry` | 28000 | 62 | 5490 | 120 | 105 | -15 | -1481.2 | False | 175 | 183 | cost too high for band; lower cost to ~183 or raise hp/dps |
+| `latinsyndicate_latinmilitia` | 25000 | 51 | 4570 | 250 | 253 | +3 | 5173.5 | False | 258 | 284 | cost too low for band; raise cost to ~258 or lower hp/dps |
+| `naxis_naxiriflerecruit` | 21000 | 48 | 4560 | 75 | 98 | +23 | -1562.2 | False | 140 | 149 | cost too high for band; lower cost to ~149 or raise hp/dps |
+| `ra1_soviets_ak47conscript` | 44000 | 71 | 4540 | 200 | 649 | +449 | -461.7 | False | 647 | 722 | cost too high for band; lower cost to ~722 or raise hp/dps |
+| `ra2_allies_gi` | 50000 | 50 | 4520 | 200 | 472 | +272 | -52.9 | False | 491 | 544 | cost too high for band; lower cost to ~544 or raise hp/dps |
+| `forgotten_mutant` | 45000 | 65 | 4590 | 160 | 248 | +88 | -2025.9 | False | 342 | 366 | cost too high for band; lower cost to ~366 or raise hp/dps |
+| `ra2_soviets_conscript` | 26000 | 58 | 4510 | 100 | 223 | +123 | -1192.5 | False | 253 | 276 | cost too high for band; lower cost to ~276 or raise hp/dps |
+| `tkm_trooper` | 33000 | 59 | 4500 | 360 | 358 | -2 | 5148.7 | False | 374 | 412 | cost too low for band; raise cost to ~374 or lower hp/dps |
+| `td_gdi_minigunner` | 31000 | 63 | 5480 | 100 | 67 | -33 | -11720.1 | False | 163 | 166 | cost too high for band; lower cost to ~166 or raise hp/dps |
+| `ra1_allies_rifleinfantry` | 27000 | 55 | 4550 | 100 | 116 | +16 | -1806.7 | False | 177 | 187 | cost too high for band; lower cost to ~187 or raise hp/dps |
+| `ra1_soviets_rifleinfantry` | 34000 | 54 | 4530 | 100 | 151 | +51 | -3063.4 | False | 221 | 235 | cost too high for band; lower cost to ~235 or raise hp/dps |
+
+## closecombat
+
+- Total units: 4
+- Units with |Δ| > 1: 0
+
+No delta issues.
+
+## special_forces
+
+- Total units: 19
+- Units with |Δ| > 1: 0
+
+No delta issues.

--- a/docs/history/balance/proposal_vehicle_defense_anchors.md
+++ b/docs/history/balance/proposal_vehicle_defense_anchors.md
@@ -1,0 +1,85 @@
+> ⚠ **ARCHIVED — provenance, not current truth.**
+>
+> Deleted by the 83→43 documentation compaction (`20f15194`) and restored here on
+> 2026-08-28 after a mechanical re-check found it was **not regenerable**, unlike the
+> thirteen `proposal_*.md` reports deleted alongside it. It does not match `propose_class_rebalance.py`'s `proposal_<class>_infantry.md` output pattern, and a repo-wide search finds no generator for it at all.
+>
+> Its numbers are a snapshot of a **pre-W24 tree**: the weapon rebuild has moved damage
+> structure since, so read it for method and for what was measured at the time, never as
+> a current statement about the roster.
+
+# PROPOSAL — vehicle + defense class anchors (baseline + verifier)
+
+> **⚠ STALE for LightTank and MBT.** The LightTank anchor was LOCKED by the maintainer
+> on 2026-07-25 at **40000 HP / 4000 dmg / 40 reload / cost0 400** (see
+> `anchor_decisions_log.md`), superseding the 50000/5000/50/500 proposed below.
+> The MBT anchor (Tiger) is also locked at the values shown in
+> `anchor_decisions_log.md`. The remaining classes below are still proposals
+> pending maintainer confirmation.
+
+_Maintainer asked me to **propose, you confirm** (2026-07-25). Every class gets a **baseline** (the
+100% anchor) **and a verifier** (the 250% tripwire = **2× HP + 2× DPS + 2.5× cost**, same range/
+speed as the baseline) — because the baseline→verifier band holds ~80% of units. Grounded in the
+real Cameo roster + the **Tiger MBT** anchor (100000 HP / 100 spd / 5000 rng / 10000 dmg / 50 reload
+/ **cost0 800**, DPS 200). Numbers are round-number **proposals** — edit any cell. Nothing applied;
+no yaml/anchors touched until you sign off. Run order after confirm: create the 4 new templates
+(boot-gated) → `fit_class` per class → sign._
+
+DPS shown = damage ÷ reload. Verifier target = **2× the baseline's HP and DPS, 2.5× its cost0,
+identical range + speed** (so the tier/role cancels and the identity is exact); its named unit is
+**restatted** to that target.
+
+## Vehicle classes
+
+| Class | Baseline unit | HP | Spd | Rng | Dmg | Reld | **cost0** | Verifier unit (→ restat 2×/2×/2.5×) |
+|---|---|--:|--:|--:|--:|--:|--:|---|
+| **LightTank** (NEW) | `ra1_allies_alliedlighttank` | 50000 | 120 | 4500 | 5000 | 50 | **500** | `td_nod_lighttank` → 100000/·/·/10000@50 / **1250** |
+| **MBT** (exists = Tiger) | `tiger.nax` | 100000 | 100 | 5000 | 10000 | 50 | **800** | `td_gdi_battletank` → 200000/·/·/20000@50 / **2000** |
+| **HighTechTank** | `ra1_allies_alliedtigerheavytank` | 130000 | 90 | 5500 | 14000 | 50 | **1300** | `naxis_kingtigerheavytank` → 260000/·/·/28000@50 / **3250** |
+| **TankDestroyer** (NEW) | `ra2_allies_tankdestroyer` | 70000 | 95 | 6500 | 18000 | 60 | **900** | `ra1_allies_alliedtankdestroyer` → 140000/·/·/36000@60 / **2250** |
+| **AntiAirTank** (NEW) | `ra2_soviets_flaktrack` | 50000 | 110 | 6000 | 4000 | 20 | **600** | `ra1_allies_alliedheavyaatank` → 100000/·/·/8000@20 / **1500** |
+| **ArtilleryTank** (NEW) | `naxis_brummbr` (Brummbär) | 80000 | 80 | 9000 | 12000 | 90 | **1000** | `naxis_sturmtiger` → 160000/·/·/24000@90 / **2500** |
+| **Artillery** | `ra1_allies_alliedartillery` | 25000 | 70 | 12000 | 15000 | 100 | **700** | `ra1_soviets_v2rocketlauncher` → 50000/·/·/30000@100 / **1750** |
+| **FireSupport** | `td_gdi_archerartillery` | 60000 | 80 | 7000 | 12000 | 60 | **900** | *(needs a clean sibling — flag)* → 120000/·/·/24000@60 / **2250** |
+| **LineBreaker** | `cabal_manticore` (dual weapon) | 90000 | 90 | 5500 | 10000 | 50 | **1000** | *(needs a clean sibling — flag)* → 180000/·/·/20000@50 / **2500** |
+| **ScoutVehicle** | `td_nod_buggy` | 30000 | 140 | 5000 | 4000 | 40 | **350** | `ra1_soviets_gatlingtank` → 60000/·/·/8000@40 / **875** |
+| ~~**SupportVehicle**~~ | **EXEMPT** — no consistent damage ⇒ not in the pipeline at all (maintainer 2026-07-25) | | | | | | | — |
+
+## Defense classes
+
+Defenses are static → the formula's "speed" term needs a convention (legacy = speed 100; pipeline
+§5 wants a **footprint/power-draw** substitute). **Using speed 100 as a placeholder here — needs a
+ruling.** Also note the §7 building damage-exemption (defenses effectively tankier than HP alone).
+
+| Class | Baseline unit | HP | Spd* | Rng | Dmg | Reld | **cost0** | Verifier unit (→ restat 2×/2×/2.5×) |
+|---|---|--:|--:|--:|--:|--:|--:|---|
+| **BasicDefense** | `ra2_allies_pillbox` | 80000 | 100 | 5000 | 8000 | 40 | **600** | `ra2_soviets_sentrygun`/`flakcannon` → 160000/·/·/16000@40 / **1500** |
+| **AdvancedDefense** | `ra2_soviets_teslacoil` | 120000 | 100 | 6500 | 16000 | 50 | **1400** | `ra2_allies_prismtower` → 240000/·/·/32000@50 / **3500** |
+| **SuperDefense** | `ra2_allies_grandcannon` | 200000 | 100 | 8000 | 25000 | 60 | **3000** | *(faction super-defense sibling)* → 400000/·/·/50000@60 / **7500** |
+| **AntiAirDefense** | `ra2_allies_patriotmissilesystem` | 90000 | 100 | 7000 | 6000 | 25 | **900** | `ra1_soviets_samsite` → 180000/·/·/12000@25 / **2250** |
+| **Bunker** | `ra2_soviets_battlebunker` | 100000 | 100 | (garrison) | — | — | **600** | `yuri_tankbunker` — garrison-damage, likely baseline-only / special |
+
+\* placeholder — resolve the defense mobility-term convention first.
+
+## Open flags (need your call)
+
+1. **Defense mobility term** — speed 100 placeholder, or the footprint/power-draw substitute (pipeline §5)?
+2. **FireSupport + LineBreaker verifiers** — thin candidates in the RA2/TD/RA1 pull (both are more TS/
+   CABAL concepts). Name the intended baseline/verifier, or I pull the TS/CABAL ledgers.
+3. **Support (medics / mechanics / casters / mind-control / spies) = FULLY EXEMPT** (maintainer
+   2026-07-25): no consistent (or no) damage ⇒ nothing to calculate ⇒ **not in the balance pipeline
+   at all.** The ONE class outside every balancing effort. `check_band.py` already skips them.
+3b. **★ CARGO-PRICING RULE (maintainer 2026-07-25) — cargo units ARE balanced, deterministically.**
+   Any **cargo vehicle or aircraft** (APC, troop transport, Battle Fortress, etc.) is priced at the
+   **SUM of the infantry it carries at full capacity** — *even if it has no weapon.* This is a FIXED
+   rule, separate from the damage formula. Verified: Battle Fortress `Cargo.MaxWeight 6` @ 4000¢,
+   GDI APC `MaxWeight 8`. So an **unarmed transport is NOT exempt** (that's the passenger-sum rule);
+   only NON-cargo support (medics/casters) is exempt (#3). **New pipeline rule** (encode into
+   `check_band`/pricing): if an actor has a `Cargo:` trait, its cost target = Σ(passenger costs at
+   capacity), and it is checked against THAT, not the class formula. *(Confirm the per-slot reference
+   infantry cost — capacity 6 → 4000¢ implies ~667¢/slot, i.e. an elite loadout assumption.)*
+4. **Bunker** — damage comes from garrisoned infantry, so it may be baseline-only (HP + cost only).
+5. **commando (infantry)** — needs a verifier (currently null). Propose: commando verifier =
+   a 2×/2×/2.5× hero sibling. (Support is exempt per #3 — no verifier.)
+6. All **cost0** values default toward the unit's **original/current price** (the nostalgia default,
+   §20) — flag any you want moved.


### PR DESCRIPTION
Asked whether anything else went missing in the 83→43 compaction, I measured it instead of re-reading my own commit message.

That message said nothing was summarised away, and that every merged file's content lines had been checked for presence in the target — verified mechanically, 0 lines lost.

**True, and it covered the wrong set.** It described the files that were *merged*. Alongside them, fifteen were **deleted outright** as generated and rebuildable on demand. That second claim was asserted, never tested.

Diffing every deleted file's content lines against the whole live corpus:

| outcome | count |
|---|--:|
| carried across into a merge target | 24 |
| deleted, regeneration **verified by running the generator** | 13 |
| deleted, **not regenerable** | **2** |

*(A sixteenth, `BALANCE_MEGAPLAN.md`, first measured as 13% absent, is fully present — the gap was table-separator rows my comparison treated as content.)*

## The two that were not

**`docs/balance/BALANCE_AUDIT.md`** — a per-unit formula-price-vs-cost delta report with range solutions and per-class band recommendations. Its generator, `tools/balance/_balance_audit_report.py`, raises:

```
ModuleNotFoundError: No module named 'scout_rebalance_proposal_final'
```

The module was removed long ago — `propose_class_rebalance.py` even carries a comment saying those modules no longer exist. The script is dead, nothing runs it, and nobody noticed **because nobody ran it**.

**`docs/balance/proposal_vehicle_defense_anchors.md`** — deleted alongside thirteen `proposal_*.md` siblings, but it is not one of them. The proposer writes `proposal_<class>_infantry.md`; this name matches no pattern, and a repo-wide search finds no generator for it at all. **It was deleted by resemblance.**

Both restored under `docs/history/balance/` with banners: their numbers predate W24, so the weapon rebuild has moved damage structure since. Read them for method and for what was measured at the time, never as a current statement about the roster.

## What I verified rather than assumed this time

```
propose_class_rebalance.py --class melee   → wrote 13 586 bytes. The thirteen
                                             proposals really are regenerable.
_balance_audit_report.py                   → ModuleNotFoundError. It is not.
grep for a vehicle_defense_anchors writer  → nothing.
```

## Two lessons, recorded in LESSONS_LEARNED

⭐ **Deleting a generated artifact is safe exactly when the generator runs.** That is one command, and skipping it converts a reversible cleanup into permanent loss *that a green verification report actively conceals* — the check that ran measured merges, and the files at risk were the ones it did not cover.

⭐ **Group deletions inherit the safety of the group's weakest member.** Fourteen files went under one justification; thirteen deserved it. A filename that merely *looks* like the others is the one to check individually, because resemblance is not provenance.

## Also worth knowing

`tools/balance/_balance_audit_report.py` is dead code with a broken import, wired into neither runner. Left in place rather than removed — that is a call for whoever owns `tools/balance/`, and this change is already reaching into their directory far enough by reading it.

## Verification

```
content-line diff of all 40 deleted files against the live corpus
python -m unittest        500 tests, all green (11 skipped)
audit_doc_health          PASS, D1–D8
audit_consistency_report  exit 0
```

**Boot gate: not run, not applicable.** Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVgd8sZKAoNQhGJcA3zoU7)_