### PR TITLE
Canonicalize remaining active duplicate traits

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/buildings.yaml
@@ -1140,7 +1140,7 @@ ixian_stormlasher:
 	WithMuzzleOverlay:
 	WithSpriteBody:
 		Name: make
-		Sequence: invisible
+		Sequence: idle
 	WithMakeAnimation:
 		Condition: build-incomplete
 		BodyNames: make
@@ -1156,8 +1156,6 @@ ixian_stormlasher:
 		ReplaceableTypes: Tower
 	AttackTurreted:
 		RequiresCondition: !build-incomplete
-	WithSpriteBody:
-		Sequence: idle
 	-WithDeathAnimation:
 	-WithWallSpriteBody:
 	-WithSpriteTurret:

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/aircraft.yaml
@@ -943,6 +943,7 @@ carryall_huskvtol.ordos:
 	FallsToEarth:
 		Moves: False
 		Velocity: 0c128
+		Explosion: D2KUnitExplodeLarge
 	Aircraft:
 		TurnSpeed: 16
 		CanSlide: True
@@ -950,8 +951,6 @@ carryall_huskvtol.ordos:
 	RenderSprites:
 		Image: ordos_advancedcarryall
 		PlayerPalette: player_rgba
-	FallsToEarth:
-		Explosion: D2KUnitExplodeLarge
 
 # d2k_emperor_worm:
 # 	Inherits: ^DINO

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/vehicles.yaml
@@ -816,7 +816,7 @@ ordos_cobratank:
 		Modifier: 50
 	RangeMultiplier@deployed:
 		RequiresCondition: deployed
-		Modifier: 125
+		Modifier: 160
 	Armament@PRIMARY:
 		Weapon: 120mm_cobra
 		LocalOffset: 600,0,300
@@ -863,9 +863,6 @@ ordos_cobratank:
 		RequireForceMoveCondition: !undeployed
 	Voiced:
 		VoiceSet: EBFDOrdosCobra
-	RangeMultiplier@deployed:
-		Modifier: 160
-		RequiresCondition: deployed
 	RenderSprites:
 		PlayerPalette: player_rgba
 	ActorStatValues:
@@ -932,7 +929,7 @@ ordos_pythontank:
 		Modifier: 50
 	RangeMultiplier@deployed:
 		RequiresCondition: deployed
-		Modifier: 125
+		Modifier: 160
 	Armament@PRIMARY:
 		Weapon: 120mm_python
 		LocalOffset: 750,0,350
@@ -972,9 +969,6 @@ ordos_pythontank:
 		Voice: Move
 	Voiced:
 		VoiceSet: EBFDOrdosCobra
-	RangeMultiplier@deployed:
-		Modifier: 160
-		RequiresCondition: deployed
 	RenderSprites:
 		PlayerPalette: player_rgba
 	ActorStatValues:

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/aircraft.yaml
@@ -160,6 +160,7 @@ carryall.huskVTOL:
 	FallsToEarth:
 		Moves: False
 		Velocity: 0c128
+		Explosion: D2KUnitExplodeLarge
 	Aircraft:
 		TurnSpeed: 16
 		CanSlide: True
@@ -167,5 +168,3 @@ carryall.huskVTOL:
 	RenderSprites:
 		Image: carryall
 		PlayerPalette: playerd2k
-	FallsToEarth:
-		Explosion: D2KUnitExplodeLarge

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/infantry.yaml
@@ -238,7 +238,6 @@ engineer:
 		PlayerPalette: raplayer
 	ActorStatValues:
 		Stats: Armor, Sight, Speed
-	ActorStatValues:
 		Upgrades: td_gdi_upgrade_longrangesensors, td_nod_upgrade_guerillatactics, td_nod_upgrade_advancedguerillatactics, td_nod_upgrade_tiberiuminfusion, td_nod_upgrade_cyberneticmodifications
 
 # submachinegunner:

--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/defenses.yaml
@@ -211,7 +211,6 @@ ra1_allies_pillbox:
 		Damage: 200
 		ReloadDelay: 48
 		Range: 6570
-	ActorStatValues:
 		Upgrades: ra1_allies_upgrade_advancedradarsystems, ra1_allies_upgrade_reinforcedstructures, ra1_allies_upgrade_lasertargetingsystems, ra1_allies_upgrade_gpssatellitesupport
 
 ra1_allies_alliedgunturret:
@@ -394,7 +393,6 @@ ra1_allies_camopillbox:
 		Damage: 200
 		ReloadDelay: 50
 		Range: 7640
-	ActorStatValues:
 		Upgrades: ra1_allies_upgrade_advancedradarsystems, ra1_allies_upgrade_reinforcedstructures, ra1_allies_upgrade_lasertargetingsystems, ra1_allies_upgrade_gpssatellitesupport
 
 ra1_allies_bastionartillerybunker:

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/buildings.yaml
@@ -50,11 +50,10 @@ japan_waveforcereactor:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: player_rgba
 	ProvidesPrerequisite@buildingname:
 	RenderSprites:
 		PlayerPalette: player_rgba
-	WithDeathAnimation:
-		DeathSequencePalette: player_rgba
 
 japan_japanesebarracks:
 	Inherits: ^BaseBuilding

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/infantry.yaml
@@ -110,6 +110,7 @@ japan_tankbuster:
 		FacingTolerance: 0
 	WithInfantryBody:
 		RequiresCondition: !parachute
