### PR TITLE
Remove remaining sniper splash and strengthen weapon audits

### DIFF
--- a/docs/design/upgrades_intent.yaml
+++ b/docs/design/upgrades_intent.yaml
@@ -15,9 +15,10 @@
 ######################## TD Nod — Temple tier #######################
 td_nod_upgrade_elitecapacitors:
 	faction: td_nod
-	effect: laser firepower and fire rate +30%; range and vision +15%; Obelisk bonuses +60%/+30%
+	effect: laser firepower +30% with 15% longer reload; range and vision +15%; Obelisk bonuses +60% firepower, -60% reload delay, and +30% range and vision
 	coverage: listed
 	phase: late
+	drawbacks: reloaddelaymultiplier
 td_nod_upgrade_cyberneticmodifications:
 	faction: td_nod
 	effect: infantry shield and Medium armor profile; speed +20%

--- a/docs/design/upgrades_intent.yaml
+++ b/docs/design/upgrades_intent.yaml
@@ -12,6 +12,75 @@
 #   drawbacks: space-separated trait base names that are INTENTIONALLY
 #              anti-buff (e.g. damagemultiplier for a glass-cannon upgrade)
 
+######################## TD Nod — Temple tier #######################
+td_nod_upgrade_elitecapacitors:
+	faction: td_nod
+	effect: laser firepower and fire rate +30%; range and vision +15%; Obelisk bonuses +60%/+30%
+	coverage: listed
+	phase: late
+td_nod_upgrade_cyberneticmodifications:
+	faction: td_nod
+	effect: infantry shield and Medium armor profile; speed +20%
+	coverage: infantry
+	phase: late
+	drawbacks: damagemultiplier
+
+######################## Reviewed weapon tradeoffs ##################
+asianalliance_doctrine_heavypulverizerweapons:
+	faction: asianalliance
+	effect: doubles Pulverizer projectiles at 75% damage per shot; range +15%
+	coverage: listed
+	phase: mid
+	drawbacks: firepowermultiplier
+japan_upgrade_energizedarrows:
+	faction: japan
+	effect: charged arrows add an electric payload; ordinary arrows gain 25% damage
+	coverage: listed
+	phase: late
+	drawbacks: firepowermultiplier reloaddelaymultiplier
+japan_upgrade_advancedplasmaweapons:
+	faction: japan
+	effect: plasma damage, fire rate, range, and vision +10%; selected units add parallel beams
+	coverage: listed
+	phase: late
+	drawbacks: firepowermultiplier
+ra1_allies_upgrade_cryomissiles:
+	faction: ra1_allies
+	effect: adds stacking Cryo control to missiles and bombs at 25% lower firepower
+	coverage: listed
+	phase: late
+	drawbacks: firepowermultiplier
+ra1_soviets_doctrine_teslaandexperimentaltech:
+	faction: ra1_soviets
+	effect: experimental Tesla loadouts; Gatling weapons trade cadence for the doctrine payload
+	coverage: listed
+	phase: mid
+	drawbacks: reloaddelaymultiplier
+ra2_soviets_doctrine_heavyarmorplatings:
+	faction: ra2_soviets
+	effect: vehicle and aircraft damage resistance +25%; speed -10%
+	coverage: listed
+	phase: late
+	drawbacks: speedmultiplier
+ra2_soviets_doctrine_reactivearmor:
+	faction: ra2_soviets
+	effect: tank area-damage resistance +50% and general resistance +10%; speed -5%
+	coverage: listed
+	phase: late
+	drawbacks: speedmultiplier
+ra2_soviets_doctrine_tesladischargearmor:
+	faction: ra2_soviets
+	effect: damage resistance +15% and charged Tesla discharge; speed -15% while charging
+	coverage: listed
+	phase: late
+	drawbacks: speedmultiplier
+steelconsortium_upgrade_resonanceammo:
+	faction: steelconsortium
+	effect: bullets ricochet for additional damage and gain 10% range
+	coverage: listed
+	phase: late
+	drawbacks: firepowermultiplier
+
 ######################## TS GDI — Radar tier ########################
 up_seretraining:
 	faction: tsgdi

