### PR TITLE
Repair paid weapon upgrade contracts

### DIFF
--- a/docs/audit/latest/phase_b_survey.md
+++ b/docs/audit/latest/phase_b_survey.md
@@ -1,6 +1,6 @@
 # Phase B Mixed-Weapon Survey
 
-Generated: 2026-08-28
+Generated: 2026-08-29
 Total concrete weapons on old families: 0
 Single old-family with new inherits (Phase B completion): 0
 Pure single old-family (mechanical Phase A candidates): 0

--- a/docs/audit/latest/weapon_structure_inventory.json
+++ b/docs/audit/latest/weapon_structure_inventory.json
@@ -1,10 +1,10 @@
 {
   "counts": {
     "concrete_weapons": 2345,
-    "stacked_main_all_concrete": 693,
-    "stacked_main_direct_actor_armament": 494,
+    "stacked_main_all_concrete": 694,
+    "stacked_main_direct_actor_armament": 495,
     "stacked_main_indirect_weapon_graph": 92,
-    "stacked_main_transitive_weapon_graph": 586,
+    "stacked_main_transitive_weapon_graph": 587,
     "stacked_main_unreached": 107
   },
   "predicate": "positive Damage on AreaDamage, SpreadDamage, HealthPercentageDamage, or TargetDamage; excludes designed companions and friendly-fire twins",
@@ -407,6 +407,7 @@
       "TSGrenade",
       "TSGrenadeG",
       "TSGrenadeSonic",
+      "TSHellfireSonic",
       "TSInfantryMortar",
       "TSInfantryMortarChem",
       "TSLaser90mm",

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
@@ -1024,12 +1024,7 @@ MammothTusk:
 		ValidTargets: Water, Underwater
 		InvalidTargets: Ship, Structure, Bridge
 
-ParaBomb:
-	Inherits: ^Warhead_Demolition_Heavy
-	Inherits@2: ^Warhead_Flame_Heavy
-	Inherits@3: ^Effect_Flame_Heavy
-	ReloadDelay: 8
-	Range: 5000
+^ParaBombDelivery:
 	Report: chute1.aud
 	Projectile: GravityBomb
 		Image: PARABOMB
@@ -1037,6 +1032,14 @@ ParaBomb:
 		Velocity: 0, 0, -75
 		Acceleration: 0, 0, 0
 		Shadow: False
+
+ParaBomb:
+	Inherits@delivery: ^ParaBombDelivery
+	Inherits: ^Warhead_Demolition_Heavy
+	Inherits@2: ^Warhead_Flame_Heavy
+	Inherits@3: ^Effect_Flame_Heavy
+	ReloadDelay: 8
+	Range: 5000
 	Warhead@Demolition_Heavy:
 		Damage: 20000
 	Warhead@Flame_Heavy:
@@ -1047,13 +1050,13 @@ ParaBomb:
 		ValidTargets: Ground, Ship
 
 ParaBombCryo:
+	Inherits@delivery: ^ParaBombDelivery
 	Inherits@wh: ^Warhead_CryoBlast_Heavy
 	Inherits@fx: ^Effect_Cryo
 	ReloadDelay: 8
 	Range: 5000
-	Report: chute1.aud
-	Projectile: GravityBomb
 	Warhead@CryoBlast_Heavy:
+		Damage: 40000
 
 JapanSuperBomb:
 	Inherits@collapsewh: ^Warhead_Demolition_Heavy

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
@@ -40,6 +40,9 @@ RA2PatriotThunderboltMissile:
 		Acceleration: 10
 		ContrailStartColor: EEEE00
 		ContrailEndColor: FFFFFF
+	Warhead@MissileAA_Heavy:
+		ValidTargets: Air
+		Damage: 10000
 
 HarrierMissiles:
 	Inherits: ^LightFlameWeapon

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
@@ -171,7 +171,7 @@ ConsortiumMissileSystem_EMP:
 	-Warhead@TeslaWeapon:
 	Warhead@MissileQuantum_MediumFlatCompatibility:
 		ValidTargets: Air
-		Damage: 15000
+		Damage: 34000
 		PercentageScale: 0
 
 SteelQuantumCannon:
@@ -1386,6 +1386,14 @@ SteelInfRailgun_EMP_elite:
 SteelScalpelRailgun_EMP_AA:
 	Inherits: SteelInfRailgun_EMP_elite
 	ValidTargets: Air
+	Warhead@Railgun_Heavy:
+		Damage: 4000
+	Warhead@Flak_Medium:
+		Damage: 4000
+	Warhead@Bullet_Medium:
+		Damage: 4000
+	Warhead@MissileAP_Light:
+		Damage: 4000
 	Warhead@EffectAir: CreateEffect
 		Explosions: steel_blueexp
 		ExplosionPalette: ra2effect

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
@@ -1354,11 +1354,11 @@ OfficerMachineGunAP:
 	ReloadDelay: 20
 	Burst: 4
 	BurstDelays: 4
-	Range: 4888
+	Range: 5596
 	Report: mgun11.aud
 	Warhead@Bullet_Medium:
 		ValidTargets: Ground, Air, Water
-		Damage: 4000
+		Damage: 16000
 GDIRigDroneTargeting:
 	# ValidTargets: SpecialRepair, Repairing, Repair, lockdowned, plagued, ivanattached
 	# ValidRelationships: Ally

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
@@ -36,7 +36,7 @@ TS30mmRail:
 		HelixRadius: 16
 	ReloadDelay: 26
 	Burst: 3
-	Range: 5873
+	Range: 6125
 	BurstDelays: 2
 	Warhead@MediumMissile: SpreadDamage
 		Damage: 2000
@@ -57,7 +57,7 @@ TS30mmRail:
 	-Warhead@RailgunExtraDamage:
 	Warhead@Flak_Medium:
 		ValidTargets: Ground, Water, Air
-		Damage: 4000
+		Damage: 16000
 		PercentageScale: 0
 
 TS120mmRail:
@@ -272,9 +272,9 @@ KodiakCannonSonic:
 	Report: tnkfire4.aud
 	ValidTargets: Ground, Water
 	Warhead@CannonHE_Heavy:
-		Damage: 8000
+		Damage: 22000
 	Warhead@Sonic_Heavy:
-		Damage: 8000
+		Damage: 22000
 TSSonicWeaponEffect:
 	ReloadDelay: 60
 	Range: 6144
@@ -670,10 +670,11 @@ TSMammothTusk2II_AA:
 		Explosions: small_building
 
 TSHellfireSonic:
+	Inherits: TSHellfire
 	Inherits@wh: ^Warhead_Sonic_Medium
 	Inherits@proj: ^Projectile_TS_Missile_Medium
 	Inherits@fx: ^Effect_Sonic_Medium
-	ReloadDelay: 60
+	ReloadDelay: 32
 	Range: 6144
 	Report: orcamis1.aud
 	ValidTargets: Ground, Water, Air
@@ -697,7 +698,7 @@ TSZoneHellfire:
 	Range: 6138
 
 TSZoneHellfireSonic:
-	Inherits: TSHellfireSonic
+	Inherits: TSZoneHellfire
 	Inherits@wh: ^Warhead_Sonic_Heavy
 	Inherits@proj: ^Projectile_TS_Missile_Heavy
 	Inherits@fx: ^Effect_Sonic_Heavy
@@ -943,6 +944,7 @@ TSAssaultCannonTalSonic:
 	Inherits@fx: ^Effect_Sonic_Shell
 	Report: 120mmf.aud
 	ReloadDelay: 45
+	Range: 6520
 	ValidTargets: Ground, Water, Air
 	Projectile: Bullet
 		Speed: 2000

--- a/mods/cameo/weapons/tiberiansun.yaml
+++ b/mods/cameo/weapons/tiberiansun.yaml
@@ -475,8 +475,8 @@ TSGrenadeSonic:
 	Inherits@wh2: ^Warhead_Sonic_Light
 	Inherits@proj: ^Projectile_Sonic_Shell
 	Inherits@fx: ^Effect_Sonic_Shell
-	ReloadDelay: 50
-	Range: 6151
+	ReloadDelay: 45
+	Range: 6656
 	Report: toss1.aud
 	ValidTargets: Ground, Water
 	Projectile: Bullet
@@ -491,10 +491,10 @@ TSGrenadeSonic:
 		ContrailEndColor: FFFFFF22
 	Warhead@Concussion_Light:
 		ValidTargets: Ground, Water
-		Damage: 12000
+		Damage: 18000
 	Warhead@Sonic_Light:
 		ValidTargets: Ground, Water
-		Damage: 12000
+		Damage: 18000
 TSGrenadeAA:
 	Inherits: TSGrenade
 	Range: 6512

--- a/tools/audit/audit_upgrade_regression.py
+++ b/tools/audit/audit_upgrade_regression.py
@@ -51,6 +51,7 @@ import target_model as tm  # noqa: E402
 # The armor classes a ground attacker is normally judged on. Air/ARMOR/HAZMAT are excluded from
 # the VERDICT (an AA or anti-shield upgrade legitimately trades them) but still printed.
 CORE = ("Scout", "Light", "Medium", "Heavy", "Superheavy", "Steel", "None", "Concrete", "Wood")
+AIR = ("Fighter", "Bomber", "Helicopter", "Spaceship")
 FLAT_TYPES = frozenset({"AreaDamage", "SpreadDamage", "TargetDamage"})
 
 
@@ -157,9 +158,14 @@ def weapon_profile(rs, name: str) -> dict | None:
     direct_actor = ed.direct_actor_impact(node)
     impact_multiplier = ed.projectile_impact_multiplier(node)
     per_armor: dict[str, float] = {}
+    utility: set[tuple[str, str]] = set()
     for wh in node.children:
         if not wh.key.startswith("Warhead") or "Concrete" in wh.key:
             continue
+        if wh.value in {"AffectsIntegrity", "GrantExternalCondition"}:
+            utility.add((wh.value, wh.get("Condition") or ""))
+        if wh.get("PhysicalStateName") or wh.child("PhysicalStates") is not None:
+            utility.add(("PhysicalState", wh.get("PhysicalStateName") or "map"))
         if wh.value not in FLAT_TYPES or not _enemy_damage(wh):
             continue
         d = int(_f(wh.get("Damage")))
@@ -189,19 +195,79 @@ def weapon_profile(rs, name: str) -> dict | None:
     total = max(per_armor.values(), default=0.0)
     if total <= 0:
         return None
+    valid_targets = {
+        target.strip() for target in (node.get("ValidTargets") or "").split(",")
+        if target.strip()
+    }
+    air_only = "Air" in valid_targets and not valid_targets.intersection({"Ground", "Water"})
     return {"total": total, "per_armor": per_armor, "rate": cycle_rate(node),
-            "projectile_impact_multiplier": impact_multiplier}
+            "projectile_impact_multiplier": impact_multiplier, "air_only": air_only,
+            "utility": utility}
+
+
+def armament_profile(rs, names: tuple[str, ...]) -> dict | None:
+    """Combined weapon-only DPS for weapons that fire together through one armament name.
+
+    OpenRA permits multiple ``Armament`` traits with the same ``Name``.  They
+    fire together, so judging only the last trait can turn a multi-beam upgrade
+    into a false downgrade.  Different names (for example ``primary`` and
+    ``garrisoned``) are separate firing modes and must not be combined.
+    """
+    per_armor: dict[str, float] = {}
+    found = False
+    air_only = True
+    utility: set[tuple[str, str]] = set()
+    for name in names:
+        profile = weapon_profile(rs, name)
+        if profile is None:
+            continue
+        found = True
+        air_only = air_only and profile["air_only"]
+        utility.update(profile["utility"])
+        for armor, damage in profile["per_armor"].items():
+            per_armor[armor] = per_armor.get(armor, 0.0) + damage * profile["rate"]
+    return {"per_armor": per_armor, "air_only": air_only,
+            "utility": utility} if found else None
+
+
+def verdict_armors(base_profile: dict, requested_armors):
+    """Judge a replacement on the target role of its base weapon."""
+    return AIR if base_profile["air_only"] else requested_armors
+
+
+def _csv(raw: str | None, default: tuple[str, ...] = ()) -> tuple[str, ...]:
+    if raw is None or not str(raw).strip():
+        return default
+    return tuple(part.strip().lower() for part in str(raw).split(",") if part.strip())
+
+
+def _normal_attack_names(node) -> set[str]:
+    """Return armament names routed by ordinary actor AttackBase traits."""
+    names: set[str] = set()
+    excluded = {"AttackMove", "AttackSounds", "AttackWander", "AttackGarrisoned"}
+    for trait in node.children:
+        trait_type = trait.key.split("@", 1)[0]
+        if not trait_type.startswith("Attack") or trait_type in excluded:
+            continue
+        # OpenRA AttackBaseInfo defaults to primary + secondary.
+        names.update(_csv(trait.get("Armaments"), ("primary", "secondary")))
+    return names
 
 
 def pairs(rs):