+		IdleSequences: idle1, idle2, idle3
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
@@ -118,8 +119,6 @@ japan_tankbuster:
 		PlayerPalette: ra2cyborgplayer
 	WithDeathAnimation:
 		DeathSequencePalette: ra2cyborgplayer
-	WithInfantryBody:
-		IdleSequences: idle1, idle2, idle3
 	Voiced:
 		VoiceSet: JapaneseVoice
 	ActorStatValues:

--- a/mods/cameo/ContentPacks/RedAlert/Japan/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Japan/yaml/templates.yaml
@@ -389,6 +389,7 @@
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: raplayer
 	ProvidesPrerequisite@raproc:
 		Prerequisite: raproc
 	HitShape:
@@ -403,8 +404,6 @@
 		AreaTypes: building, cityi
 	RenderSprites:
 		PlayerPalette: raplayer
-	WithDeathAnimation:
-		DeathSequencePalette: raplayer
 
 ^Dome:
 	Inherits@shape: ^2x2Shape

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/buildings.yaml
@@ -33,11 +33,10 @@ ra1_powerplant:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: raplayer
 	ProvidesPrerequisite@buildingname:
 	RenderSprites:
 		PlayerPalette: raplayer
-	WithDeathAnimation:
-		DeathSequencePalette: raplayer
 
 ra1_advancedpowerplant:
 	Inherits: ^BaseBuilding
@@ -76,12 +75,11 @@ ra1_advancedpowerplant:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: raplayer
 	ProvidesPrerequisite@powerplant:
 		Prerequisite: ra1_powerplant
 	RenderSprites:
 		PlayerPalette: raplayer
-	WithDeathAnimation:
-		DeathSequencePalette: raplayer
 
 ra1_soviets_kennel:
 	Inherits: ^BaseBuilding
@@ -238,4 +236,3 @@ ra1_soviets_subpen:
 		PlayerPalette: raplayer
 	WithDeathAnimation:
 		DeathSequencePalette: raplayer
-

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/infantry.yaml
@@ -221,7 +221,6 @@ ra1_engineer:
 		PlayerPalette: raplayer
 	ActorStatValues:
 		Stats: Armor, Sight, Speed
-	ActorStatValues:
 		Upgrades: td_gdi_upgrade_longrangesensors, td_nod_upgrade_guerillatactics, td_nod_upgrade_advancedguerillatactics, td_nod_upgrade_tiberiuminfusion, td_nod_upgrade_cyberneticmodifications
 
 ra1_einstein:
@@ -290,4 +289,3 @@ ra1_technician:
 ####################################################################################################
 #		VEHICLES
 ####################################################################################################
-

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/defenses.yaml
@@ -272,7 +272,6 @@ ra2_allies_pillbox:
 		Damage: 120
 		ReloadDelay: 24
 		Range: 6583
-	ActorStatValues:
 		Upgrades: ra2_allies_upgrade_assaultsquadtraining, ra2_allies_upgrade_vanguardtraining, ra2_allies_upgrade_infiltratorstraining
 
 ra2_allies_patriotmissilesystem:

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/defenses.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/defenses.yaml
@@ -194,6 +194,7 @@ ra2_soviets_battlebunker:
 		QuantizedFacings: 8
 	Selectable:
 		Bounds: 1792, 1792, 0, 0
+		Class: ra2_soviets_battlebunker
 	Cargo:
 		Types: Infantry, Hacker, Fremen
 		MaxWeight: 6
@@ -210,8 +211,6 @@ ra2_soviets_battlebunker:
 		Modifier: 50
 	RevealsShroud:
 		Range: 6666
-	Selectable:
-		Class: ra2_soviets_battlebunker
 	ActorStatValues:
 		Upgrades: ra2_soviets_doctrine_conscription, ra2_soviets_doctrine_harshenvironmentinfantryconditioning, ra2_soviets_doctrine_shocktroopertraining
 

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/infantry.yaml
@@ -635,7 +635,6 @@ ra2_soviets_boris:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		StandSequences: stand
-	WithInfantryBody:
 		AttackSequences:
 			secondary: secondary-fire
 	Voiced:

--- a/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Yuri/yaml/buildings.yaml
@@ -143,7 +143,6 @@ yuri_bioreactor:
 		RequiresSelection: true
 	ActorStatValues:
 		Stats: Armor, Sight, Power, Cargo
-	ActorStatValues:
 		Upgrades: yuri_upgrade_bioreactorefficiency
 
 yuri_barracks:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/aircraft.yaml
@@ -304,6 +304,7 @@ kami.asian:
 		RequiresCondition: diving
 	WithMoveAnimation:
 		MoveSequence: move
+		Condition: !Aircraft-Turning
 	AttackAircraft:
 		FacingTolerance: 40
 		PersistentTargeting: false
@@ -333,9 +334,6 @@ kami.asian:
 	WithMoveAnimation@Turn-R:
 		MoveSequence: move-r
 		RequiresCondition: Aircraft-Turning && Aircraft-Vertical
-	WithMoveAnimation:
-		MoveSequence: move
-		Condition: !Aircraft-Turning
 	Contrail:
 		Offset: -500,0,250
 		TrailLength: 15

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/vehicles.yaml
@@ -775,8 +775,6 @@ steelconsortium_consortiumminer:
 	Targetable@Hover:
 		TargetTypes: Water, Ship
 	WithMoveAnimation:
-	StoresResources:
-	DockClientManager:
 	WithHarvestOverlay@harvesting:
 		Sequence: harvesting
 		Palette: ra2effect