--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml
@@ -16,6 +16,8 @@ CryoLightSniper:
 		ContrailLength: 10
 	Warhead@BulletCryo_Light:
 		Damage: 30000
+		Spread: 1
+		Falloff: 100, 0
 
 M60mg:
 	Inherits@wh: ^Warhead_Bullet_Light

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
@@ -336,10 +336,16 @@ LightSniper:
 	Range: 9153
 	Warhead@Sniper_Light:
 		Damage: 30000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 30000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 15
+		Spread: 1
+		Falloff: 100, 0
 
 ReimuYinYangOrb:
 	# Shrine super-orb projectile. Pure Magic (2026-08-10). Was 32k Tesla + 32k Magic = 64k total.

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
@@ -2719,10 +2719,16 @@ RA2AWP:
 	Report: isniatta.wav
 	Warhead@Sniper_Light:
 		Damage: 44000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 44000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 22
+		Spread: 1
+		Falloff: 100, 0
 
 RA2GattlingMG1:
 	Inherits@roleflat: ^Compatibility_Bullet_MediumFlat

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/weapons.yaml
@@ -804,10 +804,14 @@ RA2Virusgun:
 	Warhead@SniperWeaponExtraDamage: OpenToppedDamage
 		ValidTargets: Infantry, Monster, Garrisoned
 		Damage: 12000
+		Spread: 1
+		Falloff: 100, 0
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@SniperWeaponPercentage: AreaDamagePercentage
 		ValidTargets: Infantry, Monster, Garrisoned
 		Damage: 6
+		Spread: 1
+		Falloff: 100, 0
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@HeavyChemicalWeapon: AreaDamage
 		ValidRelationships: Ally, Neutral, Enemy
@@ -821,6 +825,8 @@ RA2Virusgun:
 	Warhead@HeavyChemicalWeaponPercentage: AreaDamagePercentage
 		ValidTargets: Infantry, Monster, Garrisoned
 		Damage: 6
+		Spread: 1
+		Falloff: 100, 0
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 		PhysicalStateName: Corrosion
 		PhysicalStateScale: 100
@@ -843,6 +849,8 @@ RA2Virusgun:
 		ValidTargets: Infantry
 		Damage: 24000
 		PercentageScale: 0
+		Spread: 1
+		Falloff: 100, 0
 
 RA2Virusgun2:
 	Inherits@wh: ^Warhead_Flak_Medium
@@ -854,6 +862,8 @@ RA2Virusgun2:
 	Warhead@Flak_Medium:
 		ValidTargets: Infantry, Monster, Garrisoned
 		Damage: 12000
+		Spread: 1
+		Falloff: 100, 0
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@SniperWeapon: SpreadDamage
 		ValidTargets: Ground, Ship, Garrisoned
@@ -896,6 +906,8 @@ RA2Virusgun3:
 	Warhead@MissileAP_Medium:
 		ValidTargets: Infantry, Monster, Garrisoned
 		Damage: 12000
+		Spread: 1
+		Falloff: 100, 0
 		DamageTypes: Prone75Percent, TriggerProne, RA2VirusDeath
 	Warhead@Condition: GrantExternalCondition
 		Range: 2000

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
@@ -411,10 +411,16 @@ NaxiSniper:
 	Range: 7777
 	Warhead@Sniper_Light:
 		Damage: 24000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 24000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 12
+		Spread: 1
+		Falloff: 100, 0
 
 NaxiSniper_elite:
 	Inherits: NaxiSniper

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
@@ -205,10 +205,16 @@ tkmawp:
 	Report: isniatta.wav
 	Warhead@Sniper_Light:
 		Damage: 44000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 44000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 22
+		Spread: 1
+		Falloff: 100, 0
 tkmsmg:
 	Inherits@wh: ^Warhead_Sniper_Light
 	Inherits@proj: ^Projectile_Sniper_Light