-    """(actor, base_weapon, upgrade_weapon, condition) for every gated armament pair."""
+    """Pair condition-swapped weapons by their runtime firing route.
+
+    Same-name replacements are always comparable. Cross-name replacements are
+    paired only when both names are ordinary AttackBase routes, the condition
+    comes from a prerequisite purchase, and one unambiguous half remains.
+    """
     for actor in sorted(rs.actors):
         if actor.startswith("^"):
             continue
         node = rs.resolve(actor)
         if node is None:
             continue
-        by_cond: dict[str, dict[str, str]] = {}
+        armaments = []
         for arm in node.children:
             if not arm.key.startswith("Armament"):
                 continue
@@ -211,10 +277,39 @@ def pairs(rs):
                 continue
             neg = cond.startswith("!")
             key = cond[1:].strip() if neg else cond
-            by_cond.setdefault(key, {})["base" if neg else "up"] = weapon
-        for cond, half in by_cond.items():
-            if "base" in half and "up" in half and half["base"] != half["up"]:
-                yield actor, half["base"], half["up"], cond
+            armament_name = (arm.get("Name") or "primary").strip().lower()
+            armaments.append((key, armament_name, "base" if neg else "up", weapon))
+
+        prerequisite_conditions = {
+            (trait.get("Condition") or "").strip()
+            for trait in node.children
+            if trait.key.split("@", 1)[0] == "GrantConditionOnPrerequisite"
+        }
+        normal_names = _normal_attack_names(node)
+        by_name: dict[tuple[str, str], dict[str, list[str]]] = {}
+        for cond, name, half_name, weapon in armaments:
+            by_name.setdefault((cond, name), {"base": [], "up": []})[half_name].append(weapon)
+
+        unmatched: dict[str, dict[str, list[tuple[str, str]]]] = {}
+        for (cond, name), half in by_name.items():
+            base, up = tuple(half["base"]), tuple(half["up"])
+            if base and up:
+                if base and up and base != up:
+                    yield actor, base, up, cond, name
+                continue
+            if name in normal_names:
+                side = "base" if base else "up"
+                for weapon in base or up:
+                    unmatched.setdefault(cond, {"base": [], "up": []})[side].append((name, weapon))
+
+        for cond, half in unmatched.items():
+            if cond not in prerequisite_conditions:
+                continue
+            if len(half["base"]) == len(half["up"]) == 1:
+                _base_name, base_weapon = half["base"][0]
+                _up_name, up_weapon = half["up"][0]
+                if base_weapon != up_weapon:
+                    yield actor, (base_weapon,), (up_weapon,), cond, "attack"
 
 
 def main() -> int:
