### PR TITLE
Smooth Patriot Thunderbolt missile climb

### DIFF
--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
@@ -38,6 +38,7 @@ RA2PatriotThunderboltMissile:
 		MaximumLaunchSpeed: 400
 		MinimumLaunchSpeed: 400
 		Acceleration: 10
+		VerticalRateOfTurn: 40
 		ContrailStartColor: EEEE00
 		ContrailEndColor: FFFFFF
 	Warhead@MissileAA_Heavy:


### PR DESCRIPTION
The upgraded Patriot Thunderbolt missile can stay low before turning sharply toward aircraft. Add a local VerticalRateOfTurn: 40 override (previously inherited 80) to begin the terminal approach earlier with a gentler turn. The shared missile template, ordinary Patriot and all other weapon fields remain unchanged.

Blackrobe approved the appearance after automatic A/B helicopter and MiG passes at close and long range, and explicitly accepts a possible damage-efficiency tradeoff. This changes simulated turning, not just rendering; hit-rate or damage-efficiency parity is not claimed.

Validation: compared all 2,896 resolved weapon definitions against the upstream base; exactly one field changes, RA2PatriotThunderboltMissile.Projectile.VerticalRateOfTurn (80 -> 40). git diff --check passes. One file, one added line; local test-map assets and unrelated working-tree changes are excluded. YAML-only: no engine rebuild required.