@@ -1146,10 +1152,16 @@ VanSniper:
 	Report: isniatta.wav
 	Warhead@Sniper_Light:
 		Damage: 80000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 80000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 40
+		Spread: 1
+		Falloff: 100, 0
 
 tkmt72cannon:
 	Inherits@wh: ^Warhead_CannonHE_Medium

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
@@ -7,10 +7,16 @@ td_gdi_commando_sniper:
 	Range: 8086
 	Warhead@Sniper_Light:
 		Damage: 40000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 40000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 20
+		Spread: 1
+		Falloff: 100, 0
 
 M16AP:
 	Inherits@wh: ^Warhead_Bullet_Medium
@@ -56,6 +62,11 @@ td_gdi_commando_sniper_elite:
 		ContrailLength: 40
 	Warhead@Railgun_Heavy:
 		Damage: 20000
+		Spread: 1
+		Falloff: 100, 0
+	Warhead@Railgun_Heavy_ExtraDamage:
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light:
 		Damage: 20000
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/upgrades.yaml
@@ -35,7 +35,7 @@
 		Modifier: 130
 	ReloadDelayMultiplier@td_nod_upgrade_elitecapacitors:
 		RequiresCondition: td_nod_upgrade_elitecapacitors
-		Modifier: 70
+		Modifier: 115
 	RangeMultiplier@td_nod_upgrade_elitecapacitors:
 		RequiresCondition: td_nod_upgrade_elitecapacitors
 		Modifier: 115

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/upgrades.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/upgrades.yaml
@@ -35,7 +35,7 @@
 		Modifier: 130
 	ReloadDelayMultiplier@td_nod_upgrade_elitecapacitors:
 		RequiresCondition: td_nod_upgrade_elitecapacitors
-		Modifier: 115
+		Modifier: 70
 	RangeMultiplier@td_nod_upgrade_elitecapacitors:
 		RequiresCondition: td_nod_upgrade_elitecapacitors
 		Modifier: 115

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
@@ -1879,10 +1879,16 @@ TSSniper:
 	Report: silencer.aud
 	Warhead@Sniper_Light:
 		Damage: 10000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_ExtraDamage: OpenToppedDamage
 		Damage: 10000
+		Spread: 1
+		Falloff: 100, 0
 	Warhead@Sniper_Light_Percentage: AreaDamagePercentage
 		Damage: 5
+		Spread: 1
+		Falloff: 100, 0
 
 TSGhostGun:
 	Inherits@wh: ^Warhead_Chemical_Light

--- a/tools/audit/audit_three_way_split.py
+++ b/tools/audit/audit_three_way_split.py
@@ -56,6 +56,14 @@ from miniyaml import Ruleset  # noqa: E402
 # 1190 -> 1178 the same day: a MEASUREMENT fix, not converted weapons. See FRIENDLY_FIRE below.
 SPLIT_BASELINE = 693
 
+# Exact, reviewed composites that intentionally carry a delivery payload plus a
+# separate status payload.  The fingerprint is deliberately strict: changing a
+# key, adding a third main, or copying the same pair onto another weapon drops
+# the exception and trips the lower-only ratchet.
+INTENTIONAL_COMPOSITES = {
+    "TSHellfireSonic": ("MissileAP_Heavy", "Sonic_Medium"),
+}
+
 # Warhead types that inflict damage on a normal target. Everything else (CreateEffect,
 # LeaveSmudge, GrantExternalCondition, SpawnActor, GlowImpact, ...) is cosmetic or utility and
 # belongs to the ^Effect_ layer, so it is not counted here.
@@ -117,11 +125,17 @@ def main_warheads(resolved) -> list[str]:
     return [wh.key.replace("Warhead@", "") for wh in main_warhead_nodes(resolved)]
 
 
