### PR TITLE
Repair advertised anti-air weapon payloads

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
@@ -650,7 +650,6 @@ schwarzermond_dieglocke:
 	Inherits@EXPERIENCE: ^GainsExperienceRA2
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Inherits@detect: ^GenericAirDetector
-	Inherits@AntiAir: ^PrioritizeAir
 	Inherits@Helium3: ^NaxiHelium3
 	Valued:
 		Cost: 15000

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
@@ -846,7 +846,7 @@ NaxDieGlocke:
 	Report: flamer2.aud
 	Range: 2500
 	ReloadDelay: 60
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Projectile: InstantHit
 	TargetActorCenter: true
 	Warhead@Chemical_Heavy:

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/vehicles.yaml
@@ -437,7 +437,7 @@ protoss_archon:
 	Inherits@decoration: ^ProtossRankDecoration
 	Inherits@Template: ^LineBreakerTemplate
 	Inherits@EXP: ^GainsExperienceTD
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMoveMelee
+	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Inherits@explode: ^UnitExplodeSmallProtoss
 	Inherits@announce: ^AnnounceOnBuild
 	Inherits@EMP: ^FrontalEMP

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/weapons.yaml
@@ -602,8 +602,10 @@ PsionicShockwave:
 	Report: parfir00.aud
 	ValidTargets: Ground, Water, Air
 	Warhead@Tesla_Super:
+		ValidTargets: Ground, Water, Air
 		Damage: 30000
 	Warhead@Tesla_Super_ExtraDamage: SpreadDamage
+		ValidTargets: Ground, Water, Air
 		DamageTypes: Tesla
 		Damage: 15000
 	Warhead@Effect: CreateEffect

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
@@ -1476,6 +1476,7 @@ VenomLaserInferno:
 		SecondaryBeamZOffset: 2047
 		SecondaryBeamColor: FFFFFF
 	Warhead@Inferno_Medium:
+		ValidTargets: Ground, Water, Air
 		Damage: 8000
 VenomLaserBurning:
 	Inherits: VenomLaserInferno

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
@@ -2582,7 +2582,10 @@ CabalOverkillCharge:
 		SecondaryBeamColor: BB22DD30
 		TrackTarget: false
 	Warhead@Tesla_Heavy:
+		ValidTargets: Ground, Water, Air
 		Damage: 24000
+	Warhead@Tesla_Heavy_ExtraDamage:
+		ValidTargets: Ground, Water, Air
 	Warhead@Effect: CreateEffect
 		Explosions: cabal_laserimpact_l
 		ImpactSounds: drtelectro.wav

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
@@ -1328,6 +1328,7 @@ TSFiendShard:
 		Image: ra2txgasg
 		TrailImage: green_smokey
 	Warhead@Chemical_Light:
+		ValidTargets: Ground, Water, Air
 		Damage: 6000
 	Warhead@3Eff: CreateEffect
 		Explosions: sczhsplash
@@ -1351,14 +1352,17 @@ TSFiendShardUP:
 		Image: ra2txgasg
 		TrailImage: green_smokey
 	Warhead@LightChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@MediumChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@HeavyChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
@@ -1382,6 +1386,7 @@ TSFiendShardUP:
 	-Warhead@MediumChemicalWeapon:
 	-Warhead@HeavyChemicalWeapon:
 	Warhead@Chemical_Heavy:
+		ValidTargets: Ground, Water, Air
 		Damage: 18000
 		PercentageScale: 0
 TSFiendShardBlue:
@@ -1402,14 +1407,18 @@ TSFiendShardBlue:
 		Image: ra2txgasg
 		TrailImage: blue_smokey
 	Warhead@GrenadePercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 	Warhead@ShrapnelWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 	Warhead@LightChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@MediumChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
@@ -1424,6 +1433,7 @@ TSFiendShardBlue:
 	-Warhead@LightChemicalWeapon:
 	-Warhead@MediumChemicalWeapon:
 	Warhead@Chemical_Medium:
+		ValidTargets: Ground, Water, Air
 		Damage: 24000
 		PercentageScale: 0
 
@@ -1447,22 +1457,28 @@ TSFiendShardBlueUP:
 		Image: ra2txgasg
 		TrailImage: blue_smokey
 	Warhead@GrenadePercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 	Warhead@ShrapnelWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 	Warhead@LightChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@MediumChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@HeavyChemicalWeaponPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
 	Warhead@HeavyBombPercentage: AreaDamagePercentage
