### PR TITLE
Restore suppressed weapon stages

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
@@ -399,7 +399,7 @@ ReimuOrbLauncher:
 		AimTargetStances: Enemy
 		ValidTargets: Air, Ground, Water
 		Delay: 108
-	Warhead@Shrapnel3: FireShrapnel
+	Warhead@Shrapnel4: FireShrapnel
 		Weapon: ReimuYinYangOrb
 		ImpactActors: true
 		AimChance: 50
@@ -470,7 +470,7 @@ MagicOrbHailstormSpawner:
 		AimTargetStances: Enemy
 		ValidTargets: Air, Ground, Water
 		Delay: 9
-	Warhead@Shrapnel3: FireShrapnel
+	Warhead@Shrapnel4: FireShrapnel
 		Weapon: MagicOrbSpreaderProjectile
 		ImpactActors: false
 		TargetActorCenter: true

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml
@@ -592,7 +592,6 @@ Future_CoilerFriend:
 	Range: 1250
 	ReloadDelay: 125
 	ValidTargets: RobotEnergizable
-	Projectile: InstantHit
 	Projectile: LightningZap
 		CoreWidth: 16
 		GlowWidth: 32

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
@@ -663,8 +663,6 @@ TSMammothTusk2II_AA:
 	ReloadDelay: 92
 	Burst: 2
 	BurstDelays: 8
-	Projectile: Missile
-		TrailImage: large_trail
 	Warhead@MissileAP_Heavy:
 		Damage: 60000
 		ValidTargets: Air

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/weapons.yaml
@@ -679,14 +679,14 @@ wc2blizzardSuper:
 		Dimensions: 9,9
 		Footprint: _xxxx_x__ _xxxx_x__ _xxxx_x__ _xxxx_x__ _xxxx_x__ _________ _xxxx_x__ _________ _________
 		#Footprint: ____x____ ___xxx___ __xxxxx__ _xxxxxxx_ xxxxxxxxx _xxxxxxx_ __xxxxx__ ___xxx___ ____x____
-	Warhead@InitialSpreader10: FireCluster
+	Warhead@InitialSpreader12: FireCluster
 		Delay: 270
 		Weapon: wc2blizzardSuper_Spread
 		RandomClusterCount: 4
 		Dimensions: 9,9
 		Footprint: _xxxx_x__ _xxxx_x__ _xxxx_x__ _xxxx_x__ _xxxx_x__ _________ _xxxx_x__ _________ _________
 		#Footprint: ____x____ ___xxx___ __xxxxx__ _xxxxxxx_ xxxxxxxxx _xxxxxxx_ __xxxxx__ ___xxx___ ____x____
-	Warhead@InitialSpreader11: FireCluster
+	Warhead@InitialSpreader13: FireCluster
 		Delay: 300
 		Weapon: wc2blizzardSuper_Spread
 		RandomClusterCount: 2

--- a/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/weapons.yaml
@@ -531,12 +531,11 @@ wc2dragonFireVisible:
 		ValidTargets: Ground, Water, Air
 wc2dragonFireExplosion:
 	Inherits: wc2dragonFireVisible
-	Projectile: Bullet
 	Burst: 3
 	BurstDelays: 0
 	FirstBurstTargetOffset: 0,0,0
 	FollowingBurstTargetOffset: 1024,0,0
-	Projectile:
+	Projectile: Bullet
 		Image: wc2_fireball
 		Inaccuracy: 250
 		TrailImage: smokey

--- a/mods/cameo/weapons/d2k.yaml
+++ b/mods/cameo/weapons/d2k.yaml
@@ -940,7 +940,7 @@ D2KRepair:
 		Types: ivanbomb
 		ValidTargets: ivanattached
 		ValidRelationships: Ally
-	Warhead@2Defuse: DetachDelayedWeapon
+	Warhead@3Defuse: DetachDelayedWeapon
 		Types: lockdown
 		ValidTargets: lockdowned
 		ValidRelationships: Ally

--- a/mods/cameo/weapons/warcraft2.yaml
+++ b/mods/cameo/weapons/warcraft2.yaml
@@ -395,8 +395,6 @@ wc2demolitionsquadExplode:
 		ImpactSounds: gexpwasa.wav
 		ValidTargets: Water, Underwater
 		InvalidTargets: Ship, Structure, Bridge
-	Warhead@Concrete: DamagesConcrete
-		Damage: 25
 	Warhead@Glow: GlowImpact
 	Warhead@ShieldHit: GrantExternalCondition
 		Condition: shieldhit