+def intentional_composite(name: str, mains: list[str]) -> bool:
+    """Whether *name* has its one exact, reviewed multi-main fingerprint."""
+    return INTENTIONAL_COMPOSITES.get(name) == tuple(sorted(mains))
+
+
 def main() -> int:
     rs = Ruleset(pathlib.Path("."))
     hist = collections.Counter()
     combos = collections.Counter()
     rows: list[tuple[str, list[str]]] = []
+    reviewed: list[tuple[str, list[str]]] = []
 
     for name in sorted(rs.weapons):
         if name.startswith("^"):
@@ -132,14 +146,19 @@ def main() -> int:
         mains = main_warheads(resolved)
         hist[len(mains)] += 1
         if len(mains) > 1:
-            rows.append((name, mains))
-            combos[tuple(sorted(mains))] += 1
+            if intentional_composite(name, mains):
+                reviewed.append((name, mains))
+            else:
+                rows.append((name, mains))
+                combos[tuple(sorted(mains))] += 1
 
     total = sum(hist.values())
-    print(f"# audit_three_way_split — {len(rows)} of {total} weapons fire more than ONE main warhead\n")
+    print(f"# audit_three_way_split — {len(rows)} of {total} weapons fire more than ONE "
+          "unreviewed main warhead\n")
     print(f"  {hist[1]:5d}  correct — exactly one main warhead")
     print(f"  {hist[0]:5d}  none — utility / effect-only weapons")
-    print(f"  {len(rows):5d}  VIOLATIONS — stacked mains\n")
+    print(f"  {len(rows):5d}  VIOLATIONS — stacked mains")
+    print(f"  {len(reviewed):5d}  reviewed — exact intentional composites\n")
 
     print("  mains  weapons")
     for k in sorted(hist):
@@ -150,6 +169,13 @@ def main() -> int:
     print("| count | combination |\n|---|---|")
     for combo, n in combos.most_common(20):
         print(f"| {n} | {' + '.join(combo)} |")
+
+    print(f"\nReviewed exact composites ({len(reviewed)}):\n")
+    if reviewed:
+        for name, mains in reviewed:
+            print(f"- `{name}`: {' + '.join(sorted(mains))}")
+    else:
+        print("_none_")
 
     over = len(rows) > SPLIT_BASELINE
     print(f"\n{'FAIL' if over else 'WARN'} {len(rows)} violating weapons (ratchet {SPLIT_BASELINE})")

--- a/tools/audit/audit_upgrades.py
+++ b/tools/audit/audit_upgrades.py
@@ -24,21 +24,34 @@ from report import h1, h2, relpath, table
 
 # trait base name -> (field, beneficial_predicate, meaning)
 DIRECTION = {
-    "FirepowerMultiplier":     ("Modifier", lambda v: v > 100, ">100 = stronger"),
-    "ReloadDelayMultiplier":   ("Modifier", lambda v: v < 100, "<100 = faster"),
-    "DamageMultiplier":        ("Modifier", lambda v: v < 100, "<100 = takes less damage"),
-    "SpeedMultiplier":         ("Modifier", lambda v: v > 100, ">100 = faster"),
-    "RangeMultiplier":         ("Modifier", lambda v: v > 100, ">100 = longer range"),
-    "RevealsShroudMultiplier": ("Modifier", lambda v: v > 100, ">100 = more vision"),
-    "DetectCloakedMultiplier": ("Modifier", lambda v: v > 100, ">100 = better detection"),
-    "InaccuracyMultiplier":    ("Modifier", lambda v: v < 100, "<100 = more accurate"),
-    "PowerMultiplier":         ("Modifier", lambda v: v > 100, ">100 = more power"),
-    "ProductionCostMultiplier":("Multiplier", lambda v: v < 100, "<100 = cheaper"),
-    "ProductionTimeMultiplier":("Multiplier", lambda v: v < 100, "<100 = faster build"),
+    "FirepowerMultiplier":     ("Modifier", lambda v: v >= 100, ">=100 = not weaker"),
+    "ReloadDelayMultiplier":   ("Modifier", lambda v: v <= 100, "<=100 = not slower"),
+    "DamageMultiplier":        ("Modifier", lambda v: v <= 100, "<=100 = no more damage"),
+    "SpeedMultiplier":         ("Modifier", lambda v: v >= 100, ">=100 = not slower"),
+    "RangeMultiplier":         ("Modifier", lambda v: v >= 100, ">=100 = not shorter"),
+    "RevealsShroudMultiplier": ("Modifier", lambda v: v >= 100, ">=100 = no less vision"),
+    "DetectCloakedMultiplier": ("Modifier", lambda v: v >= 100, ">=100 = no worse detection"),
+    "InaccuracyMultiplier":    ("Modifier", lambda v: v <= 100, "<=100 = no less accurate"),
+    "PowerMultiplier":         ("Modifier", lambda v: v >= 100, ">=100 = no less power"),
+    "ProductionCostMultiplier":("Multiplier", lambda v: v <= 100, "<=100 = no dearer"),
+    "ProductionTimeMultiplier":("Multiplier", lambda v: v <= 100, "<=100 = no slower build"),
 }
 
 UPGRADE_QUEUES = ("upgrade", "research", "promotion")
 _ident = re.compile(r"[A-Za-z0-9_.\-]+")