+		ValidTargets: Ground, Water, Air
 		Damage: 3
 	Warhead@Cloud: SpawnSmokeParticle
 		Count: 2
@@ -1487,6 +1503,7 @@ TSFiendShardBlueUP:
 	-Warhead@HeavyChemicalWeapon:
 	-Warhead@HeavyBomb:
 	Warhead@Chemical_Heavy:
+		ValidTargets: Ground, Water, Air
 		Damage: 36000
 		PercentageScale: 0
 

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
@@ -904,6 +904,7 @@ TSAssaultCannonSonic:
 	Burst: 2
 	BurstDelays: 2
 	Range: 6305
+	ValidTargets: Ground, Water, Air
 	Projectile: Bullet
 		Inaccuracy: 250
 	Warhead@Flak_Medium: AreaDamage
@@ -915,7 +916,7 @@ TSAssaultCannonSonic:
 	-Warhead@Flak_Medium:
 	-Warhead@Sonic_Medium:
 	Warhead@Sonic_MediumFlatCompatibility:
-		ValidTargets: Ground, Water
+		ValidTargets: Ground, Water, Air
 		Damage: 8000
 		PercentageScale: 4988
 
@@ -932,7 +933,7 @@ TSAssaultCannonTal:
 		Speed: 2000
 		Inaccuracy: 200
 	Warhead@Bullet_Medium:
-		ValidTargets: Ground, Water
+		ValidTargets: Ground, Water, Air
 		Damage: 8000
 TSAssaultCannonTalSonic:
 	Inherits@roleflat: ^Compatibility_Sonic_MediumFlat
@@ -942,6 +943,7 @@ TSAssaultCannonTalSonic:
 	Inherits@fx: ^Effect_Sonic_Shell
 	Report: 120mmf.aud
 	ReloadDelay: 45
+	ValidTargets: Ground, Water, Air
 	Projectile: Bullet
 		Speed: 2000
 		Inaccuracy: 200
@@ -951,7 +953,7 @@ TSAssaultCannonTalSonic:
 	-Warhead@Bullet_Medium:
 	-Warhead@Sonic_Medium:
 	Warhead@Sonic_MediumFlatCompatibility:
-		ValidTargets: Ground, Water
+		ValidTargets: Ground, Water, Air
 		Damage: 16000
 		PercentageScale: 6244
 

--- a/mods/cameo/weapons/tiberiansun.yaml
+++ b/mods/cameo/weapons/tiberiansun.yaml
@@ -1308,7 +1308,7 @@ TSAssaultCannon:
 	-Warhead@Bullet_Medium:
 	-Warhead@Flak_Medium:
 	Warhead@Bullet_MediumFlatCompatibility:
-		ValidTargets: Ground, Water
+		ValidTargets: Ground, Water, Air
 		Damage: 4000
 		PercentageScale: 9975
 TSLaserRaiderCannon:

--- a/tools/audit/audit_stat_formulas.py
+++ b/tools/audit/audit_stat_formulas.py
@@ -53,9 +53,10 @@ Ordos Raider (raider.ordos).
       unlock (tier counted from tech buildings only, transitively;
       production buildings and refineries never count) — the FutureTech
       Prospector Mk2 lockout class
