### PR TITLE
Remove generic Nax corrosion overlays

### DIFF
--- a/docs/design/PHYSICAL_STATE_SYSTEM.md
+++ b/docs/design/PHYSICAL_STATE_SYSTEM.md
@@ -234,16 +234,15 @@ cold/corrosion auto-scale with damage. **Everything else below is YAML config of
 
 ⚠ Corrosion is NOT greenfield: it already exists as a **binary `corroded` condition** (`defaults.yaml`
 ~5495–5516) applied on/off by the Schwarzer Mond rockets — `DamageMultiplier@corroded 125`,
-`SpeedMultiplier@corroded 75`, `WithColoredOverlay@corroded 44FF4444` (green), `WithIdleOverlay@corroded`
-(`Image: explosion, Sequence: nax_corr_frag` = the pulse), `Targetable@corroded`. So BUILD 1 is a
-CONVERSION, reusing the existing art:
+`SpeedMultiplier@corroded 75`, `WithColoredOverlay@corroded 44FF4444` (green), `Targetable@corroded`.
+So BUILD 1 is a CONVERSION, reusing the existing gameplay mechanics:
 1. Add `PhysicalState@Corrosion` meter (0–20000, `RelativeToHealth`, decay) on `^CryoFreezable` (the
    shared Temperature home) + wherever else Temperature lives.
 2. Replace the fixed `@corroded` traits with **scaled** ones from 50%→100% (`ChangesHealthProportionalToPhysicalState`
    DoT ~180 + a `@…Hazmat` half via `hazmatsuits`; `SlowsProportionalToPhysicalState` `OnlyPositiveValues`
    to ~60%; `DamageMultiplierProportionalToPhysicalState` to +150%).
-3. Keep the art: `WithPhysicalStateColoredOverlay@Corrosion` green tint 200→20000; `WithIdleOverlay`
-   `nax_corr_frag` pulse gated on a `CorrosionMax` condition (meter == 20000).
+3. Keep the meter art: `WithPhysicalStateColoredOverlay@Corrosion` green tint 200→20000; leave the
+   `CorrosionMax` condition visual-empty.
 4. Migrate the Schwarzer Mond weapons from granting the binary `corroded` to feeding the Corrosion meter
    (via the new `PhysicalStateScale`, or an `ApplyPhysicalState` warhead). Keep the old binary path until
    migrated so nothing breaks mid-way.
@@ -385,7 +384,7 @@ reference an image+sequence, so the yaml wires with placeholders and the art dro
 - ✅ C# damage-scaled `PhysicalStateName`/`PhysicalStateScale` on `AreaDamage` + `_Percentage` — `406261128`
 - ✅ C# MULTI-state `PhysicalStates` dict (one warhead → many meters) — `2e6d6968a`
 - ✅ Corrosion meter axis on `^Corrodible` (green tint 200→20000, DoT+slow+vuln 50→100%, hazmat-half,
-  `nax_corr_frag` pulse at max) — additive, INERT until fed — `ecf616978`
+  no cap visual) — additive, INERT until fed — `ecf616978`
 - ✅ Family wiring LIVE: Flame +100 / Laser +75 / Chemical +100 (generator `FAMILY_PHYSICAL_STATE`) — `51148be5b`
 - ✅ Cryo family = `^Warhead_Cryo_*` inherits `^Warhead_Prism_*` + Temperature −100 (generator
   `INHERIT_FAMILIES`) — `f97a3b77c`

--- a/mods/cameo/rules/defaults.yaml
+++ b/mods/cameo/rules/defaults.yaml
@@ -5689,15 +5689,9 @@
 	WithColoredOverlay@corroded:
 		RequiresCondition: corroded
 		Color: 44FF4444
-	WithIdleOverlay@corroded:
-		RequiresCondition: corroded
-		Image: explosion
-		Sequence: nax_corr_frag
-		StartSequence: nax_corr_frag
-		Palette: ra2effect
 	# --- Corrosion METER (physical-state axis). ADDITIVE + inert until a weapon feeds it via
 	# AreaDamage PhysicalStateName: Corrosion / PhysicalStateScale. Green tint 200->20000; effects
-	# open at 1% (Corroding); nax_corr_frag pulse at max. Binary `corroded` above kept until the
+	# open at 1% (Corroding). Binary `corroded` above is kept until the
 	# Schwarzer Mond weapons are migrated onto the meter. See docs/design/PHYSICAL_STATE_SYSTEM.md.
 	PhysicalState@Corrosion:
 		Name: Corrosion
@@ -5770,14 +5764,6 @@
 		DamageMultiplierAtMaximum: 150
 		UseDeviationFromRelaxed: true
 		RequiresCondition: Corroding
-	WithIdleOverlay@CorrosionPulse:
-		RequiresCondition: CorrosionMax
-		Image: explosion
-		Sequence: nax_corr_frag
-		StartSequence: nax_corr_frag
-		Palette: ra2effect
-		IsDecoration: True
-
 ^AffectedByHealingField:
 	ExternalCondition@HealingField:
 		Condition: HealingField


### PR DESCRIPTION
## Summary
- remove the Nax fragment sprite from the shared binary `corroded` overlay
- leave `CorrosionMax` visual-empty while retaining its condition and corrosion gameplay
- update the physical-state design note to reflect the visual scope

## Validation
- `git diff --check`
- confirmed active YAML retains `nax_corr_frag` only for the sequence definition and Schwarzer Mond's three direct shrapnel impacts
- high-effort independent static review

No build or game launch: YAML/documentation-only change.