### PR TITLE
Remove exact duplicate active traits

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
@@ -1159,7 +1159,6 @@ ixian_stormlasher:
 		RequiresCondition: !build-incomplete
 	WithSpriteBody:
 		Sequence: idle
-	WithMuzzleOverlay:
 	-WithDeathAnimation:
 	-WithWallSpriteBody:
 	-WithSpriteTurret:

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/infantry.yaml
@@ -734,10 +734,6 @@ ra1_soviets_commissar:
 		ValidRelationships: Ally, Enemy, Neutral
 	AcceptsDeliveredExperience:
 		ValidTypes: infantry
-	WithDecoration@Carryall:
-		Image: d2k_pips
-		Sequence: pickup-indicator
-		ValidRelationships: Ally, Enemy, Neutral
 	GrantExternalConditionToTransport:
 		Condition: ifv-healer
 	Voiced:

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/misc.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/misc.yaml
@@ -1381,8 +1381,6 @@ yrbpln:
 	HasParent:
 	AirstrikeSlaveCA:
 		LandingDistance: 1c0
-	SpawnActorOnDeath:
-		Actor: yrbpln.husk
 	RejectsOrders:
 	GivesExperienceToMaster:
 	-DamagedByTintedCells@rad:

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/vehicles.yaml
@@ -533,7 +533,6 @@ yuri_mastermind:
 		RangeCircleType: mindcontrol
 		Color: 663399b0
 	AutoTarget:
-	AttackTurreted:
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 1280, 1280, 0, -128

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/buildings.yaml
@@ -283,7 +283,6 @@ latinsyndicate_spycenter:
 	WithIdleOverlay@lights:
 		Sequence: idle-lights2
 		RequiresCondition: !build-incomplete
-	SupportPowerChargeBar:
 	DetonateWeaponPowerCA:
 		AllowMultiple: false
 		OrderName: TraitorsPower

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/buildings.yaml
@@ -233,7 +233,6 @@ tkm_airpad:
 		ExitDelay: 3
 	Power:
 		Amount: -40
-	ProvidesPrerequisite@buildingname:
 	RenderSprites:
 		Image: tkm_airpad
 		PlayerPalette: player_rgba
@@ -255,8 +254,6 @@ tkm_observationvan:
 		ProductionType: Upgrades
 	Tooltip:
 		Name: TKM Observation Van
-	Selectable:
-		Bounds: 2048, 2048
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
@@ -286,8 +283,6 @@ tkm_techcenter:
 		Description: Provides advanced TKM technologies.
 	Tooltip:
 		Name: TKM Tech Center
-	Selectable:
-		Bounds: 2048, 2048
 	Building:
 		Footprint: xxxx xxxx xxxx xxxx
 		Dimensions: 4,4

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/buildings.yaml
@@ -66,9 +66,6 @@ protoss_nexus:
 	ProvidesRadar:
 		RequiresCondition: !jammed
 	Refinery:
-	Selectable:
-		Bounds: 3072, 2560, 0, 0
-		DecorationBounds: 3072, 2560, 0, 0
 	WithResourceStoragePipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true

--- a/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Protoss/yaml/templates.yaml
@@ -36,8 +36,6 @@
 		BaleUnloadDelay: 1
 		BaleUnloadAmount: 5
 		FullyLoadedSpeed: 100
-	StoresResources:
-		Capacity: 5
 	Captures:
 		CaptureTypes: building, tech
 		PlayerExperience: 500

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/aircraft.yaml
@@ -846,7 +846,6 @@ terran_phobos:
 	FirepowerMultiplier@DualWeapon:
 		Modifier: 50
 		RequiresCondition: !tacticaljump
-	DeathSounds:
 	AmbientSound:
 		RequiresCondition: tacticaljump
 		SoundFiles: yamatocharge.wav

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/defenses.yaml
@@ -179,7 +179,6 @@ terran_sentinel:
 		Range: 4090
 	RenderSprites:
 		PlayerPalette: player_rgba
-	ProvidesPrerequisite@buildingname:
 	ActorStatValues:
 		Upgrades: terran_upgrade_vehicleweaponslevel1, terran_upgrade_vehicleweaponslevel2, terran_upgrade_vehicleplatinglevel1, terran_upgrade_vehicleplatinglevel2
 

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
@@ -1221,7 +1221,6 @@ td_gdi_defenserig:
 	Voiced:
 		VoiceSet: SCSiegeTankVoice
 	DeathSounds:
-	WithMuzzleOverlay:
 	SelectionDecorations:
 	Selectable:
 		Bounds: 1536, 1536

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/buildings.yaml
@@ -136,7 +136,6 @@ cabal_cyborgfactory:
 	ProductionQueue@INFANTRY:
 	Power:
 		Amount: -20
-	ProvidesPrerequisite@buildingname:
 	Selectable:
 		Bounds: 1280, 1024
 	SelectionDecorations:
@@ -191,7 +190,6 @@ cabal_mechfactory:
 	ProductionQueue@VEHICLE:
 	Power:
 		Amount: -40
-	ProvidesPrerequisite@buildingname:
 	WithIdleOverlay@ROOF:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-roof

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/defenses.yaml
@@ -23,7 +23,6 @@ cabal_silo:
 		Range: 4c0
 	Power:
 		Amount: -8
-	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/infantry.yaml
@@ -223,10 +223,6 @@ cabal_rocketcyborg:
 		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
 		Damage: -20
 		DamageInterval: 1
-	DamagedByTerrain@TiberiumHeal:
-		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
-		Damage: -20
-		DamageInterval: 1
 	-SpawnActorOnDeath:
 	ExternalCondition@EMP:
 		TotalCap: 1
@@ -341,10 +337,6 @@ cabal_devout:
 		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
 		Damage: -20
 		DamageInterval: 1
-	DamagedByTerrain@TiberiumHeal:
-		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
-		Damage: -20
-		DamageInterval: 1
 	-SpawnActorOnDeath:
 	ExternalCondition@EMP:
 		TotalCap: 1
@@ -453,10 +445,6 @@ cabal_ascended:
 		Modifier: 50
 		RequiresCondition: cydamaged
 	-DamagedByTerrain:
-	DamagedByTerrain@TiberiumHeal:
-		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
-		Damage: -20
-		DamageInterval: 1
 	DamagedByTerrain@TiberiumHeal:
 		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
 		Damage: -20
@@ -581,10 +569,6 @@ cabal_enlighted:
 		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
 		Damage: -20
 		DamageInterval: 1
-	DamagedByTerrain@TiberiumHeal:
-		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
-		Damage: -20
-		DamageInterval: 1
 	-SpawnActorOnDeath:
 	ExternalCondition@EMP:
 		TotalCap: 1
@@ -702,10 +686,6 @@ cabal_hackercyborg:
 		Modifier: 50
 		RequiresCondition: cydamaged
 	-DamagedByTerrain:
-	DamagedByTerrain@TiberiumHeal:
-		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
-		Damage: -20
-		DamageInterval: 1
 	DamagedByTerrain@TiberiumHeal:
 		Terrain: Tiberium, BlueTiberium, RedTiberium, GoldTiberium
 		Damage: -20

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/infantry.yaml
@@ -797,7 +797,6 @@ forgotten_visceroid:
 		QuantizedFacings: 8
 	-WithInfantryBody:
 	WithSpriteBody:
-	WithMuzzleOverlay:
 	Voiced:
 		VoiceSet: DinoVoice
 	HitShape:

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/buildings.yaml
@@ -234,7 +234,6 @@ ts_gdi_barracks:
 	ProductionQueue@INFANTRY:
 	Power:
 		Amount: -20
-	ProvidesPrerequisite@buildingname:
 	Selectable:
 		Bounds: 1280, 1024
 	WithIdleOverlay@LIGHTS:
@@ -290,7 +289,6 @@ ts_gdi_warfactory:
 	ProductionQueue@VEHICLE:
 	Power:
 		Amount: -40
-	ProvidesPrerequisite@buildingname:
 	WithIdleOverlay@ROOF:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-roof
@@ -567,7 +565,6 @@ ts_gdi_silo:
 		Range: 4c0
 	Power:
 		Amount: -10
-	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/buildings.yaml
@@ -285,7 +285,6 @@ ts_nod_handof:
 	ProductionQueue@INFANTRY:
 	Power:
 		Amount: -20
-	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
@@ -337,7 +336,6 @@ ts_nod_warfactory:
 	ProductionQueue@VEHICLE:
 	Power:
 		Amount: -40
-	ProvidesPrerequisite@buildingname:
 	WithIdleOverlay@ROOF:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-roof

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/defenses.yaml
@@ -23,7 +23,6 @@ ts_nod_silo:
 		Range: 4c0
 	Power:
 		Amount: -10
-	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/infantry.yaml
@@ -46,8 +46,6 @@ wc2_humans_militiapeasant:
 		ImageByFullness: wc2_humans_militiapeasant, wc2_humans_militiapeasant
 	WithMoveAnimation:
 		MoveSequence: run
-	Voiced:
-		VoiceSet: wc2voicehumanpeasant
 	-DamagedByTerrain:
 	ActorStatValues:
 		Upgrades: wc2_humans_upgrade_swordstrength, wc2_humans_upgrade_swordstrengthii, wc2_humans_upgrade_armorstrength, wc2_humans_upgrade_armorstrengthii

--- a/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/templates.yaml
@@ -259,8 +259,6 @@
 		ProductionType: Research
 	FreeActor@CPQDEBUGDUMMY:
 		Actor: CPQDEBUGDUMMY