-  F18 anti-air weapons: a weapon whose ValidTargets include Air must have at
-      least one damage warhead whose ValidTargets include Air (inherited
-      warheads resolved) — otherwise it fires at aircraft but deals nothing
+  F18 anti-air weapons: a weapon whose ValidTargets include Air must deliver
+      a positive-damage warhead, delayed payload, or cluster chain that can
+      affect Air (inherited warheads resolved) — otherwise it fires at
+      aircraft but has no gameplay payload
 
 Scope: buildable rosters of real factions. Tolerance ±1 on divisions.
 """
@@ -466,8 +467,61 @@ def promotion_tier_check(m, rows):
                              f"promotion {pname} tier {ptier} — must match"])
 
 
+def targets_air(node, *, default_all: bool = False) -> bool:
+    raw = node.get("ValidTargets")
+    if raw is None:
+        return default_all
+    return "air" in {v.strip().lower() for v in raw.split(",")}
+
+
+def positive_damage(node) -> bool:
+    if node.value == "DamagesConcrete":
+        return False
+    damage = ivalue(node, "Damage")
+    return damage is not None and damage > 0
+
+
+def is_point_defense(weapon) -> bool:
+    targets = {v.strip().lower()
+               for v in (weapon.get("ValidTargets") or "").split(",")}
+    invalid = {v.strip().lower()
+               for v in (weapon.get("InvalidTargets") or "").split(",")}
+    projectile_targets = {"missile", "ballisticmissile", "bulletas", "bulletca"}
+    excluded_units = {"infantry", "vehicle", "structure"}
+    return bool(targets & projectile_targets) and excluded_units <= invalid
+
+
+def has_air_payload(rs, weapon, seen: set[str] | None = None) -> bool:
+    """Return whether a resolved weapon delivers a gameplay payload to Air.
+
+    Delivery chains are followed because the carrier weapon can intentionally
+    use a token impact while a spawned or delayed weapon owns the real damage.
+    AttachDelayedWeapon must itself accept Air before its nested chain counts.
+    """
+    seen = set() if seen is None else seen
+    key = weapon.key.lower()
+    if key in seen:
+        return False
+    seen.add(key)
+    for child in weapon.children:
+        if not child.key.startswith("Warhead"):
+            continue
+        if positive_damage(child) and targets_air(child, default_all=True):
+            return True
+        if child.value in ("AttachDelayedWeapon", "FireCluster",
+                           "SpawnSmokeParticle"):
+            if child.value == "AttachDelayedWeapon" and not targets_air(
+                    child, default_all=True):
+                continue
+            nested_name = child.get("Weapon")
+            nested = rs.resolve_weapon(nested_name) if nested_name else None
+            if nested is not None and has_air_payload(rs, nested, set(seen)):
+                return True
+    return False
+
+
 def aa_warhead_check(m: Model, rows: dict) -> None:
-    """F18 — weapons that target Air but whose damage warheads can't hit Air."""
+    """F18 — weapons that target Air but deliver no gameplay payload to it."""
     rs = m.rs
     used_by: dict[str, set[str]] = {}
     roster_all: set[str] = set()
@@ -486,18 +540,23 @@ def aa_warhead_check(m: Model, rows: dict) -> None:
         w = rs.resolve_weapon(wname)
         if w is None:
             continue
-        if "air" not in (w.get("ValidTargets") or "").lower():
+        if not targets_air(w):
+            continue
+        # Point-defense beams carry Air alongside projectile target types, but
+        # explicitly exclude normal unit classes. Their token damage destroys
+        # intercepted projectile actors and is not an anti-air unit contract.
+        if is_point_defense(w):
             continue
         dmg_warheads = [c for c in w.children
-                        if c.key.startswith("Warhead") and "Damage" in (c.value or "")]
+                        if c.key.startswith("Warhead") and positive_damage(c)]
         if not dmg_warheads:
             continue
-        airless = [c.key for c in dmg_warheads
-                   if "air" not in (c.get("ValidTargets") or "").lower()]
-        if len(airless) == len(dmg_warheads):
+        if not has_air_payload(rs, w):
+            airless = [c.key for c in dmg_warheads
+                       if not targets_air(c, default_all=True)]
             users = ", ".join(sorted(used_by[wname])[:5])
             rows["F18"].append([wname, ", ".join(airless[:4]),
-                                f"targets Air but no damage warhead hits Air (used by {users})"])
+                                f"targets Air but no gameplay payload hits Air (used by {users})"])
 
 
 def main() -> int:
@@ -703,7 +762,7 @@ def main() -> int:
         "F15": "F15 — Light Support composition (Tier-1 only, ~2000, 5:1 inf:veh)",
         "F16": "F16 — Heavy Support composition (all tiers, ~10000, 5:1 inf:veh)",
         "F17": "F17 — fighter/bomber TurnSpeed ≠ Speed/15 (frontal: 2×)",
-        "F18": "F18 — weapons targeting Air whose damage warheads can't hit Air",
+        "F18": "F18 — weapons targeting Air whose gameplay payload can't hit Air",
         "F19": "F19 — helicopter/spaceship TurnSpeed ≠ Speed/5",
         "F20": "F20 — AA support vehicle: air range ≠ 1.5 × ground range",
         "F22": "F22 — promotion tech gate ≠ unlocked unit's tech gate",