@@ -926,10 +924,9 @@ steelconsortium_quantumtank:
 	WithMuzzleOverlay:
 	SelectionDecorations:
 	Selectable:
-	WithSpriteTurret:
-	Selectable:
 		Bounds: 1440, 1440
 		DecorationBounds: 1440, 1440
+	WithSpriteTurret:
 	Voiced:
 		VoiceSet: SteelQuantumTankVoice
 	RenderSprites:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/buildings.yaml
@@ -493,6 +493,7 @@ futuretech_multiturretsystem:
 		Offset: -1,1,1
 	AttackTurreted:
 		Voice: Attack
+		RequiresCondition: !build-incomplete
 	ExternalCondition@mg:
 		Condition: ifv-mg
 	ExternalCondition@hmg:
@@ -560,8 +561,6 @@ futuretech_multiturretsystem:
 	WithMuzzleOverlay:
 	-WithSpriteBody:
 	WithEmbeddedTurretSpriteBody:
-	AttackTurreted:
-		RequiresCondition: !build-incomplete
 	AutoTarget:
 	ActorStatValues:
 		Stats: Armor, Sight, Speed, Damage, ReloadDelay, MaxRange, Cargo, Kills

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/aircraft.yaml
@@ -48,6 +48,7 @@ naxis_interceptor:
 		Actor: naxis_interceptor_husk
 	WithMoveAnimation:
 		MoveSequence: move
+		Condition: !Aircraft-Turning
 	AttackAircraft:
 		FacingTolerance: 40
 		PersistentTargeting: false
@@ -79,9 +80,6 @@ naxis_interceptor:
 	WithMoveAnimation@Turn-R:
 		MoveSequence: move-r
 		RequiresCondition: Aircraft-Turning && Aircraft-Vertical
-	WithMoveAnimation:
-		MoveSequence: move
-		Condition: !Aircraft-Turning
 	Contrail:
 		Offset: -500,0,250
 		TrailLength: 15

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/buildings.yaml
@@ -574,6 +574,7 @@ naxis_naxibunker:
 		QuantizedFacings: 8
 	Selectable:
 		Bounds: 1792, 1792, 0, 0
+		Class: naxis_naxibunker
 	Cargo:
 		Types: Infantry, Hacker, Fremen
 		MaxWeight: 6
@@ -590,10 +591,9 @@ naxis_naxibunker:
 		Modifier: 50
 	RevealsShroud:
 		Range: 6666
-	Selectable:
-		Class: naxis_naxibunker
 	ActorStatValues:
 		Stats: Armor, Sight, Cargo, Kills, Experience
+		Upgrades: naxis_upgrade_atlantikwall
 	AttackTurreted:
 		Voice: Attack
 	Armament@mortar:
@@ -621,8 +621,6 @@ naxis_naxibunker:
 		RequiresCondition: !build-incomplete && aa
 		Sequence: turret-aa
 	ProvidesPrerequisite@buildingname:
-	ActorStatValues:
-		Upgrades: naxis_upgrade_atlantikwall
 	Pluggable:
 		Conditions:
 			naxis_machinegunbunkeraddon: mg

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/aircraft.yaml
@@ -42,6 +42,7 @@ schwarzermond_drone:
 		Actor: schwarzermond_drone_husk
 	WithMoveAnimation:
 		MoveSequence: move
+		Condition: !Aircraft-Turning
 	AttackAircraft:
 		FacingTolerance: 40
 		PersistentTargeting: false
@@ -77,9 +78,6 @@ schwarzermond_drone:
 	WithMoveAnimation@Turn-R:
 		MoveSequence: move-r
 		RequiresCondition: Aircraft-Turning && Aircraft-Vertical
-	WithMoveAnimation:
-		MoveSequence: move
-		Condition: !Aircraft-Turning
 	Contrail:
 		Offset: -500,0,250
 		TrailLength: 15

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/vehicles.yaml
@@ -775,7 +775,7 @@ schwarzermond_komet:
 		Name: loaded
 	WithFacingSpriteBody@EMPTY:
 		RequiresCondition: firing
-		Sequence: empty-idle
+		Sequence: empty-turret
 		Name: reloading
 	RenderSprites:
 		PlayerPalette: playerra2
@@ -784,10 +784,6 @@ schwarzermond_komet:
 		RequiresCondition: !firing
 		Sequence: turret
 		Name: loaded
-	WithFacingSpriteBody@EMPTY:
-		RequiresCondition: firing
-		Sequence: empty-turret
-		Name: reloading
 schwarzermond_lasertank:
 	Inherits: ^Tank
 	Inherits@Crypto: ^NaxiCryptofascism

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Shared/yaml/templates.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Shared/yaml/templates.yaml
@@ -484,16 +484,11 @@
 		Modifier: 95
 	ChangesHealth@steelconsortium_upgrade_naniteinfusion:
 		PercentageStep: 1
-		Delay: 80
-		StartIfBelow: 100
-		DamageCooldown: 50
-		RequiresCondition: steelconsortium_upgrade_naniteinfusion
-	ChangesHealth@steelconsortium_upgrade_naniteinfusion:
-		Step: 25
 		Delay: 1
 		StartIfBelow: 100
 		DamageCooldown: 50
 		RequiresCondition: steelconsortium_upgrade_naniteinfusion
+		Step: 25
 	GrantConditionOnPrerequisite@steelconsortium_upgrade_naniteinfusion:
 		Condition: steelconsortium_upgrade_naniteinfusion
 		Prerequisites: steelconsortium_upgrade_naniteinfusion
