### PR TITLE
Fix case-insensitive weapon reachability survey

### DIFF
--- a/docs/audit/latest/weapon_structure_inventory.json
+++ b/docs/audit/latest/weapon_structure_inventory.json
@@ -3,9 +3,9 @@
     "concrete_weapons": 2345,
     "stacked_main_all_concrete": 693,
     "stacked_main_direct_actor_armament": 494,
-    "stacked_main_indirect_weapon_graph": 90,
-    "stacked_main_transitive_weapon_graph": 584,
-    "stacked_main_unreached": 109
+    "stacked_main_indirect_weapon_graph": 92,
+    "stacked_main_transitive_weapon_graph": 586,
+    "stacked_main_unreached": 107
   },
   "predicate": "positive Damage on AreaDamage, SpreadDamage, HealthPercentageDamage, or TargetDamage; excludes designed companions and friendly-fire twins",
   "reference_fields": [
@@ -532,6 +532,7 @@
       "AsianHowitzerSplash",
       "AsianSubmarineBomb",
       "AsianTSIonCannon",
+      "Atomic",
       "CabalMagicNuke",
       "ChemRocketsExplosion",
       "DalekCannonScatter",
@@ -571,6 +572,7 @@
       "RA2SCUD_rad",
       "RA2SCUD_tesla",
       "RA2Terrorist",
+      "RAAtomic",
       "ReactorNuke",
       "ReactorNukeWeak",
       "SCScourgeDroneExplosion",
@@ -620,7 +622,6 @@
     "unreached": [
       "12MissilesSpawnerScud",
       "25mmWaveforce",
-      "Atomic",
       "CHFlameBlue",
       "ChemTibAtomic",
       "CrateNuke",
@@ -682,7 +683,6 @@
       "RA2REVENANTAA",
       "RA2TRIPODPLAZMA",
       "RA2ThermobaricFlame",
-      "RAAtomic",
       "Rocket_stealth",
       "Rocket_stealth_AA",
       "Rocketeer_o",

--- a/tools/audit/survey_weapon_structure.py
+++ b/tools/audit/survey_weapon_structure.py
@@ -47,7 +47,15 @@ def walk(node):
         yield from walk(child)
 
 
-def weapon_references(node, known: set[str]) -> set[str]:
+def canonical_weapon_names(known: set[str]) -> dict[str, str]:
+    """Map case-insensitive weapon references to their canonical definition names."""
+    canonical = {name.lower(): name for name in known}
+    if len(canonical) != len(known):
+        raise ValueError("weapon definitions differ only by letter case")
+    return canonical
+
+
+def weapon_references(node, known_by_case: dict[str, str]) -> set[str]:
     refs = set()
     for child in walk(node):
         field = child.key.split("@", 1)[0]
@@ -62,12 +70,14 @@ def weapon_references(node, known: set[str]) -> set[str]:
         for raw in values:
             for value in str(raw).split(","):
                 name = value.strip()
-                if name in known:
-                    refs.add(name)
+                canonical = known_by_case.get(name.lower())
+                if canonical is not None:
+                    refs.add(canonical)
     return refs
 
 
-def direct_armament_references(rules: Ruleset, known: set[str]) -> set[str]:
+def direct_armament_references(
+        rules: Ruleset, known_by_case: dict[str, str]) -> set[str]:
     refs = set()
     for name in rules.actors:
         if name.startswith("^"):
@@ -77,24 +87,26 @@ def direct_armament_references(rules: Ruleset, known: set[str]) -> set[str]:
             continue
         for armament in resolved.children_named("Armament"):
             weapon = str(armament.get("Weapon") or "").strip()
-            if weapon in known:
-                refs.add(weapon)
+            canonical = known_by_case.get(weapon.lower())
+            if canonical is not None:
+                refs.add(canonical)
     return refs
 
 
 def weapon_reference_sets(rules: Ruleset, concrete: set[str]) -> tuple[set[str], set[str]]:
     """Return direct Armament references and the full modeled weapon closure."""
-    direct_refs = direct_armament_references(rules, concrete)
+    known_by_case = canonical_weapon_names(concrete)
+    direct_refs = direct_armament_references(rules, known_by_case)
     actor_refs = set()
     for name in rules.actors:
         if name.startswith("^"):
             continue
         resolved = rules.resolve(name)
         if resolved is not None:
-            actor_refs.update(weapon_references(resolved, concrete))
+            actor_refs.update(weapon_references(resolved, known_by_case))
 
     graph = {
-        name: weapon_references(rules.resolve_weapon(name), concrete)
+        name: weapon_references(rules.resolve_weapon(name), known_by_case)
         for name in concrete
     }
     reachable = set(actor_refs)

--- a/tools/tests/test_weapon_structure_inventory.py
+++ b/tools/tests/test_weapon_structure_inventory.py
@@ -7,13 +7,18 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools" / "audit"))
 
 from miniyaml import Ruleset
-from survey_weapon_structure import inventory
+from survey_weapon_structure import (
+    canonical_weapon_names,
+    inventory,
+    weapon_reference_sets,
+)
 
 
 class WeaponStructureInventoryTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.data = inventory(Ruleset(ROOT))
+        cls.rules = Ruleset(ROOT)
+        cls.data = inventory(cls.rules)
 
     def test_partition_is_complete_and_disjoint(self):
         sets = self.data["sets"]
@@ -40,16 +45,34 @@ class WeaponStructureInventoryTests(unittest.TestCase):
         self.assertEqual(2345, self.data["counts"]["concrete_weapons"])
         self.assertEqual(693, self.data["counts"]["stacked_main_all_concrete"])
         self.assertEqual(494, self.data["counts"]["stacked_main_direct_actor_armament"])
+        self.assertEqual(586, self.data["counts"]["stacked_main_transitive_weapon_graph"])
+        self.assertEqual(107, self.data["counts"]["stacked_main_unreached"])
 
     def test_engine_weapon_reference_fields_are_followed(self):
         reached = (set(self.data["sets"]["direct_actor_armament"])
                    | set(self.data["sets"]["indirect_weapon_graph"]))
         expected = {
-            "AsianHowitzerSplash", "CabalMagicNuke", "NaxiV1Rocket",
-            "NaxisBlackBombSmaller", "PulseMissile",
+            "AsianHowitzerSplash", "Atomic", "CabalMagicNuke", "NaxiV1Rocket",
+            "NaxisBlackBombSmaller", "PulseMissile", "RAAtomic",
         }
         self.assertTrue(expected <= reached)
         self.assertTrue(expected.isdisjoint(self.data["sets"]["unreached"]))
+
+    def test_weapon_references_match_definition_names_case_insensitively(self):
+        concrete = {
+            name for name in self.rules.weapons
+            if not name.startswith("^") and self.rules.resolve_weapon(name) is not None
+        }
+        direct, reachable = weapon_reference_sets(self.rules, concrete)
+        self.assertIn("Claw", direct)
+        self.assertTrue({
+            "AsianIonbeam", "Atomic", "Claw", "RAAtomic", "TSIonbeam",
+        } <= reachable)
+
+    def test_canonical_lookup_matches_engine_lowercase_semantics(self):
+        self.assertEqual({"atomic": "Atomic"}, canonical_weapon_names({"Atomic"}))
+        with self.assertRaisesRegex(ValueError, "differ only by letter case"):
+            canonical_weapon_names({"Atomic", "atomic"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- match weapon references case-insensitively using the engine's lowercase semantics
- regenerate the active weapon-structure inventory
- add live and synthetic regression coverage

## Result
- reachable stacked weapons: 584 -> 586
- unreached stacked weapons: 109 -> 107
- newly recognized reachable entries: Atomic and RAAtomic
- no gameplay YAML, C#, assets, pricing, or parked percentage-damage runtime work changed

## Verification
- 577-test full suite passed before the review precision adjustment (11 optional openpyxl skips)
- focused 6-test suite passed after the adjustment
- survey --check passed
- classifier and scaled-bullet audit passed
- independent review completed; its lowercase-semantics recommendation was applied
- clean 90-second boot reached MenuPostProcessEffect.PostWorldLoaded with no error/exception match