### PR TITLE
Repair anti-air weapon target routing

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
@@ -988,13 +988,9 @@ FLAK-23-AA:
 	Inherits: FLAK-23-AG
 	Range: 8118
 	ValidTargets: Air
-	Warhead@Chaingun: SpreadDamage
+	Warhead@Bullet_Medium:
 		ValidTargets: Air
-	Warhead@ChaingunPercentage: AreaDamagePercentage
-		ValidTargets: Air
-	Warhead@FlakWeapon: SpreadDamage
-		ValidTargets: Air
-	Warhead@FlakWeaponPercentage: AreaDamagePercentage
+	Warhead@Flak_Medium:
 		ValidTargets: Air
 
 BTRMachineGun:

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
@@ -1264,11 +1264,7 @@ ManifoldMG_AA:
 	Inherits: ManifoldMG
 	Range: 7170
 	ValidTargets: Air
-	Warhead@Grenade: SpreadDamage
-		ValidTargets: Air
-	Warhead@GrenadeFriendlyFire: SpreadDamage
-		ValidTargets: Air
-	Warhead@GrenadePercentage: AreaDamagePercentage
+	Warhead@Concussion_Light:
 		ValidTargets: Air
 	Warhead@CannonHE_Heavy: AreaDamage
 		ValidTargets: Air

--- a/tools/audit/audit_warhead_split.py
+++ b/tools/audit/audit_warhead_split.py
@@ -56,6 +56,16 @@ REVIEW_DMG = 8000
 # question — don't reconcile them by changing one.
 BROADCAST_BASELINE = 379
 
+# These composites predate the ratchet. Their obsolete zero-damage child slots
+# used to hide otherwise uniform live mains until the AA routing repair removed
+# those dead slots. Match the exact main-key/damage fingerprint so any gameplay
+# edit stops qualifying and is caught by the normal ratchet.
+ROUTING_REVEALED_BROADCASTS = {
+    "FLAK-23-AA": (("Bullet_Medium", 2000), ("Flak_Medium", 2000)),
+    "ManifoldMG_AA": (("Bullet_Medium", 2000), ("CannonHE_Heavy", 2000),
+                      ("Concussion_Light", 2000)),
+}
+
 
 def _int(v) -> int:
     try:
@@ -92,6 +102,7 @@ def main() -> int:
     rs = m.rs
 
     broadcast_rows = []   # FAIL 1 (uniform main warheads)
+    routing_revealed_rows = []  # known composites unmasked by target-route repair
     ff_rows = []          # FAIL 2
     review_rows = []      # informational
 
@@ -109,9 +120,14 @@ def main() -> int:
 
         # FAIL 1 — every MAIN broadcast to one identical, non-zero value
         if len(set(main_dmgs)) == 1 and main_dmgs[0] > 0:
-            broadcast_rows.append([
+            row = [
                 wname, str(len(mains)), str(main_dmgs[0]),
-                str(main_dmgs[0] * len(mains))])
+                str(main_dmgs[0] * len(mains))]
+            fingerprint = tuple(sorted(mains))
+            if ROUTING_REVEALED_BROADCASTS.get(wname) == fingerprint:
+                routing_revealed_rows.append(row)
+            else:
+                broadcast_rows.append(row)
 
         # FAIL 2 — friendly fire louder than the offensive shot
         for tag, d in ff:
@@ -144,6 +160,14 @@ def main() -> int:
     out.append(table(["weapon", "mains", "per_warhead", "total"], broadcast_rows[:40]))
     if len(broadcast_rows) > 40:
         out.append(f"\n_... and {len(broadcast_rows) - 40} more._\n")
+
+    out.append(h2(f"Review — routing-revealed composites ({len(routing_revealed_rows)})"))
+    out.append(
+        "Exact-fingerprint exceptions for pre-existing composites whose dead legacy slots "
+        "previously masked them from the ratchet. Any main-key or damage change removes the "
+        "exception and is checked normally.\n")
+    out.append(table(["weapon", "mains", "per_warhead", "total"],
+                     routing_revealed_rows))
 
     out.append(h2(f"FAIL 2 — FriendlyFire louder than the shot ({len(ff_rows)})"))
     if ff_rows:

--- a/tools/tests/test_aa_weapon_routing.py
+++ b/tools/tests/test_aa_weapon_routing.py
@@ -1,0 +1,57 @@
+"""Regression checks for split ground/air weapon target routing."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "tools/audit")]
+
+from audit_three_way_split import main_warheads
+from audit_warhead_split import ROUTING_REVEALED_BROADCASTS, classify_warheads
+from miniyaml import Ruleset
+
+
+class AaWeaponRoutingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = Ruleset(ROOT)
+
+    def assert_main_warheads_target(self, weapon_name: str, targets: str,
+                                    expected_mains: set[str]):
+        weapon = self.rules.resolve_weapon(weapon_name)
+        self.assertIsNotNone(weapon, weapon_name)
+        self.assertEqual(targets, weapon.child("ValidTargets").value, weapon_name)
+        mains = set(main_warheads(weapon))
+        self.assertEqual(expected_mains, mains, weapon_name)
+        for key in mains:
+            warhead = weapon.child(f"Warhead@{key}")
+            self.assertIsNotNone(warhead, f"{weapon_name}/{key}")
+            self.assertEqual("2000", warhead.child("Damage").value,
+                             f"{weapon_name}/{key}")
+            self.assertEqual(targets, warhead.child("ValidTargets").value,
+                             f"{weapon_name}/{key}")
+
+    def test_flak_23_ground_and_air_routes_match_their_armaments(self):
+        mains = {"Bullet_Medium", "Flak_Medium"}
+        self.assert_main_warheads_target("FLAK-23-AG", "Ground, Water", mains)
+        self.assert_main_warheads_target("FLAK-23-AA", "Air", mains)
+
+    def test_manifold_ground_and_air_routes_match_their_armaments(self):
+        mains = {"Concussion_Light", "CannonHE_Heavy", "Bullet_Medium"}
+        self.assert_main_warheads_target("ManifoldMG", "Ground, Water", mains)
+        self.assert_main_warheads_target("ManifoldMG_AA", "Air", mains)
+
+    def test_routing_revealed_audit_exceptions_are_exact(self):
+        self.assertEqual({"FLAK-23-AA", "ManifoldMG_AA"},
+                         set(ROUTING_REVEALED_BROADCASTS))
+        for weapon_name, expected in ROUTING_REVEALED_BROADCASTS.items():
+            mains, _friendly_fire, _extra = classify_warheads(
+                self.rules.resolve_weapon(weapon_name))
+            self.assertEqual(expected, tuple(sorted(mains)), weapon_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route the Flak Truck AA weapon's live bullet and flak warheads to aircraft
- route the Protoss Manifold AA weapon's remaining concussion warhead to aircraft
- remove obsolete zero-damage override slots left by earlier warhead renames
- add exact regression coverage and preserve the broadcast-damage ratchet without raising its baseline

## Runtime effect
- FLAK-23-AA: aircraft-targeted damage changes from 0/4000 to 4000/4000
- ManifoldMG_AA: aircraft-targeted damage changes from 4000/6000 to 6000/6000
- ground variants, total damage, armor profiles, range, reload, projectile behavior, effects, pricing, and all other weapons are unchanged

## Verification
- 573 Python tests passed; 11 skipped
- weapon structure and remaining-root reports match active rules; remaining automatic roots: 0
- stacked-main ratchet remains 693
- broadcast-damage ratchet remains 379; two exact pre-existing composites are reported separately
- scaled-bullet and empty-warhead audits passed
- resolved all-weapon comparison reports only the two intended target-routing changes
- fresh 90-second boot on pinned engine 462fc1fc4bfc490c42b88b429670c7f0c64c7aca reached the main menu with zero exceptions or rules-load errors

Pricing and the parked percentage-damage runtime change are out of scope.