@@ -506,7 +501,6 @@
 		Modifier: 90
 	ChangesHealth@steelconsortium_upgrade_naniteinfusion:
 		Delay: 40
-	ChangesHealth@steelconsortium_upgrade_naniteinfusion:
 		Step: 50
 
 ^SteelConsortiumFerrocrete:

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/vehicles.yaml
@@ -599,6 +599,7 @@ latinsyndicate_diablo:
 	Selectable:
 		DecorationBounds: 1280, 1280
 	WithSpriteTurret:
+		RequiresCondition: !tree
 	Voiced:
 		VoiceSet: LatinTankVoice
 	RenderSprites:
@@ -618,8 +619,6 @@ latinsyndicate_diablo:
 		RequiresCondition: tree && latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging
 		IsPlayerPalette: false
 		Palette: ra_temperat
-	WithSpriteTurret:
-		RequiresCondition: !tree
 	WithFacingSpriteBody:
 		RequiresCondition: !tree
 	ActorStatValues:
@@ -761,6 +760,8 @@ latinsyndicate_latinapc:
 		Image: latinsyndicate_latinapc
 		PlayerPalette: playerra2
 	WithSpriteTurret:
+		Sequence: turret
+		RequiresCondition: !latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging
 	Voiced:
 		VoiceSet: LatinSoldierVoice
 	Cargo:
@@ -770,9 +771,6 @@ latinsyndicate_latinapc:
 	GrantConditionOnPrerequisite@Missile:
 		Condition: latinsyndicate_doctrine_cartelrockets
 		Prerequisites: latinsyndicate_doctrine_cartelrockets
-	WithSpriteTurret:
-		Sequence: turret
-		RequiresCondition: !latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging
 	WithSpriteTurret@up:
 		Sequence: turret-up
 		RequiresCondition: latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging
@@ -846,6 +844,7 @@ latinsyndicate_narcohummer:
 		Image: latinsyndicate_narcohummer
 		PlayerPalette: playerra2
 	WithSpriteTurret:
+		Sequence: turret
 	Voiced:
 		VoiceSet: LatinNarcoVVoice
 	Cargo:
@@ -857,8 +856,6 @@ latinsyndicate_narcohummer:
 		Armaments: garrisoned
 		PortOffsets: 0,0,128, 224,-341,128, -224,-341,128, -224,341,128, 224,341,128
 		PauseOnCondition: chronobeamed
-	WithSpriteTurret:
-		Sequence: turret
 	ActorStatValues:
 		Upgrades: latinsyndicate_upgrade_cashrecovery, latinsyndicate_upgrade_sovietstolentechindustrialmethods, latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging, latinsyndicate_upgrade_yuristolentechchainguns
 
@@ -927,6 +924,7 @@ latinsyndicate_carteltruck:
 	RenderSprites:
 		PlayerPalette: playerra2
 	WithSpriteTurret:
+		Sequence: turret
 	Voiced:
 		VoiceSet: LatinNarcoVVoice
 	Cargo:
@@ -938,8 +936,6 @@ latinsyndicate_carteltruck:
 		Armaments: garrisoned
 		PortOffsets: 384,0,128, 224,-341,128, 224,0,128, 224,341,128, 0,-341,128, 0,341,128, -224,-341,128, -224,0,128, -224,341,128, -384,0,128
 		PauseOnCondition: chronobeamed
-	WithSpriteTurret:
-		Sequence: turret
 	ActorStatValues:
 		Upgrades: latinsyndicate_upgrade_cashrecovery, latinsyndicate_upgrade_sovietstolentechindustrialmethods, latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging, latinsyndicate_upgrade_yuristolentechchainguns
 
@@ -1196,7 +1192,6 @@ latinsyndicate_collectiontruck:
 	WithHarvestAnimation:
 	RenderSprites:
 		PlayerPalette: playerra2
-	StoresResources:
 	DockClientManager:
 	WithHarvestOverlay@harvesting:
 		Sequence: harvesting
@@ -1378,6 +1373,7 @@ latinsyndicate_topolm:
 		Modifier: 50
 	ActorStatValues:
 		ReloadDelay: 500
+		Upgrades: latinsyndicate_upgrade_cashrecovery, latinsyndicate_upgrade_sovietstolentechindustrialmethods, latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging, latinsyndicate_upgrade_asianalliancestolentechhotfire
 	RevealsShroud@SWReveal:
 		Range: 2500
 		ValidRelationships: Neutral, Enemy
@@ -1425,8 +1421,6 @@ latinsyndicate_topolm:
 		Name: reloading
 	RenderSprites:
 		PlayerPalette: playerra2
-	ActorStatValues:
-		Upgrades: latinsyndicate_upgrade_cashrecovery, latinsyndicate_upgrade_sovietstolentechindustrialmethods, latinsyndicate_upgrade_alliedstolentechextramissilesandmiraging, latinsyndicate_upgrade_asianalliancestolentechhotfire
 
 #######################################
 # Red Alert 2 Syndicate Promotion Tree

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/infantry.yaml
@@ -541,7 +541,7 @@ tkm_engineer:
 		RequiresCondition: tkm_upgrade_titanarsenalupgrade
 	RenderRangeCircleCA:
 		Armaments: primary
-		RangeCircleType: heal
+		RangeCircleType: repair
 		RequiresCondition: tkm_upgrade_titanarsenalupgrade
 	Armament@REPAIR:
 		Weapon: Repair