-	Power:
-		Amount: 0
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@blacksmith:
 		Prerequisite: wc_blacksmith
@@ -319,12 +317,8 @@
 		ProductionType: Research
 	FreeActor@CPQDEBUGDUMMY:
 		Actor: CPQDEBUGDUMMY
-	Health:
-		HP: 250000
 	RevealsShroud:
 		Range: 5000
-	Power:
-		Amount: 0
 	ProvidesPrerequisite@buildingname:
 
 ^WC2Church:
@@ -353,8 +347,6 @@
 		ProductionType: Research
 	FreeActor@CPQDEBUGDUMMY:
 		Actor: CPQDEBUGDUMMY
-	Power:
-		Amount: 0
 	ProvidesPrerequisite@buildingname:
 
 ^WC2Temple:

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -3627,8 +3627,6 @@
 		MaxMoveDelay: 750
 	MapEditorData:
 		Categories: Civilian infantry
-	Passenger:
-		CustomPipType: civilian
 
 ^Monster:
 	Inherits@1: ^ExistsInWorld
@@ -3719,7 +3717,6 @@
 	Voiced:
 		VoiceSet: AntVoice
 	WithDamageOverlay:
-	CombatDebugOverlay:
 	KillsSelf:
 		RequiresCondition: invulnerability
 	Chronoshiftable:

--- a/mods/cameo/rules/warcraft2.yaml
+++ b/mods/cameo/rules/warcraft2.yaml
@@ -723,8 +723,6 @@ Player:
 		Type: Wood
 	Power:
 		Amount: 0
-	Valued:
-		Cost: 2500
 	Buildable:
 		Description: Unlocks advanced naval vessels and upgrades.
 		BuildPaletteOrder: 50
@@ -740,8 +738,6 @@ Player:
 		HP: 300000
 	RevealsShroud:
 		Range: 5000
-	Power:
-		Amount: 0
 	GivesBuildableArea:
 		AreaTypes: building, cityi
 	Targetable:

--- a/tools/audit/audit_duplicate_keys.py
+++ b/tools/audit/audit_duplicate_keys.py
@@ -47,7 +47,7 @@ SKIP_PARTS = ("maps", "bits")
 
 # Ratchets: lower them as duplicates are resolved; never raise without a note.
 D1_BASELINE = 35
-D2_BASELINE = 407
+D2_BASELINE = 370
 
 
 def duplicate_children(node: Node) -> dict[str, list[Node]]:

--- a/tools/tests/test_weapon_correctness_followups.py
+++ b/tools/tests/test_weapon_correctness_followups.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pathlib
 import sys
 import unittest
+from collections import defaultdict
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools" / "audit"))
@@ -185,6 +186,36 @@ class WeaponCorrectnessFollowupTests(unittest.TestCase):
             labels = [node.key for node in actor.children
                       if node.key == "Inherits" or node.key.startswith("Inherits@")]
             self.assertEqual(len(labels), len(set(labels)), name)
+
+    def test_active_actor_and_weapon_rules_have_no_exact_duplicate_traits(self):
+        def fingerprint(node):
+            return (node.key, node.value,
+                    tuple(fingerprint(item) for item in node.children))
+
+        findings = []
+
+        def inspect(node, path):
+            groups = defaultdict(list)
+            for item in node.children:
+                if item.key and not item.key.startswith("-"):
+                    groups[item.key].append(item)
+
+            for key, items in groups.items():
+                fingerprints = [fingerprint(item) for item in items]
+                if len(items) > 1 and len(set(fingerprints)) == 1:
+                    findings.append(
+                        f"{path} > {key} at "
+                        f"{', '.join(str(item.line) for item in items)}")
+
+            for item in node.children:
+                inspect(item, f"{path} > {item.key}")
+
+        paths = self.rules.manifest.rules + self.rules.manifest.weapons
+        for path in paths:
+            for node in load(path):
+                inspect(node, f"{path.relative_to(ROOT)}:{node.key}")
+
+        self.assertEqual([], findings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove 37 recursively identical duplicate trait blocks from active actor and weapon rules
- preserve every resolved actor, template, and weapon value
- ratchet merged-duplicate findings from 407 to 370 and add a dynamic active-manifest regression check

## Verification
- resolved comparison: 0 differences across 3,973 actors/templates and 2,847 weapons
- exact duplicate active trait groups: 37 -> 0
- duplicate audit: D1 remains 35; D2 407 -> 370
- all 363 map archives checked for affected overlays/removals
- 612 tests passed, 11 skipped
- 32 balance ledgers: zero drift
- relevant weapon audits passed
- fresh isolated boot responsive for 109 seconds with zero rules, Lua, exception, crash, or fatal log hits
- independent review: no blockers

No pricing, weapon statistics, engine code, or parked percentage-damage runtime work is included.