--- a/tools/audit/audit_duplicate_keys.py
+++ b/tools/audit/audit_duplicate_keys.py
@@ -21,10 +21,10 @@ D2 — every other duplicate key (same trait or field declared twice, or a
     result is usually what the author wanted, but any field set by both copies
     resolves to the last one. Hygiene: collapse them into one node.
 
-Exit code 1 when the D1 count RISES ABOVE ``D1_BASELINE``. The pre-existing
-findings are a ratchet, not a green light.  Renaming a label is behavior-preserving
+Exit code 1 when the D1 or D2 count rises above its baseline. The pre-existing
+findings are ratchets, not a green light. Renaming a label is behavior-preserving
 only when a resolved before/after comparison confirms it; otherwise the case needs
-individual review. Lower the baseline as findings are fixed; never raise it.
+individual review. Lower each baseline as findings are fixed; never raise them.
 
 Usage: python tools/audit/audit_duplicate_keys.py
 """
@@ -45,9 +45,9 @@ if hasattr(sys.stdout, "reconfigure"):
 SCAN_DIRS = ("mods/cameo",)
 SKIP_PARTS = ("maps", "bits")
 
-# Ratchet: D1 findings measured on 2026-08-11 against the unmodified tree.
-# Lower it as duplicates are resolved; never raise it without a note.
+# Ratchets: lower them as duplicates are resolved; never raise without a note.
 D1_BASELINE = 80
+D2_BASELINE = 411
 
 
 def duplicate_children(node: Node) -> dict[str, list[Node]]:
@@ -121,6 +121,15 @@ def main() -> int:
     if len(d1_rows) < D1_BASELINE:
         print(f"\nD1 count {len(d1_rows)} is below the baseline {D1_BASELINE} — "
               f"lower D1_BASELINE in this script to lock the fix in.\n")
+
+    if len(d2_rows) > D2_BASELINE:
+        print(f"\n**FAIL** — D2 count {len(d2_rows)} exceeds the baseline "
+              f"{D2_BASELINE}: a new duplicate key was introduced.\n")
+        return 1
+
+    if len(d2_rows) < D2_BASELINE:
+        print(f"\nD2 count {len(d2_rows)} is below the baseline {D2_BASELINE} — "
+              f"lower D2_BASELINE in this script to lock the fix in.\n")
 
     return 0
 

--- a/tools/tests/test_audit_duplicate_keys.py
+++ b/tools/tests/test_audit_duplicate_keys.py
@@ -61,7 +61,7 @@ class WalkTest(unittest.TestCase):
 
 
 class SeverityTest(unittest.TestCase):
-    """D1 = duplicate Inherits with DIFFERENT values (a template is dropped)."""
+    """D1 marks ambiguous inheritance labels with different parent values."""
 
     @staticmethod
     def classify(key: str, values: list[str]) -> str:
@@ -81,6 +81,8 @@ class SeverityTest(unittest.TestCase):
     def test_baseline_is_a_ratchet_not_a_target(self):
         self.assertGreaterEqual(dup.D1_BASELINE, 0)
         self.assertIsInstance(dup.D1_BASELINE, int)
+        self.assertGreaterEqual(dup.D2_BASELINE, 0)
+        self.assertIsInstance(dup.D2_BASELINE, int)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_weapon_source_key_integrity.py
+++ b/tools/tests/test_weapon_source_key_integrity.py
@@ -14,8 +14,6 @@ sys.path.insert(0, str(ROOT / "tools" / "audit"))
 from miniyaml import Ruleset
 
 
-SINGLE_VALUE_FIELDS = {"ValidTargets", "Range", "ReloadDelay", "Report"}
-
 EXPECTED_VALUES = {
     "FLAK-23-AG": {"ReloadDelay": "5"},
     "Fremen_S": {"Report": "MGUN2.WAV"},
@@ -69,17 +67,95 @@ class WeaponSourceKeyIntegrityTests(unittest.TestCase):
             if not name.startswith("^") and cls.rules.resolve_weapon(name) is not None
         }
 
-    def test_concrete_weapons_do_not_repeat_single_value_fields(self):
+    def test_concrete_weapons_do_not_repeat_top_level_keys(self):
         duplicates = []
         for name, node in self.concrete.items():
             counts = collections.Counter(
                 child.key for child in node.children
-                if child.key in SINGLE_VALUE_FIELDS
+                if child.key and not child.key.startswith("-")
             )
             duplicates.extend(
                 (name, key, count) for key, count in counts.items() if count > 1
             )
         self.assertEqual([], duplicates)
+
+    def test_numbered_effect_stages_are_not_silently_suppressed(self):
+        expected = {
+            "D2KRepair": {
+                "Warhead@2Defuse": ("Types", "ivanbomb"),
+                "Warhead@3Defuse": ("Types", "lockdown"),
+            },
+            "ReimuOrbLauncher": {
+                f"Warhead@Shrapnel{i}": ("Delay", str(96 + 4 * i))
+                for i in range(1, 5)
+            },
+            "MagicOrbHailstormSpawner": {
+                f"Warhead@Shrapnel{i}": ("Delay", str(i * i))
+                for i in range(1, 5)
+            },
+            "wc2blizzardSuper": {
+                f"Warhead@InitialSpreader{i}": (
+                    "Delay",
+                    "" if i == 1 else str(
+                        (i - 1) * 20 if i <= 7 else 30 * i - 90
+                    ),
+                )
+                for i in range(1, 14)
+            },
+        }
+        for weapon, stages in expected.items():
+            resolved = self.rules.resolve_weapon(weapon)
+            for key, (field, value) in stages.items():
+                node = resolved.child(key)
+                self.assertIsNotNone(node, f"{weapon}/{key}")
+                self.assertEqual(
+                    value or None,
+                    node.get(field),
+                    f"{weapon}/{key}/{field}",
+                )
+
+    def test_restored_effect_stage_payloads_are_pinned(self):
+        repair = self.rules.resolve_weapon("D2KRepair")
+        self.assertEqual("ivanattached", repair.child("Warhead@2Defuse").get("ValidTargets"))
+        self.assertEqual("lockdowned", repair.child("Warhead@3Defuse").get("ValidTargets"))
+        for key in ("Warhead@2Defuse", "Warhead@3Defuse"):
+            self.assertEqual("Ally", repair.child(key).get("ValidRelationships"))
+
+        reimu = self.rules.resolve_weapon("ReimuOrbLauncher")
+        for i in range(1, 5):
+            node = reimu.child(f"Warhead@Shrapnel{i}")
+            self.assertEqual("4", node.get("Amount"))
+            self.assertEqual("50", node.get("AimChance"))
+
+        hailstorm = self.rules.resolve_weapon("MagicOrbHailstormSpawner")
+        for i in range(1, 5):
+            node = hailstorm.child(f"Warhead@Shrapnel{i}")
+            expected = str(i * i)
+            self.assertEqual(expected, node.get("Amount"))
+            self.assertEqual(expected, node.get("AimChance"))
+
+        blizzard = self.rules.resolve_weapon("wc2blizzardSuper")
+        counts = (2, 4, 6, 8, 10, 12, 14, 12, 10, 8, 6, 4, 2)
+        for i, count in enumerate(counts, start=1):
+            node = blizzard.child(f"Warhead@InitialSpreader{i}")
+            self.assertEqual(str(count), node.get("RandomClusterCount"))
+            self.assertEqual("wc2blizzardSuper_Spread", node.get("Weapon"))
+
+    def test_collapsed_nodes_keep_the_previously_effective_behavior(self):
+        expected = {
+            "Future_CoilerFriend": ("Projectile", "LightningZap", "CoreWidth", "16"),
+            "TSMammothTusk2II_AA": ("Projectile", "Missile", "Speed", "500"),
+            "wc2dragonFireExplosion": (
+                "Projectile", "Bullet", "Speed", "384"
+            ),
+            "wc2demolitionsquadExplode": (
+                "Warhead@Concrete", "DamagesConcrete", "Damage", "25"
+            ),
+        }
+        for weapon, (key, node_type, field, value) in expected.items():
+            node = self.rules.resolve_weapon(weapon).child(key)
+            self.assertEqual(node_type, node.value, f"{weapon}/{key}")
+            self.assertEqual(value, node.get(field), f"{weapon}/{key}/{field}")
 
     def test_concrete_weapons_do_not_shadow_inheritance_parents(self):
         duplicates = []


### PR DESCRIPTION
## Summary
- restore four numbered weapon-effect stages that duplicate MiniYAML keys had silently suppressed
- collapse four duplicate projectile/warhead source nodes with no resolved behavior change
- reject repeated top-level keys in active concrete weapons and ratchet the repo-wide D2 duplicate count from 420 to 411

## Runtime impact
- Human Mage Tower Blizzard restores its authored symmetric 13-stage sequence: 84 to 98 spread clusters, or 420 to 490 final projectiles (+16.7%)
- D2KRepair, ReimuOrbLauncher, and MagicOrbHailstormSpawner regain their authored stages but are currently unreached
- Future_CoilerFriend, TSMammothTusk2II_AA, wc2dragonFireExplosion, and wc2demolitionsquadExplode are behavior-identical after full resolution
- no pricing or percentage-damage runtime work

## Verification
- 585 Python tests passed; 11 optional openpyxl tests skipped
- full 2,846-definition resolved comparison: exactly four intended changed definitions, no descendant drift
- main and percentage damage preserved for all 2,345 concrete weapons
- duplicate audit: D1 80 unchanged; D2 420 to 411
- weapon structure survey and remaining-root classifier match live rules
- reachable Bullet speed audit passes
- independent review: no blocker; authored sequence intent confirmed
- isolated 90-second boot stayed alive, reached MenuPostProcessEffect.PostWorldLoaded, and logged no load error or exception