@@ -555,10 +555,6 @@ tkm_engineer:
 		Weapon: Repair
 		TargetRelationships: Ally
 		ForceTargetRelationships: None
-		RequiresCondition: tkm_upgrade_titanarsenalupgrade
-	RenderRangeCircleCA:
-		Armaments: primary
-		RangeCircleType: repair
 		RequiresCondition: tkm_upgrade_titanarsenalupgrade
 	AttackFrontal:
 		Voice: Action

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/aircraft.yaml
@@ -14,10 +14,6 @@ td_gdi_chinooktransport:
 		BuildPaletteOrder: 10
 		Prerequisites: ~td_gdi_helipad
 		Queue: Aircraft, RAAircraft
-		Description: actor_tran.description
-	Buildable:
-		Prerequisites: ~td_gdi_helipad
-		Queue: Aircraft, RAAircraft
 		Description: Transport vehicle.\n  Unarmed
 	Aircraft:
 		TurnSpeed: 30
@@ -445,6 +441,7 @@ gdirigdrone:
 		AttackType: Hover
 		PersistentTargeting: false
 		FacingTolerance: 10
+		Armaments: primary, pointdefense
 	-Targetable@SpecialRepair:
 	-SpawnActorOnDeath:
 	-ActorLostNotification:
@@ -475,7 +472,5 @@ gdirigdrone:
 		Turret: pointdefense
 		TurnSpeed: 80
 	WithMuzzleOverlay:
-	AttackAircraft:
-		Armaments: primary, pointdefense
 	ActorStatValues:
 		Upgrades: steelconsortium_upgrade_shieldresistance

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/buildings.yaml
@@ -33,7 +33,7 @@ td_gdi_barracks:
 	Tooltip:
 		Name: GDI Barracks
 	ProvidesPrerequisite:
-		Prerequisite: barracks
+		Prerequisite: cncbarracks
 	Buildable:
 		Prerequisites: ~td_gdi_constructionyard, nuke
 		Description: Trains infantry units.
@@ -50,8 +50,6 @@ td_gdi_barracks:
 	Exit@2:
 		SpawnOffset: 300,333,0
 		ExitCell: 1,1
-	ProvidesPrerequisite:
-		Prerequisite: cncbarracks
 
 td_gdi_weaponsfactory:
 	Inherits: ^TDBuilding

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/vehicles.yaml
@@ -1188,7 +1188,7 @@ td_gdi_defenserig:
 		RequiresCondition: deployed
 	RejectsOrders@deployment:
 		Reject: AttackMove, AssaultMove
-		RequiresCondition: !botmicro && deployed
+		RequiresCondition: !(botmicro && !attacking) && deployed
 	GrantConditionOnDeploy:
 		PauseOnCondition: disabled
 		DeployedCondition: deployed
@@ -1198,9 +1198,6 @@ td_gdi_defenserig:
 		UndeployOnMove: true
 		SmartDeploy: True
 		Facing: 0
-	RejectsOrders@deployment:
-		Reject: AttackMove, AssaultMove
-		RequiresCondition: !(botmicro && !attacking) && deployed
 	RejectsMoveToAttack:
 		RequiresCondition: !(botmicro && !attacking) && deployed
 	Passenger:

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/buildings.yaml
@@ -46,7 +46,7 @@ td_nod_handofnod:
 	Tooltip:
 		Name: Hand of Nod
 	ProvidesPrerequisite:
-		Prerequisite: barracks
+		Prerequisite: cncbarracks
 	Buildable:
 		Prerequisites: ~td_nod_constructionyard, nuke
 		Description: Trains infantry units.
@@ -61,8 +61,6 @@ td_nod_handofnod:
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
-	ProvidesPrerequisite:
-		Prerequisite: cncbarracks
 
 td_nod_airstrip:
 	Inherits: ^TDBuilding

--- a/mods/cameo/ContentPacks/TiberianDawn/Shared/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Shared/yaml/infantry.yaml
@@ -78,5 +78,4 @@ E6:
 		PlayerPalette: raplayer
 	ActorStatValues:
 		Stats: Armor, Sight, Speed
-	ActorStatValues:
 		Upgrades: td_gdi_upgrade_longrangesensors, td_nod_upgrade_guerillatactics, td_nod_upgrade_advancedguerillatactics, td_nod_upgrade_tiberiuminfusion, td_nod_upgrade_cyberneticmodifications

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/aircraft.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/aircraft.yaml
@@ -12,6 +12,7 @@ cabal_overkillgunship:
 		Name: Overkill Gunship
 	Selectable:
 		Bounds: 1280, 1024
+		DecorationBounds: 1536, 1536
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
@@ -53,8 +54,6 @@ cabal_overkillgunship:
 		PauseOnCondition: disabled
 		AttackType: Hover
 	SelectionDecorations:
-	Selectable:
-		DecorationBounds: 1536, 1536
 	Voiced:
 		VoiceSet: TSHeli
 	SpawnActorOnDeath:

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/vehicles.yaml
@@ -132,6 +132,9 @@ cabal_cyborgreaper:
 		AddToArmyValue: true
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: playerra2
+		PlayerPalette: playerra2
+		CrushedSequencePalette: ra2effect
 	DeathSounds:
 	AttackMove:
 		Voice: Attack
@@ -150,10 +153,6 @@ cabal_cyborgreaper:
 		Delay: 1
 		StartIfBelow: 100
 		DamageCooldown: 1