@@ -227,33 +322,39 @@ def main() -> int:
     rs = Model().rs
     weaker, shifted, marginal, npairs = [], [], [], 0
 
-    for actor, base_w, up_w, cond in pairs(rs):
-        b, u = weapon_profile(rs, base_w), weapon_profile(rs, up_w)
+    for actor, base_w, up_w, cond, armament_name in pairs(rs):
+        b, u = armament_profile(rs, base_w), armament_profile(rs, up_w)
         if not b or not u:
             continue
         npairs += 1
         losses, gains = [], []
-        for armor in armors:
-            bd = b["per_armor"].get(armor, 0.0) * b["rate"]
-            ud = u["per_armor"].get(armor, 0.0) * u["rate"]
+        # Judge on the role of the weapon being replaced. Becoming all-target
+        # must not hide a regression in an Air-only base weapon.
+        judged_armors = verdict_armors(b, armors)
+        for armor in judged_armors:
+            bd = b["per_armor"].get(armor, 0.0)
+            ud = u["per_armor"].get(armor, 0.0)
             if bd <= 0:
                 continue
             ratio = ud / bd
             (losses if ratio < 0.995 else gains).append((armor, ratio))
-        row = (actor, base_w, up_w, cond, sorted(losses, key=lambda x: x[1]), gains)
+        row = (actor, base_w, up_w, cond, armament_name,
+               sorted(losses, key=lambda x: x[1]), gains)
         if losses:
