### PR TITLE
Fix AI selling StarCraft and Warcraft headquarters as redundant refineries

### DIFF
--- a/OpenRA.Mods.CA/Traits/BotModules/BaseBuilderBotModuleCA.cs
+++ b/OpenRA.Mods.CA/Traits/BotModules/BaseBuilderBotModuleCA.cs
@@ -841,6 +841,14 @@ namespace OpenRA.Mods.CA.Traits
 
 			for (var i = 0; i < refineries.Length; i++)
 			{
+				// StarCraft and Warcraft headquarters also accept resources. Keep them
+				// in the refinery count, but never sell them as redundant drop-off sites.
+				if (Info.ConstructionYardTypes.Contains(refineries[i].Info.Name))
+				{
+					AIUtils.BotDebug("AI ({0}): Preserving headquarters during refinery cleanup: {1}", player.ClientIndex, refineries[i]);
+					continue;
+				}
+
 				for (var j = i + 1; j < refineries.Length; j++)
 				{
 					if ((refineries[i].Location - refineries[j].Location).LengthSquared <= Info.SellRefineryTooCloseCellDistance * Info.SellRefineryTooCloseCellDistance)

--- a/tools/tests/test_ai_headquarters_refinery_cleanup.py
+++ b/tools/tests/test_ai_headquarters_refinery_cleanup.py
@@ -1,0 +1,56 @@
+"""Active-rule coverage and source guard checks; not an in-game simulation."""
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools/audit"))
+from miniyaml import Ruleset
+
+
+class HeadquartersRefineryCleanupTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = Ruleset(ROOT)
+        cls.ai = cls.rules.resolve("Player").child("BaseBuilderBotModuleCA@generic")
+        cls.protected = set(cls.ai.get("ConstructionYardTypes").split(", "))
+
+    def test_all_starcraft_and_warcraft_headquarters_are_protected(self):
+        for name in ("protoss_nexus", "terran_commandcenter", "zerg_hatchery",
+                     "wc2_humans_townhall",
+                     "wc2_orcs_greathall"):
+            with self.subTest(actor=name):
+                actor = self.rules.resolve(name)
+                self.assertIsNotNone(actor)
+                self.assertTrue(actor.children_named("Refinery"))
+                self.assertIn(name, self.protected)
+
+    def test_normal_refineries_remain_unprotected(self):
+        for name in ("protoss_assimilator", "terran_refinery", "zerg_extractor",
+                     "ixian_refineryixian", "ra1_soviets_sovietorerefinery",
+                     "wc2_humans_elvenlumbermill", "wc2_orcs_trolllumbermill"):
+            with self.subTest(actor=name):
+                actor = self.rules.resolve(name)
+                self.assertIsNotNone(actor)
+                self.assertTrue(actor.children_named("Refinery"))
+                self.assertNotIn(name, self.protected)
+
+    def test_cleanup_guard_precedes_both_sell_paths_without_changing_count(self):
+        source = (ROOT / "OpenRA.Mods.CA/Traits/BotModules/BaseBuilderBotModuleCA.cs").read_text()
+        cleanup = source.split("void SellUselessRefinery(IBot bot)", 1)[1].split(
+            "List<MiniYamlNode>", 1)[0]
+        self.assertIn("world.ActorsHavingTrait<Refinery>().Where(a => a.Owner == player).ToArray()", cleanup)
+        guard = "if (Info.ConstructionYardTypes.Contains(refineries[i].Info.Name))"
+        self.assertIn(guard, cleanup)
+        # The diagnostic string contains braces, so inspect through the next loop.
+        guard_body = cleanup.split(guard, 1)[1].split("for (var j =", 1)[0]
+        self.assertIn("continue;", guard_body)
+        self.assertLess(cleanup.index("if (refineries.Length <="), cleanup.index(guard))
+        self.assertLess(cleanup.index("for (var i ="), cleanup.index(guard))
+        self.assertLess(cleanup.index(guard), cleanup.index("for (var j ="))
+        self.assertLess(cleanup.index(guard), cleanup.index("if (ResourceMapModule != null"))
+        self.assertEqual(2, cleanup.count('new Order("Sell"'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fix
Protect every configured construction yard from both automatic refinery-cleanup sale paths (nearby refinery and exhausted resources). Headquarters remain included in refinery counts; normal refinery cleanup, manual selling, damage-triggered selling, and expansion settings are unchanged.

The cleanup routine scans all actors with Refinery, not just configured RefineryTypes. This includes the Protoss Nexus, Terran Command Center, Zerg Hatchery, Warcraft Human Town Hall, and Orc Great Hall. It previously bypassed the last-construction-yard protection in the separate attack-response sale path.

## Validation
- Full ./make all build passed (existing engine analyzer warnings).
- Verified fresh OpenRA.Mods.CA.dll timestamp and unique diagnostic marker in compiled bytes.
- All 48 Cameo C# tests passed.
- Three new Python regression checks passed: resolved active HQ protection, ordinary refinery eligibility, and source guard placement ahead of both sale paths while retaining the original refinery count.
- git diff --check passed.

These new checks are active-configuration/source regression checks, not an in-game simulation. No game or replay launched; the historical Discord match has not been reproduced.

## Scope
Separate from PR #329 and tooltip work. No YAML gameplay stats, prices, engine pins, or expansion changes. Protects all headquarters recognized by the shared AI configuration, not just the last Nexus.