--- a/tools/balance/consolidate_high_identity_profiles.py
+++ b/tools/balance/consolidate_high_identity_profiles.py
@@ -51,7 +51,9 @@ PRESERVED_HASHES = {
     "asianalliance_asianmilitia_grenade": "efc2a6ac497014679c90e887d3b7dd9cbcb60f4c231897daccfd134edef1420d",
     "asianalliance_asianmilitia_grenade_elite": "bcb0ae17f7673a55b7127faef9f93d1d212b1aa8f440de9e4203d901cb1dc2ff",
     "IxRailgunDroneBullet": "8f6f05b056d48d7a61c623779ea6b3115aef386a6c10a681e7ad94a92ebb96b1",
-    "TSAssaultCannonTalSonic": "9cba3f24ded85a2f819c8c610011b86afc3b5f2f1d199db020bc57e1f31e9bc7",
+    # Post-consolidation correction: Wolverine Mk II keeps its advertised weak
+    # AA role after Sonic Weaponry replaces the base armament.
+    "TSAssaultCannonTalSonic": "193772b68bde138b7365ad1f6c6cbbd6632e2cf98a84d2987491fba67b514413",
 }
 
 CANONICAL = re.compile(r"^\^Warhead_([A-Za-z]+)_(\w+)$")

--- a/tools/balance/consolidate_named_family_profiles.py
+++ b/tools/balance/consolidate_named_family_profiles.py
@@ -112,7 +112,9 @@ PRESERVED_HASHES = {
     "IncendiaryYakChainGun": "41c173cf4287292c5f8b45970053de5c609067d9a92e5dda586772cdc2e2d870",
     "NapalmA10Carrier": "681759d81958c17756b909aada1c0d24669ad2a12560795ad018aba701183f7e",
     "RA2CosmonautLaser": "95be178ac49664713f083712f15c5e7110c7e5b26856f3a04c5d580317f8f557",
-    "TSAssaultCannonSonic": "ce605c56ec936776472769de6bbb00a219f46fbdcce9656170da13defc74c1a0",
+    # Post-consolidation correction: Wolverine keeps its advertised weak AA
+    # role after Sonic Weaponry replaces the base armament.
+    "TSAssaultCannonSonic": "845a4a6c2be68852fed127665fe7537cbb26bab0c9886649bfd3c14945e88b4f",
     "TSLaserHarpyAOEClaw": "91796c834129cda6876c6b969432b236b98b70ef3815a37f4d2446e6225f33a0",
     "TSLaserHarpyClaw": "eeb4e892b06d1edc15620ad691e45b7e7afe45286088e83f81c9baa0a30257e1",
     "TSLaserHarpyMultiClaw": "31023bbe2fc4ead557dfb71e272e73293046514efa4470760dc0a44d5dbf5538",

--- a/tools/tests/test_air_payload_contracts.py
+++ b/tools/tests/test_air_payload_contracts.py
@@ -1,0 +1,120 @@
+"""Regression checks for weapons that advertise Air as a valid target."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "audit"))
+
+import audit_stat_formulas as formulas
+from miniyaml import Ruleset
+
+
+class AirPayloadContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = Ruleset(ROOT)
+
+    def test_advertised_air_damage_cohort_delivers_an_air_payload(self):
+        names = {
+            "TSAssaultCannon",
+            "TSAssaultCannonSonic",
+            "TSAssaultCannonTal",
+            "TSAssaultCannonTalSonic",
+            "TSFiendShard",
+            "TSFiendShardUP",
+            "TSFiendShardBlue",
+            "TSFiendShardBlueUP",
+            "VenomLaserInferno",
+            "VenomLaserBurning",
+            "CabalOverkillCharge",
+            "PsionicShockwave",
+        }
+        for name in sorted(names):
+            weapon = self.rules.resolve_weapon(name)
+            self.assertTrue(formulas.targets_air(weapon), name)
+            self.assertTrue(
+                formulas.has_air_payload(self.rules, weapon), name)
+
+    def test_fiend_damage_layers_all_reach_air(self):
+        for name in ("TSFiendShard", "TSFiendShardUP",
+                     "TSFiendShardBlue", "TSFiendShardBlueUP"):
+            weapon = self.rules.resolve_weapon(name)
+            damage_layers = [
+                node for node in weapon.children
+                if node.value in ("AreaDamage", "AreaDamagePercentage")
+                and formulas.positive_damage(node)
+            ]
+            self.assertTrue(damage_layers, name)
+            self.assertTrue(
+                all(formulas.targets_air(node) for node in damage_layers), name)
+
+    def test_ground_cloud_does_not_advertise_air_targeting(self):
+        weapon = self.rules.resolve_weapon("NaxDieGlocke")
+        self.assertFalse(formulas.targets_air(weapon))
+        damage = weapon.child("Warhead@Chemical_Heavy")
+        self.assertEqual("10000", damage.get("Damage"))
+        self.assertEqual("Ground, Water", damage.get("ValidTargets"))
+
+        source = self.rules.actor("schwarzermond_dieglocke")
+        parents = {node.key: node.value for node in source.children
+                   if node.key.startswith("Inherits")}
+        self.assertNotIn("^PrioritizeAir", parents.values())
+
+    def test_archon_autonomous_targeting_matches_its_air_weapon(self):
+        source = self.rules.actor("protoss_archon")
+        parent = source.child("Inherits@AUTOTARGET")
+        self.assertEqual("^AutoTargetAllAssaultMove", parent.value)
+        resolved = self.rules.resolve("protoss_archon")
+        priorities = resolved.children_named("AutoTargetPriority")
+        target_sets = [node.get("ValidTargets") or "" for node in priorities]
+        self.assertTrue(any("Air" in targets for targets in target_sets))
+
+    def test_delayed_and_cluster_payloads_are_not_false_positives(self):
+        for name in ("DefilerPlague", "wc2DeathKnightDeathAndDecay",
+                     "wc2MageBlizzard"):
+            weapon = self.rules.resolve_weapon(name)
+            self.assertTrue(formulas.targets_air(weapon), name)
+            self.assertTrue(
+                formulas.has_air_payload(self.rules, weapon), name)
+
+        plague_dummy = self.rules.resolve_weapon("RemovableDebuffDummy")
+        cloud_delivery = plague_dummy.child("Warhead@Cloud")
+        self.assertEqual("SpawnSmokeParticle", cloud_delivery.value)
+        self.assertEqual("AnthraxCloudBlueLarge", cloud_delivery.get("Weapon"))
+        cloud = self.rules.resolve_weapon(cloud_delivery.get("Weapon"))
+        toxic = cloud.child("Warhead@Toxic_Light")
+        self.assertTrue(formulas.positive_damage(toxic))
+        self.assertTrue(formulas.targets_air(toxic))
+
+    def test_target_only_helpers_are_not_positive_damage(self):
+        weapon = self.rules.resolve_weapon("BeeHiveCarrierTarget")
+        target = weapon.child("Warhead@1Dam")
+        self.assertEqual("TargetDamage", target.value)
+        self.assertFalse(formulas.positive_damage(target))
+
+        harpy = self.rules.resolve_weapon("TSHarpyMultiClaw")
+        self.assertEqual("0", harpy.child("Warhead@Bullet_Medium").get("Damage"))
+        concrete = harpy.child("Warhead@Concrete")
+        self.assertEqual("25", concrete.get("Damage"))
+        self.assertFalse(formulas.positive_damage(concrete))
+        self.assertFalse(formulas.has_air_payload(self.rules, harpy))
+
+    def test_point_defense_is_not_misclassified_as_unit_anti_air(self):
+        for name in ("PDLaserBike", "PDLaserLTNK2", "TKMPDLaser"):
+            weapon = self.rules.resolve_weapon(name)
+            self.assertTrue(formulas.targets_air(weapon), name)
+            self.assertTrue(formulas.is_point_defense(weapon), name)
+
+    def test_missing_warhead_targets_keep_engine_all_target_default(self):
+        weapon = self.rules.resolve_weapon("PDLaserBike")
+        damage = weapon.child("Warhead@1Dam")
+        self.assertIsNone(damage.get("ValidTargets"))
+        self.assertTrue(formulas.targets_air(damage, default_all=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore complete Air damage routing for 12 weapons that already advertised Air targeting: Wolverine/Mk II (including Sonic replacements), both Fiend progressions, Venom upgrades, CABAL Overkill Charge, and Protoss Archon shockwave
- make Archon autonomous targeting match its Strong vs Everything role; this restores automatic acquisition of Air and Structure targets
- narrow Die Glocke to Ground/Water and remove its inert Air priority, matching its documented targets-below toxin-cloud role
- strengthen F18 to follow delayed/cluster payload chains and exclude target helpers, concrete-only damage, and engine point-defense helpers

No costs, cadence, projectile behavior, flat damage amounts, or promotion behavior changed. Pricing was not started and the percentage-damage runtime work remains parked.

## Evidence
- whole-ruleset comparison: exactly 13 intended resolved weapon changes; 0 added/removed definitions
- F18: 22 noisy findings before classification -> 0 after repairs and false-positive modeling
- 593 tests passed; 11 optional openpyxl skips
- weapon structure survey, remaining-root classifier, duplicate-key audit, empty-warhead audit, and scaled-Bullet audit passed
- independent review: no blocker
- fresh isolated OpenRA boot stayed alive at 30/60/90 seconds, reached post-world menu initialization, and logged 0 exception/fatal/rules-load errors