-            (shifted if gains else weaker).append(row)
+            added_utility = bool(u["utility"] - b["utility"])
+            (shifted if gains or added_utility else weaker).append(row)
             continue
         # No outright loss — but an upgrade that is +4% on the armor the unit exists to fight and
         # +126% on something else has still changed the unit's ROLE and will FEEL like a downgrade.
         # Maintainer 2026-08-19 on MonsterTank: *"the upgrade feels like a downgrade."*
         ratios = [r for _a, r in gains]
         if len(ratios) >= 3 and min(ratios) < 1.10 and max(ratios) / min(ratios) >= 2.0:
-            marginal.append((actor, base_w, up_w, cond,
+            marginal.append((actor, base_w, up_w, cond, armament_name,
                              sorted(gains, key=lambda x: x[1])[:4], max(ratios)))
 
     print("# audit_upgrade_regression — is the upgrade better than what it replaces?\n")
-    print(f"Reference target HP: **{tm.reference_hp():,}**; centered impact; full burst cycle.\n")
+    print(f"Reference target HP: **{tm.reference_hp():,}**; centered impact; full burst cycle; "
+          "weapon profile only (actor multipliers excluded).\n")
     print(f"Gated armament pairs found: **{npairs}**\n")
 
     def table(rows, title, note):
@@ -264,9 +365,11 @@ def main() -> int:
             return
         print("| actor | base → upgrade | condition | worst losses (upgrade DPS ÷ base DPS) |")
         print("|---|---|---|---|")
-        for actor, bw, uw, cond, losses, _g in rows[:40]:
+        for actor, bw, uw, cond, armament_name, losses, _g in rows[:40]:
             worst = ", ".join(f"{ar} {rt:.2f}x" for ar, rt in losses[:4])
-            print(f"| `{actor}` | `{bw}` → `{uw}` | `{cond}` | {worst} |")
+            base_label, up_label = " + ".join(bw), " + ".join(uw)
+            mode = f" ({armament_name})" if armament_name != "primary" else ""
+            print(f"| `{actor}` | `{base_label}` → `{up_label}` | `{cond}`{mode} | {worst} |")
         if len(rows) > 40:
             print(f"\n_… {len(rows) - 40} more_")
         print()
@@ -286,9 +389,9 @@ def main() -> int:
     if marginal:
         print("| actor | base → upgrade | weakest core gains | best |")
         print("|---|---|---|--:|")
-        for actor, bw, uw, _c, worst, best in marginal[:40]:
+        for actor, bw, uw, _c, _armament_name, worst, best in marginal[:40]:
             w = ", ".join(f"{ar} {rt:.2f}x" for ar, rt in worst)
-            print(f"| `{actor}` | `{bw}` → `{uw}` | {w} | {best:.2f}x |")
+            print(f"| `{actor}` | `{' + '.join(bw)}` → `{' + '.join(uw)}` | {w} | {best:.2f}x |")
         if len(marginal) > 40:
             print(f"\n_… {len(marginal) - 40} more_")
         print()

--- a/tools/balance/consolidate_high_identity_profiles.py
+++ b/tools/balance/consolidate_high_identity_profiles.py
@@ -53,7 +53,7 @@ PRESERVED_HASHES = {
     "IxRailgunDroneBullet": "8f6f05b056d48d7a61c623779ea6b3115aef386a6c10a681e7ad94a92ebb96b1",
     # Post-consolidation correction: Wolverine Mk II keeps its advertised weak
     # AA role after Sonic Weaponry replaces the base armament.
-    "TSAssaultCannonTalSonic": "193772b68bde138b7365ad1f6c6cbbd6632e2cf98a84d2987491fba67b514413",
+    "TSAssaultCannonTalSonic": "6351589c35a2e3c2e9dac7dce494ecaed4be168eea38f407dda8affe87125e08",
 }
 
 CANONICAL = re.compile(r"^\^Warhead_([A-Za-z]+)_(\w+)$")

--- a/tools/tests/test_weapon_structure_inventory.py
+++ b/tools/tests/test_weapon_structure_inventory.py
@@ -43,9 +43,9 @@ class WeaponStructureInventoryTests(unittest.TestCase):
 
     def test_current_corrected_baseline(self):
         self.assertEqual(2345, self.data["counts"]["concrete_weapons"])
-        self.assertEqual(693, self.data["counts"]["stacked_main_all_concrete"])
-        self.assertEqual(494, self.data["counts"]["stacked_main_direct_actor_armament"])
-        self.assertEqual(586, self.data["counts"]["stacked_main_transitive_weapon_graph"])
+        self.assertEqual(694, self.data["counts"]["stacked_main_all_concrete"])
+        self.assertEqual(495, self.data["counts"]["stacked_main_direct_actor_armament"])
+        self.assertEqual(587, self.data["counts"]["stacked_main_transitive_weapon_graph"])
         self.assertEqual(107, self.data["counts"]["stacked_main_unreached"])
 
     def test_engine_weapon_reference_fields_are_followed(self):

--- a/tools/tests/test_weapon_upgrade_contracts.py
+++ b/tools/tests/test_weapon_upgrade_contracts.py
@@ -1,0 +1,129 @@
+"""Resolved-rules contracts for paid weapon replacements."""
+
+from __future__ import annotations
+
+import unittest
+
+import _bootstrap  # noqa: F401 — sys.path side effect
+
+import audit_upgrade_regression as upgrade
+from cameo_model import Model
+
+
+class WeaponUpgradeContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rs = Model().rs
+
+    def _warhead(self, weapon_name: str, key: str):
+        node = self.rs.resolve_weapon(weapon_name)
+        self.assertIsNotNone(node)
+        warhead = next((c for c in node.children if c.key == key), None)
+        self.assertIsNotNone(warhead, f"{weapon_name} must resolve {key}")
+        return warhead
+
+    def _assert_not_weaker(self, base: str, upgraded: str, armors):
+        b = upgrade.armament_profile(self.rs, (base,))
+        u = upgrade.armament_profile(self.rs, (upgraded,))
+        self.assertIsNotNone(b)
+        self.assertIsNotNone(u)
+        for armor in armors:
+            base_dps = b["per_armor"].get(armor, 0)
+            if base_dps > 0:
+                self.assertGreaterEqual(
+                    u["per_armor"].get(armor, 0), base_dps,
+                    f"{upgraded} regressed against {armor} versus {base}")
+
+    def test_parallel_upgrade_beams_are_compared_as_one_firing_group(self):
+        pairs = [p for p in upgrade.pairs(self.rs) if p[0] == "japan_waveforcetank"]
+        self.assertIn((
+            "japan_waveforcetank", ("WaveforceCannon",),
+            ("WaveforceCannonChargedLaser", "WaveforceCannonDistortedBeam1",
+             "WaveforceCannonDistortedBeam2"),
+            "japan_upgrade_advancedplasmaweapons", "primary"), pairs)
+
+    def test_attack_route_pairs_upgrades_that_switch_armament_names(self):
+        pairs = [p for p in upgrade.pairs(self.rs) if p[0] == "ts_gdi_wolverine"]
+        self.assertIn((
+            "ts_gdi_wolverine", ("TSAssaultCannon",),
+            ("TSAssaultCannonSonic",), "ts_gdi_upgrade_sonicweaponry", "attack"), pairs)
+
+        pairs = [p for p in upgrade.pairs(self.rs) if p[0] == "ts_gdi_mammothmkii"]
+        self.assertIn((
+            "ts_gdi_mammothmkii", ("TSMechRailgunII",),
+            ("TSMechRailgunRailII",), "ts_gdi_upgrade_railgunweaponry", "attack"), pairs)
+
+    def test_air_only_base_keeps_air_verdict_if_upgrade_targets_more(self):
+        self.assertEqual(
+            upgrade.verdict_armors({"air_only": True}, list(upgrade.CORE)), upgrade.AIR)
+
+    def test_garrisoned_mode_is_not_combined_with_primary_fire(self):
+        pairs = [p for p in upgrade.pairs(self.rs) if p[0] == "ts_gdi_discthrower"]
+        self.assertEqual({p[4] for p in pairs}, {"primary", "garrisoned"})
+
+    def test_cryo_cargo_bomb_preserves_bomb_delivery_and_full_raw_payload(self):
+        weapon = self.rs.resolve_weapon("ParaBombCryo")
+        self.assertEqual(weapon.get("ReloadDelay"), "8")
+        self.assertEqual(weapon.get("Range"), "5000")
+        self.assertEqual(weapon.get("Projectile"), "GravityBomb")
+        self.assertEqual(weapon.get("Projectile", "Image"), "PARABOMB")
+        cryo = self._warhead("ParaBombCryo", "Warhead@CryoBlast_Heavy")
+        self.assertEqual(cryo.get("Damage"), "40000")
+        self.assertEqual(cryo.get("PhysicalStates", "Temperature"), "-67")
+        self.assertEqual(
+            {c.key for c in weapon.children if c.key.startswith("Warhead")},
+            {"Warhead@CryoBlast_Heavy", "Warhead@Effect", "Warhead@EffectWater",
+             "Warhead@EffectAir"})
+
+    def test_thunderbolt_patriot_is_an_anti_air_upgrade(self):
+        self.assertEqual(
+            self._warhead("RA2PatriotThunderboltMissile", "Warhead@MissileAA_Heavy").get("Damage"),
+            "10000")
+        self._assert_not_weaker("RA2Patriot", "RA2PatriotThunderboltMissile", upgrade.AIR)
+
+    def test_armor_piercing_officer_round_preserves_base_payload_and_range(self):
+        weapon = self.rs.resolve_weapon("OfficerMachineGunAP")
+        self.assertEqual(weapon.get("Range"), "5596")
+        self.assertEqual(self._warhead("OfficerMachineGunAP", "Warhead@Bullet_Medium").get("Damage"),
+                         "16000")
+        self._assert_not_weaker("OfficerMachineGun", "OfficerMachineGunAP", upgrade.CORE)
+
+    def test_ts_paid_replacements_do_not_reduce_centered_core_damage(self):
+        for base, upgraded in (
+                ("TSGrenadeG", "TSGrenadeSonic"),
+                ("TS30mm", "TS30mmRail"),
+                ("KodiakCannon", "KodiakCannonSonic"),
+                ("TSHellfire", "TSHellfireSonic"),
+                ("TSZoneHellfire", "TSZoneHellfireSonic")):
+            with self.subTest(base=base, upgraded=upgraded):
+                self._assert_not_weaker(base, upgraded, upgrade.CORE + upgrade.AIR)
+
+        expected_delivery = {
+            "TSGrenadeSonic": ("45", "6656", "Ground, Water"),
+            "TS30mmRail": ("26", "6125", "Ground, Water, Air"),
+            "TSAssaultCannonTalSonic": ("45", "6520", "Ground, Water, Air"),
+            "KodiakCannonSonic": ("86", "9165", "Ground, Water"),
+            "TSHellfireSonic": ("32", "6144", "Ground, Water, Air"),
+            "TSZoneHellfireSonic": ("28", "6138", "Ground, Water, Air"),
+        }
+        for weapon_name, expected in expected_delivery.items():
+            weapon = self.rs.resolve_weapon(weapon_name)
+            self.assertEqual(
+                (weapon.get("ReloadDelay"), weapon.get("Range"), weapon.get("ValidTargets")),
+                expected)
+
+        kodiak_projectile = self.rs.resolve_weapon("KodiakCannonSonic").child("Projectile")
+        self.assertEqual(kodiak_projectile.value, "Bullet")
+        self.assertIsNone(kodiak_projectile.get("TrailImage"))
+        self.assertIsNone(kodiak_projectile.get("PointDefenseTypes"))
+
+    def test_quantum_emp_anti_air_replacements_increase_damage(self):
+        for base, upgraded in (
+                ("SteelScalpelRailgunAA", "SteelScalpelRailgun_EMP_AA"),
+                ("ConsortiumMissileSystem", "ConsortiumMissileSystem_EMP")):
+            with self.subTest(base=base, upgraded=upgraded):
+                self._assert_not_weaker(base, upgraded, upgrade.AIR)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- repair paid weapon replacements that resolved to weaker or incomplete weapon contracts
- preserve cargo-bomb delivery while separating the Cryo payload from the normal ParaBomb damage stack
- extend the upgrade audit to compare complete firing groups, prerequisite-backed renamed armaments, Air roles, and utility effects
- refresh the active weapon-structure survey and pin the intentional Hellfire Sonic payload stack

## Gameplay rationale
Purchased replacements should not silently lose their base weapon's range or core payload unless that loss is an intentional role trade. This restores the missing base delivery/damage pieces for the affected Patriot, Consortium, Officer, and Tiberian Sun upgrades while retaining their authored special effects, cadence, targeting, and role-specific tradeoffs.

## Validation
- 602 Python tests passed (11 skipped because the optional spreadsheet dependency is unavailable)
- upgrade audit: 420 gated pairs, 0 strictly weaker, 88 advisory role/tradeoff findings at the existing ratchet
- empty-warhead audit: 2,847 constructed weapons, 0 crash sites/suspects/errors
- physical-state audit: pass across 2,345 active concrete weapons
- scaled-Bullet audit: no reachable Speed 17 fallback
- weapon-structure survey: generated inventory matches live rules
- independent review: no blockers
- fresh 90-second hidden boot: process remained alive; no crash, rules-load, Lua, graphics, or server errors

Pricing and the parked percentage-damage runtime change are intentionally out of scope.