-	WithDeathAnimation:
-		DeathSequencePalette: playerra2
-		PlayerPalette: playerra2
-		CrushedSequencePalette: ra2effect
 
 cabal_tiberiumharvester:
 	Inherits: ^TDHARV
@@ -781,6 +780,9 @@ cabal_heavyreaper:
 		AddToArmyValue: true
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false
+		DeathSequencePalette: playerra2
+		PlayerPalette: playerra2
+		CrushedSequencePalette: ra2effect
 	DeathSounds:
 	AttackMove:
 		Voice: Attack
@@ -800,10 +802,6 @@ cabal_heavyreaper:
 	RenderSprites:
 		Image: cabal_cyborgreaper
 		PlayerPalette: playerra2
-	WithDeathAnimation:
-		DeathSequencePalette: playerra2
-		PlayerPalette: playerra2
-		CrushedSequencePalette: ra2effect
 
 cabal_avatar:
 	Inherits: ^Vehicle

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/buildings.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/buildings.yaml
@@ -71,11 +71,9 @@ wc2_humans_townhall:
 		Requirements:
 			wc2_humans_keep: wc2_humans_keep && !wc2_humans_castle
 	WithSpriteBody@keep:
-		RequiresCondition: !wc2_humans_keep && !wc2_humans_castle
-	WithSpriteBody@keep:
+		RequiresCondition: wc2_humans_keep && !wc2_humans_castle
 		Sequence: wc2_humans_keep
 		Name: keep
-		RequiresCondition: wc2_humans_keep && !wc2_humans_castle
 	WithSpriteBody@castle:
 		Sequence: wc2_humans_castle
 		Name: castle
@@ -449,6 +447,7 @@ wc2_humans_sunwell:
 	Building:
 		Footprint: XX XX
 		Dimensions: 2,2
+		BuildSounds: wc2_constrct.aud
 	Selectable:
 		Bounds: 2048, 2048, 0, -512
 	SpawnActorsOnSell:
@@ -461,8 +460,6 @@ wc2_humans_sunwell:
 		Type: CenterPosition
 		Weapon: wc2buildingexplode
 		EmptyWeapon: wc2buildingexplode
-	Building:
-		BuildSounds: wc2_constrct.aud
 	GrantTimedCondition:
 		Condition: wc2cond_playsound
 		Duration: 50

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/infantry.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/infantry.yaml
@@ -418,6 +418,7 @@ wc2_humans_mortarteam:
 		Step: 40
 	Mobile:
 		Speed: 80
+		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: ~wc2_humans_gnomishinventor, wc2_humans_blacksmith
@@ -432,8 +433,6 @@ wc2_humans_mortarteam:
 	GrantConditionOnAttack@CatapultCooldown:
 		Condition: cond_catapult_cooldown
 		RevokeDelay: 25
-	Mobile:
-		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	Targetable@ra1_soviets_attackdog:
 		TargetTypes: DogImmune
 	Voiced:

--- a/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Humans/yaml/vehicles.yaml
@@ -134,6 +134,7 @@ wc2_humans_ballista:
 	Mobile:
 		Speed: 45
 		TurnSpeed: 18
+		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~wc2_humans_blacksmith
@@ -156,8 +157,6 @@ wc2_humans_ballista:
 	GrantConditionOnAttack@CatapultCooldown:
 		Condition: cond_catapult_cooldown
 		RevokeDelay: 34
-	Mobile:
-		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	ActorStatValues:
 		Upgrades: wc2_humans_upgrade_ballistastrength, wc2_humans_upgrade_ballistastrengthii, wc2_humans_upgrade_armorstrength, wc2_humans_upgrade_armorstrengthii
 

--- a/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/vehicles.yaml
+++ b/mods/cameo/ContentPacks/Warcraft2/Orcs/yaml/vehicles.yaml
@@ -93,6 +93,7 @@ wc2_orcs_catapult:
 	Mobile:
 		Speed: 40
 		TurnSpeed: 16
+		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: ~wc2_orcs_blacksmith
@@ -119,8 +120,6 @@ wc2_orcs_catapult:
 	GrantConditionOnAttack@CatapultCooldown:
 		Condition: cond_catapult_cooldown
 		RevokeDelay: 34
-	Mobile:
-		PauseOnCondition: cond_catapult_cooldown || disabled || notmobile
 	ActorStatValues:
 		Upgrades: wc2_orcs_upgrade_catapultstrength, wc2_orcs_upgrade_catapultstrengthii, wc2_orcs_upgrade_armorstrength, wc2_orcs_upgrade_armorstrengthii
 

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -2736,6 +2736,7 @@
 
 ^Submarine:
 	Targetable:
+		TargetTypes: Ground, Water, Ship, Submarine
 	Cloak@underwater:
 		DetectionTypes: Underwater
 		InitialDelay: 0
@@ -2763,8 +2764,6 @@
 		RequiresCondition: underwater
 	WithColoredSelectionBox@UnderBridge:
 		RequiresCondition: underbridge && !underwater
-	Targetable:
-		TargetTypes: Ground, Water, Ship, Submarine
 	Targetable@Underwater:
 		TargetTypes: Submarine, Underwater
 		RequiresCondition: underwater
@@ -4079,6 +4078,7 @@
 		RepairStep: 200
 		PlayerExperience: 10
 		RepairingNotification: Repairing
+		RepairCondition: repairing
 	WithDeathAnimation:
 		DeathSequence: dead
 		DeathSequencePalette: ra2player