+
+# Aedis deliberately changed this from 160 to 91 together with a production-cost
+# rebalance.  Its intended formula cannot be resolved without reopening pricing,
+# which is outside this pipeline.  Pin the exact unresolved fingerprint so any
+# actor, trait, or value drift becomes a new blocking finding.
+DEFERRED_INVERTED = {
+    ("steelconsortium_upgrade_pulseweapons", "steelconsortium_clonetrooper",
+     "FirepowerMultiplier@steelconsortium_upgrade_pulseweapons", "91"),
+}
+
+
+def is_deferred_inverted(upgrade: str, actor: str, trait: str, value: str) -> bool:
+    return (upgrade, actor, trait, value) in DEFERRED_INVERTED
 
 
 def load_intent(root: pathlib.Path) -> dict[str, dict]:
@@ -122,7 +135,7 @@ def main() -> int:
             unlock_consumers.setdefault(tok, []).append(name.lower())
 
     # ---- checks ------------------------------------------------------------ #
-    inverted, dead_upgrades, no_intent = [], [], []
+    inverted, deferred_inverted, dead_upgrades, no_intent = [], [], [], []
     for uname, toks in sorted(upgrades.items()):
         entry = intent.get(uname, None)
         drawbacks = set((entry or {}).get("drawbacks", "").replace(",", " ").split())
@@ -145,8 +158,12 @@ def main() -> int:
                 except ValueError:
                     continue
                 if not spec[1](v) and base.lower() not in drawbacks:
-                    inverted.append([uname, actor, trait_key, str(v), spec[2],
-                                     "declared drawback?" if entry else "no intent entry"])
+                    row = [uname, actor, trait_key, str(v), spec[2],
+                           "declared drawback?" if entry else "no intent entry"]
+                    if is_deferred_inverted(uname, actor, trait_key, str(v)):
+                        deferred_inverted.append(row)
+                    else:
+                        inverted.append(row)
         if not consumed:
             node = rs.actor(uname)
             dead_upgrades.append([uname, ", ".join(sorted(toks - {uname})) or "(own name only)",
@@ -176,12 +193,16 @@ def main() -> int:
 
     print(h1("audit_upgrades — inverted / dead upgrade effects (B3)"))
     print(f"Upgrade items found: **{len(upgrades)}** — inverted-direction traits: "
-          f"**{len(inverted)}**, dead upgrades: **{len(dead_upgrades)}**, "
+          f"**{len(inverted)}**, exact deferred traits: **{len(deferred_inverted)}**, "
+          f"dead upgrades: **{len(dead_upgrades)}**, "
           f"dead wiring tokens: **{len(dead_wiring)}**, "
           f"without intent entries: **{len(no_intent)}**\n")
     print(h2("Inverted-direction stat traits gated on upgrade conditions"))
     print(table(["upgrade", "affected actor", "trait", "value", "beneficial means", "note"],
                 inverted))
+    print(h2("Exact deferred inverted traits (pricing-linked review boundary)"))
+    print(table(["upgrade", "affected actor", "trait", "value", "beneficial means", "note"],
+                deferred_inverted))
     print(h2("Dead upgrades (granted tokens nobody consumes)"))
     print(table(["upgrade", "extra tokens", "file"], dead_upgrades))
     print(h2("Dead wiring (GrantConditionOnPrerequisite tokens granted by nothing)"))

--- a/tools/tests/test_sniper_damage_profile.py
+++ b/tools/tests/test_sniper_damage_profile.py
@@ -25,7 +25,7 @@ RESOLVED_SNIPERS = (
     "SpecterSniper", "SpecterSniperLockdown",
     "VonSniper", "VonSniperAP", "VonSniperLockdown",
     "GDISniperRifle", "CommandoSniper", "DragunovSniper",
-    "LightSniper", "CryoLightSniper", "RA2AWP",
+    "LightSniper", "CryoLightSniper", "RA2AWP", "RA2AWP_elite",
     "NaxiSniper", "NaxiSniper_elite", "tkmawp", "VanSniper",
     "TSSniper", "td_gdi_commando_sniper", "td_gdi_commando_sniper_elite",
     "RA2Virusgun", "RA2Virusgun2", "RA2Virusgun3", "RA2Virusgun_elite",

--- a/tools/tests/test_sniper_damage_profile.py
+++ b/tools/tests/test_sniper_damage_profile.py
@@ -25,6 +25,9 @@ RESOLVED_SNIPERS = (
     "SpecterSniper", "SpecterSniperLockdown",
     "VonSniper", "VonSniperAP", "VonSniperLockdown",
     "GDISniperRifle", "CommandoSniper", "DragunovSniper",
+    "LightSniper", "CryoLightSniper", "RA2AWP",
+    "NaxiSniper", "NaxiSniper_elite", "tkmawp", "VanSniper",
+    "TSSniper", "td_gdi_commando_sniper", "td_gdi_commando_sniper_elite",
 )
 SPATIAL_DAMAGE_TYPES = {
     "AreaDamage", "AreaDamagePercentage", "OpenToppedDamage", "SpreadDamage",

--- a/tools/tests/test_sniper_damage_profile.py
+++ b/tools/tests/test_sniper_damage_profile.py
@@ -28,6 +28,7 @@ RESOLVED_SNIPERS = (
     "LightSniper", "CryoLightSniper", "RA2AWP",
     "NaxiSniper", "NaxiSniper_elite", "tkmawp", "VanSniper",
     "TSSniper", "td_gdi_commando_sniper", "td_gdi_commando_sniper_elite",
+    "RA2Virusgun", "RA2Virusgun2", "RA2Virusgun3", "RA2Virusgun_elite",
 )
 SPATIAL_DAMAGE_TYPES = {
     "AreaDamage", "AreaDamagePercentage", "OpenToppedDamage", "SpreadDamage",

--- a/tools/tests/test_upgrade_direction_contracts.py
+++ b/tools/tests/test_upgrade_direction_contracts.py
@@ -16,7 +16,7 @@ class UpgradeDirectionContractTests(unittest.TestCase):
         cls.model = Model()
         cls.rules = cls.model.rs
 
-    def test_elite_capacitors_increase_fire_rate_for_every_recipient(self):
+    def test_elite_capacitors_preserve_authored_reload_tradeoff(self):
         recipients = {}
         condition = "td_nod_upgrade_elitecapacitors"
         for actor in sorted(self.rules.actors):
@@ -30,15 +30,18 @@ class UpgradeDirectionContractTests(unittest.TestCase):
                     recipients[actor] = int(trait.get("Modifier"))
 
         self.assertEqual({
-            "nodlasercorvette": 70,
-            "td_nod_lasercommando": 70,
-            "td_nod_lasertrooper": 70,
-            "td_nod_laserturret": 70,
-            "td_nod_lighttankmkii": 70,
+            "nodlasercorvette": 115,
+            "td_nod_lasercommando": 115,
+            "td_nod_lasertrooper": 115,
+            "td_nod_laserturret": 115,
+            "td_nod_lighttankmkii": 115,
             "td_nod_obeliskoflight": 40,
-            "td_nod_venom": 70,
+            "td_nod_venom": 115,
         }, recipients)
-        self.assertTrue(all(modifier < 100 for modifier in recipients.values()))
+        self.assertEqual(
+            "reloaddelaymultiplier",
+            load_intent(self.model.root)["td_nod_upgrade_elitecapacitors"]["drawbacks"],
+        )
 
     def test_cybernetic_damage_amplification_is_an_authored_tradeoff(self):
         intent = load_intent(self.model.root)

--- a/tools/tests/test_upgrade_direction_contracts.py
+++ b/tools/tests/test_upgrade_direction_contracts.py
@@ -1,0 +1,87 @@
+"""Resolved contracts for paid stat upgrades with intentional tradeoffs."""
+
+from __future__ import annotations
+
+import unittest
+
+import _bootstrap  # noqa: F401 - sys.path side effect
+
+from audit_upgrades import is_deferred_inverted, load_intent
+from cameo_model import Model
+
+
+class UpgradeDirectionContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = Model()
+        cls.rules = cls.model.rs
+
+    def test_elite_capacitors_increase_fire_rate_for_every_recipient(self):
+        recipients = {}
+        condition = "td_nod_upgrade_elitecapacitors"
+        for actor in sorted(self.rules.actors):
+            if actor.startswith("^"):
+                continue
+            resolved = self.rules.resolve(actor)
+            if resolved is None:
+                continue
+            for trait in resolved.children_named("ReloadDelayMultiplier"):
+                if (trait.get("RequiresCondition") or "").strip() == condition:
+                    recipients[actor] = int(trait.get("Modifier"))
+
+        self.assertEqual({
+            "nodlasercorvette": 70,
+            "td_nod_lasercommando": 70,
+            "td_nod_lasertrooper": 70,
+            "td_nod_laserturret": 70,
+            "td_nod_lighttankmkii": 70,
+            "td_nod_obeliskoflight": 40,
+            "td_nod_venom": 70,
+        }, recipients)
+        self.assertTrue(all(modifier < 100 for modifier in recipients.values()))
+
+    def test_cybernetic_damage_amplification_is_an_authored_tradeoff(self):
+        intent = load_intent(self.model.root)
+        self.assertEqual(
+            "damagemultiplier",
+            intent["td_nod_upgrade_cyberneticmodifications"]["drawbacks"],
+        )
+        template = self.rules.resolve("^CyberneticModifications")
+        damage = template.child(
+            "DamageMultiplier@td_nod_upgrade_cyberneticmodifications")
+        self.assertEqual("200", damage.get("Modifier"))
+
+    def test_reviewed_multi_payload_and_armor_tradeoffs_are_declared(self):
+        intent = load_intent(self.model.root)
+        expected = {
+            "asianalliance_doctrine_heavypulverizerweapons": "firepowermultiplier",
+            "japan_upgrade_energizedarrows":
+                "firepowermultiplier reloaddelaymultiplier",
+            "japan_upgrade_advancedplasmaweapons": "firepowermultiplier",
+            "ra1_allies_upgrade_cryomissiles": "firepowermultiplier",
+            "ra1_soviets_doctrine_teslaandexperimentaltech":
+                "reloaddelaymultiplier",
+            "ra2_soviets_doctrine_heavyarmorplatings": "speedmultiplier",
+            "ra2_soviets_doctrine_reactivearmor": "speedmultiplier",
+            "ra2_soviets_doctrine_tesladischargearmor": "speedmultiplier",
+            "steelconsortium_upgrade_resonanceammo": "firepowermultiplier",
+        }
+        self.assertEqual(
+            expected,
+            {name: intent[name]["drawbacks"] for name in expected},
+        )
+
+    def test_clone_trooper_pricing_linked_finding_is_exactly_deferred(self):
+        fingerprint = (
+            "steelconsortium_upgrade_pulseweapons",
+            "steelconsortium_clonetrooper",
+            "FirepowerMultiplier@steelconsortium_upgrade_pulseweapons",
+        )
+        self.assertTrue(is_deferred_inverted(*fingerprint, "91"))
+        self.assertFalse(is_deferred_inverted(*fingerprint, "92"))
+        self.assertFalse(is_deferred_inverted(
+            fingerprint[0], "steelconsortium_otheractor", fingerprint[2], "91"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_weapon_upgrade_contracts.py
+++ b/tools/tests/test_weapon_upgrade_contracts.py
@@ -7,6 +7,12 @@ import unittest
 import _bootstrap  # noqa: F401 — sys.path side effect
 
 import audit_upgrade_regression as upgrade
+from audit_three_way_split import (
+    INTENTIONAL_COMPOSITES,
+    SPLIT_BASELINE,
+    intentional_composite,
+    main_warheads,
+)
 from cameo_model import Model
 
 
@@ -116,6 +122,18 @@ class WeaponUpgradeContractTest(unittest.TestCase):
         self.assertEqual(kodiak_projectile.value, "Bullet")
         self.assertIsNone(kodiak_projectile.get("TrailImage"))
         self.assertIsNone(kodiak_projectile.get("PointDefenseTypes"))
+
+    def test_sonic_hellfire_is_one_exact_reviewed_composite(self):
+        self.assertEqual(693, SPLIT_BASELINE)
+        self.assertEqual(
+            {"TSHellfireSonic": ("MissileAP_Heavy", "Sonic_Medium")},
+            INTENTIONAL_COMPOSITES,
+        )
+        mains = main_warheads(self.rs.resolve_weapon("TSHellfireSonic"))
+        self.assertTrue(intentional_composite("TSHellfireSonic", mains))
+        self.assertFalse(intentional_composite("CopiedHellfireSonic", mains))
+        self.assertFalse(intentional_composite(
+            "TSHellfireSonic", mains + ["Sonic_Heavy"]))
 
     def test_quantum_emp_anti_air_replacements_increase_damage(self):
         for base, upgraded in (


### PR DESCRIPTION
## Summary
- make the remaining active sniper/AWP/Virus spatial damage profiles direct-hit only
- preserve Virus clouds, corrosion, conditions, death behavior, exact impact damage, targeting, range, and reload
- ratchet the reviewed Hellfire Sonic composite to its exact intended pair
- document authored upgrade tradeoffs and keep the pricing-linked Clone Trooper pulse case as an exact deferred fingerprint
- add resolved-inheritance regression coverage, including the elite AWP path

## Runtime impact
This changes sniper splash geometry only: affected spatial warheads now use `Spread: 1` and `Falloff: 100, 0`. It does not alter unit statistics, costs, exact-impact damage, weapon cadence, range, targeting, engine code, or the parked percentage-damage runtime work. The intermediate Elite Capacitors edit is fully counteracted in the final tree, preserving its authored firepower/range versus reload tradeoff.

## Validation
- full Python suite: 607 passed, 11 skipped (optional dependency)
- focused sniper profile: 5 passed
- upgrade direction contracts: 4 passed
- weapon upgrade contracts: 10 passed
- three-way split audit: 693 unreviewed findings plus 1 exact reviewed composite; exit 0
- warhead split audit: 377 findings versus 379 baseline; exit 0
- upgrade audit: 0 blockers, 1 exact pricing-linked deferred fingerprint, 0 dead upgrades
- scaled-bullet, physical-state, empty-warhead, upgrade-regression, and diff checks passed
- fresh hidden OpenRA boot: responsive for 163 seconds; no crash, rules-load, Lua, or fatal-error log entries
- independent review: initial Elite Capacitors concern corrected; final review found no blockers

No pricing changes are included.