@@ -4131,6 +4131,8 @@
 		IsPlayerPalette: True
 		Scale: 0.40
 		ScaleWithZoom: True
+		Offsets:
+			powerdown: -10, 0
 	GrantCondition@disable:
 		Condition: disabled
 		RequiresCondition: (empdisable || superfreeze || chronobeamed || diskdrain || being-captured) && !invulnerability
@@ -4172,11 +4174,6 @@
 	GrantConditionOnBotOwner@defensebot:
 		Condition: defensebot
 		Bots: defenseai
-	RepairableBuilding:
-		RepairCondition: repairing
-	WithBuildingRepairDecoration:
-		Offsets:
-			powerdown: -10, 0
 	ActorStatValues:
 		Stats: Armor, Sight, Power
 	WithIdleOverlay@shrouded:
@@ -6901,7 +6898,7 @@ CPQDEBUGDUMMY:
 	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
-		PipCount: 7
+		PipCount: 10
 	SpeedMultiplier@HARVBALANCE:
 		RequiresCondition: harv-balance
 		Modifier: 138
@@ -6911,14 +6908,9 @@ CPQDEBUGDUMMY:
 		Stats: Armor, Sight, Speed, None, None, None, Harvester
 	StoresResources:
 		Resources: Tiberium, BlueTiberium, RedTiberium, GoldTiberium, Ore, Gems, RA2Copper, RA2Silver, RA2Ore, RA2Gems, SCMinerals, GESupplies, SWPCarbon, SWRCarbon, SWDCarbon, SWPNova, SWCNova, SWPMin, SWCMin, Spice, SCGas, SCGas2, SCGas3, SCMineralsChunk, SCRMinerals, DRWater, DRTaelon, D2Spice, D2SpiceDense, SWFarms, OP2Ore2, OP2Ore
-	DockClientManager:
 	Selectable:
 		Priority: 7
 		DecorationBounds: 1536, 1536
-	WithStoresResourcesPipsDecoration:
-		Position: BottomLeft
-		RequiresSelection: true
-		PipCount: 10
 
 ^RearmableAircraft:
 	Rearmable:

--- a/mods/cameo/rules/misc.yaml
+++ b/mods/cameo/rules/misc.yaml
@@ -975,6 +975,8 @@ spicebloom:
 	BodyOrientation:
 		QuantizedFacings: 1
 	RenderSprites:
+		Image: spicebloom
+		Palette: effect50alpha
 	AppearsOnRadar:
 		UseLocation: true
 	Tooltip:
@@ -1009,9 +1011,6 @@ spicebloom:
 	Interactable:
 	RequiresSpecificOwners:
 		ValidOwnerNames: Neutral
-	RenderSprites:
-		Image: spicebloom
-		Palette: effect50alpha
 
 spicebloom.spawnpoint:
 	Interactable:

--- a/mods/cameo/rules/shared.yaml
+++ b/mods/cameo/rules/shared.yaml
@@ -122,13 +122,10 @@ ForceShieldDrainer:
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	ChangesHealth:
 		Step: 10
-		Delay: 1
-		StartIfBelow: 100
-		DamageCooldown: 1
-	ChangesHealth:
-		PercentageStep: 1
 		Delay: 10
 		StartIfBelow: 100
+		DamageCooldown: 1
+		PercentageStep: 1
 	AutoTarget:
 		ScanRadius: 10
 		InitialStance: AttackAnything

--- a/mods/cameo/rules/starcraft.yaml
+++ b/mods/cameo/rules/starcraft.yaml
@@ -275,7 +275,6 @@ SCSENTINELM:
 		Offset: 0,0
 	RenderSprites:
 		Image: scsentinelm
-	RenderSprites:
 		PlayerPalette: player_rgba
 	ActorStatValues:
 		Upgrades: terran_upgrade_vehicleweaponslevel1, terran_upgrade_vehicleweaponslevel2, terran_upgrade_vehicleplatinglevel1, terran_upgrade_vehicleplatinglevel2
@@ -610,7 +609,6 @@ SCCOMMANDCENTERM:
 		Prerequisite: conyard
 	RenderSprites:
 		Image: terran_commandcenter
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 SCBARRACKSM:
@@ -627,7 +625,6 @@ SCBARRACKSM:
 		IntoActor: terran_barracks
 	RenderSprites:
 		Image: terran_barracks
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 SCENGINEERINGBAYM:
@@ -644,7 +641,6 @@ SCENGINEERINGBAYM:
 		IntoActor: terran_engineeringbay
 	RenderSprites:
 		Image: terran_engineeringbay
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 SCFACTORYM:
@@ -661,7 +657,6 @@ SCFACTORYM:
 		IntoActor: terran_weaponsfactory
 	RenderSprites:
 		Image: terran_weaponsfactory
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 SCSTARPORTM:
@@ -678,7 +673,6 @@ SCSTARPORTM:
 		IntoActor: terran_starport
 	RenderSprites:
 		Image: terran_starport
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 SCSCIENCEFACILITYM:
@@ -695,7 +689,6 @@ SCSCIENCEFACILITYM:
 		IntoActor: terran_sciencefacility
 	RenderSprites:
 		Image: terran_sciencefacility
-	RenderSprites:
 		PlayerPalette: player_rgba
 
 ^ProtossPersonalShield:

--- a/mods/cameo/rules/tiberiansun.yaml
+++ b/mods/cameo/rules/tiberiansun.yaml
@@ -190,8 +190,8 @@ tsmonstermaker1:
 		RequiresLobbyCreeps: true
 	SpawnActorOnDeath@monstermaker3:
 		RequiresCondition: monsterbirth
-		Probability: 8
-		Actor: forgotten_tiberianfiend_wild
+		Probability: 5
+		Actor: tsfloater
 		OwnerType: InternalName
 		InternalOwner: Creeps
 		RequiresLobbyCreeps: true
@@ -199,13 +199,6 @@ tsmonstermaker1:
 		RequiresCondition: monsterbirth
 		Probability: 8
 		Actor: forgotten_tiberianfiend_wild
-		OwnerType: InternalName
-		InternalOwner: Creeps
-		RequiresLobbyCreeps: true
-	SpawnActorOnDeath@monstermaker3:
-		RequiresCondition: monsterbirth
-		Probability: 5
-		Actor: tsfloater
 		OwnerType: InternalName
 		InternalOwner: Creeps
 		RequiresLobbyCreeps: true
@@ -264,7 +257,7 @@ TSGTCNST:
 	Inherits@shape: ^3x2Shape
 	Inherits@sell: ^TSSpawnActorsOnSell
 	Selectable:
-		Bounds: 3072, 2048
+		Bounds: 3072, 2560, 0, 0
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -314,8 +307,6 @@ TSGTCNST:
 		Sequence: idle-front
 	WithBuildingPlacedOverlay:
 		RequiresCondition: !build-incomplete
-	Selectable:
-		Bounds: 3072, 2560, 0, 0
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:

--- a/mods/cameo/rules/warcraft2.yaml
+++ b/mods/cameo/rules/warcraft2.yaml
@@ -718,7 +718,7 @@ Player:
 	Valued:
 		Cost: 2500
 	Health:
-		HP: 250000
+		HP: 300000
 	Armor:
 		Type: Wood
 	Power:
@@ -734,8 +734,6 @@ Player:
 		TerrainTypes: Water
 	RequiresBuildableArea:
 		Adjacent: 10
-	Health:
-		HP: 300000
 	RevealsShroud:
 		Range: 5000
 	GivesBuildableArea:
@@ -1340,7 +1338,7 @@ wc2_orc_skeleton:
 	Valued:
 		Cost: 100
 	Power:
-		Amount: -5
+		Amount: 0
 	Health:
 		HP: 10000
 	ChangesHealth@SelfHealing:
@@ -1351,8 +1349,6 @@ wc2_orc_skeleton:
 		Weapon: wc2skeletonpunch
 	Voiced:
 		VoiceSet: voiceskeleton
-	Power:
-		Amount: 0
 	# Undead target type
 	Targetable@UNDEAD:
 		TargetTypes: undeadtarget

--- a/tools/audit/audit_duplicate_keys.py
+++ b/tools/audit/audit_duplicate_keys.py
@@ -47,7 +47,7 @@ SKIP_PARTS = ("maps", "bits")
 
 # Ratchets: lower them as duplicates are resolved; never raise without a note.
 D1_BASELINE = 35
-D2_BASELINE = 329
+D2_BASELINE = 260
 
 
 def duplicate_children(node: Node) -> dict[str, list[Node]]:

--- a/tools/tests/test_weapon_correctness_followups.py
+++ b/tools/tests/test_weapon_correctness_followups.py
@@ -266,6 +266,28 @@ class WeaponCorrectnessFollowupTests(unittest.TestCase):
                 count = sum(item.key == key for item in actor.children)
                 self.assertEqual(1, count, f"{actor_name} > {key}")
 
+    def test_active_actor_and_weapon_rules_have_no_duplicate_traits(self):
+        expected = set()
+        findings = set()
+        paths = self.rules.manifest.rules + self.rules.manifest.weapons
+        for path in paths:
+            for actor in load(path):
+                groups = defaultdict(list)
+                for index, item in enumerate(actor.children):
+                    if item.key and not item.key.startswith("-"):
+                        groups[item.key].append(index)
+
+                for key, indexes in groups.items():
+                    if len(indexes) <= 1:
+                        continue
+                    removal = f"-{key}"
+                    between = actor.children[indexes[0] + 1:indexes[-1]]
+                    marker = removal if any(
+                        item.key == removal for item in between) else "<missing>"
+                    findings.add((actor.key, key, marker))
+
+        self.assertEqual(expected, findings)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- consolidate all 69 remaining duplicate trait groups in active actor and weapon YAML into single canonical declarations
- reduce active duplicate-trait findings from 329 to 260 while leaving duplicate inheritance-label findings unchanged at 35
- add a regression test that rejects any future duplicate trait declarations in active actor and weapon rules

## Behavior proof
- independently resolved 3,973 actors/templates and 2,847 weapons before and after: zero differences
- exactly 65 intended actor/template owners changed; no neighboring definitions changed
- all 363 packed maps and 15 unpacked map YAML files are unaffected
- no pricing, engine, weapon-balance, or parked percentage-damage runtime changes

## Validation
- 614 tests passed, 11 skipped
- focused weapon-correctness tests: 10 passed
- duplicate-key, orphan-weapon, empty-warhead, three-way, split-warhead, physical-state, scaled-bullet, upgrade, garrison, upgrade-regression, balance-drift, and weapon-structure audits passed
- all 32 balance ledgers show zero drift
- fresh cold boot remained alive and responsive for 123 seconds; 10 logs had zero crash/exception/rules-load/Lua/fatal-error matches
- independent review found no blockers