### PR TITLE
Smooth conventional anti-air and air-to-ground missile trajectories

### DIFF
--- a/docs/audit/missile-trajectory-rollout.json
+++ b/docs/audit/missile-trajectory-rollout.json
@@ -1,0 +1,2396 @@
+{
+  "changed_weapon_count": 203,
+  "resolved_definitions_checked": 2896,
+  "changes": [
+    {
+      "weapon": "M1A1Missiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MammothMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "227mmAMT",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "OrcaMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "OrcaMissilesAMT",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "MinimumLaunchAngle": {
+          "before": "50",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "TowerMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TowerMissileAMT",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "RocketsHumvee2_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RocketsHumvee2AMT_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "GDIPredatorTankMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTank3Missiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "GDIRigMissilePod",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "GDIRigMissilePodAMT",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "CommandoRocketLauncher",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "BikeRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "LTNKMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "StealthTankMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "StealthTankMissilesBlackMarket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HeliMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "Dragon",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "ChemRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "ChemicalBikeRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "ChemicalStealthTankMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LightTank2Missiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "BHRedDarts",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "CorvetteDragon",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "50",
+          "after": "24"
+        }
+      }
+    },
+    {
+      "weapon": "RocketsRA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RocketsRACryo",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "Stinger",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "StingerCryo",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "FireRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "FireRocketsThermobaric",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "HindMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HindMissilesThermobaric",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "30",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "HindMissilesNuclear",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "30",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "KamovMissilesTesla",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "30",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "Maverick",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "TeslaMaverick",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "ThermobaricMaverick",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "Su57Maverick",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "Su57MaverickThermobaric",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTuskTargetingComputer",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTuskThermobaric",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTuskThermobaricTargetingComputer",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTuskTesla",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTuskTeslaTargetingComputer",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTusk2",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTusk2TargetingComputer",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTusk2Thermobaric",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MammothTusk2ThermobaricTargetingComputer",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MonsterTankTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MonsterTankTuskTesla",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "MonsterTankTuskThermobaric",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "Nike",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "Hellfire",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "HellfireCryo",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "SheridanMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "SheridanMissilesCryo",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "APTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "APTuskCryo",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "ChronoTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "ChronoTuskCryo",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSHellfireTwin",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSTibBazooka",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSStankTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSSBoatTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSStankTibTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSNODRedEye",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSNODTibRedEye",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "PitbullRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSHoverMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSDestroyerMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSMammothTusk2",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSMammothTusk2II_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSZoneHellfire",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSGDIRedEye",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSChemBazooka",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSMammothTusk",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "TSRuinerMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSChemRuinerMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSApacheMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSChemApacheMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSCobraMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSChemCobraMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSAdatsMissile_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2HoverMissile_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2HoverMissile_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2ThunderboltMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2ThunderboltMissile_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2ThunderboltMissile_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2ThunderboltMissile_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiHoverMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiHoverMissile_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiHoverMissile_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiHoverMissile_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiThunderboltMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiThunderboltMissile_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiThunderboltMissile_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MultiThunderboltMissile_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2HornetMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_rad",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_fire",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_tesla",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_rad_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_fire_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "RA2Patriot",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HarrierMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HarrierMissiles_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2Medusa_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MigMissiles_tesla_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MammothTusk_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2MammothTusk_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "AsianPelicanMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "AsianPelicanMissile_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "AsianPhoenixRocket",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "AsianPhoenixRocket_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "AsianMLRS",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "AsianSpitfireRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "ConsortiumMissileSystem",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "ConsortiumMissileSystem_EMP",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "SteelHoverMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "RA2FreedomRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2FreedomRocket_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2LarsRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinRusherRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinRusherRocket_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinSmokerRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinSmokerRocket_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2APCRocket_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "RA2APCRocket_AA_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LunarNaxiDroneMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        },
+        "MinimumLaunchAngle": {
+          "before": "25",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "NaxPlaneRockets_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        },
+        "MinimumLaunchAngle": {
+          "before": "128",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "NaxCorrosionRocket",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "NaxCorrosionRocketTrooper_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "NaxCorrosionBeast",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "NaxCorrosionBeast_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "Naxis_Komet_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "Future_Cryocopter_Rocket",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "Future_MultiMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "Future_MultiMissile_Javelin",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "Future_MultiMissile_Sigma",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "FutureJavelinRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "FutureJavelinRockets_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "FutureJavelinRocketsDeployed",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "FutureJavelinRocketsDeployed_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MissileAttackRobotGun",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MissileAttackRobotGun_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HueyMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "tkmtwinrockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "tkmtwinrocketstechnicaltank",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "tkmrockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "as42rockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "tkmcryorockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "tkmstrykerrockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HueyCryoMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "HueyTwinMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "tkmstrykerfirerockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_TowerMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Shared/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "mtank_pri",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/d2k.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_Rocket_Trooper_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_APC_Rocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_APC_Rocket_AA",
+      "launcher_domains": "airground",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "DeviatorMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "Wraith_ToxinMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        },
+        "MinimumLaunchAngle": {
+          "before": "64",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "facedancer_grenade",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_Bazooka2",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_Rocket_Trooper1",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "mtank_pri2",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "25",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_RocketsCymek",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MongooseRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "OrniMissile",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/D2k/Atreides/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        },
+        "MinimumLaunchAngle": {
+          "before": "64",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "CycloneRockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "SCTyrAA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "GoliathMk2Rockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "SunDogRockets",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "MinimumLaunchAngle": {
+          "before": "64",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "WyvernRockets",
+      "launcher_domains": "air",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "MissileTurret",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "Rockets",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiandawn.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "227mm",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiandawn.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "SteelHoverMissile_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/redalert2mod.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "SteelTwisterMissiles",
+      "launcher_domains": "air",
+      "file": "mods/cameo/weapons/redalert2mod.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "SteelTwisterMissiles_elite",
+      "launcher_domains": "air",
+      "file": "mods/cameo/weapons/redalert2mod.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinBuggyRocket",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/redalert2mod.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "LatinBuggyRocket_elite",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/redalert2mod.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_Rocket_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/d2k.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "D2K_Rocket_Trooper",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/d2k.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "22",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "ixian_airdrone",
+      "launcher_domains": "air",
+      "file": "mods/cameo/weapons/d2k.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        },
+        "MinimumLaunchAngle": {
+          "before": "64",
+          "after": "-128"
+        }
+      }
+    },
+    {
+      "weapon": "TSBazooka",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSAegisMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSBikeMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSBikeTibMissile",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSSAPCMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSSAPCCoreMissiles",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "TSHellfire",
+      "launcher_domains": "air",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "30",
+          "after": "16"
+        }
+      }
+    },
+    {
+      "weapon": "TSChemAdatsMissileAA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/tiberiansun.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "40",
+          "after": "20"
+        }
+      }
+    },
+    {
+      "weapon": "eden_EMP_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/outpost2.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "edenTiger_EMP_AA",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/outpost2.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "20",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "plymouthRPG",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/outpost2.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "plymouthTigerRPG",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/outpost2.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    },
+    {
+      "weapon": "plymouthDefenceRPG",
+      "launcher_domains": "ground",
+      "file": "mods/cameo/weapons/outpost2.yaml",
+      "fields": {
+        "VerticalRateOfTurn": {
+          "before": "24",
+          "after": "12"
+        }
+      }
+    }
+  ],
+  "preserved_descendants": {
+    "ChemRocketsExplosion": {
+      "VerticalRateOfTurn": "40"
+    },
+    "ChemicalBikeRocketsExplosion": {
+      "VerticalRateOfTurn": "30"
+    },
+    "ChemicalStealthTankExplosion": {
+      "VerticalRateOfTurn": "30"
+    },
+    "MammothTuskGal": {
+      "VerticalRateOfTurn": "20"
+    },
+    "FireRocketsExplode": {
+      "VerticalRateOfTurn": "20"
+    },
+    "FireRocketsThermobaricExplode": {
+      "VerticalRateOfTurn": "20"
+    },
+    "TeslaMaverickFragment1": {
+      "VerticalRateOfTurn": "30",
+      "MinimumLaunchAngle": "128"
+    },
+    "TeslaMaverickFragment2": {
+      "VerticalRateOfTurn": "30",
+      "MinimumLaunchAngle": "128"
+    },
+    "MammothTuskTeslaFragment1": {
+      "VerticalRateOfTurn": "20"
+    },
+    "MammothTuskTeslaFragment2": {
+      "VerticalRateOfTurn": "20"
+    },
+    "MigMissiles_AA": {
+      "VerticalRateOfTurn": "30",
+      "MinimumLaunchAngle": "25"
+    },
+    "MigMissiles_AA_elite": {
+      "VerticalRateOfTurn": "30",
+      "MinimumLaunchAngle": "25"
+    },
+    "RA2MedusaAG": {
+      "VerticalRateOfTurn": "30"
+    },
+    "NaxInterceptorRockets": {
+      "VerticalRateOfTurn": "30",
+      "MinimumLaunchAngle": "128"
+    },
+    "DeviatorMissile_Artillery": {
+      "VerticalRateOfTurn": "20"
+    },
+    "D2K_Annihilator_AA": {
+      "VerticalRateOfTurn": "20"
+    },
+    "CycloneRocketsLockOn": {
+      "VerticalRateOfTurn": "40"
+    },
+    "D2K_Rocket_ultimate": {
+      "VerticalRateOfTurn": "20"
+    },
+    "D2K_Rocket_Fremen": {
+      "VerticalRateOfTurn": "20"
+    },
+    "TSBazookaG": {
+      "VerticalRateOfTurn": "40"
+    },
+    "TSMammothTusk_elite": {
+      "VerticalRateOfTurn": "25"
+    },
+    "TSRedEye2": {
+      "VerticalRateOfTurn": "25"
+    }
+  }
+}

--- a/docs/audit/missile-trajectory-rollout.md
+++ b/docs/audit/missile-trajectory-rollout.md
@@ -1,0 +1,24 @@
+# Broader missile trajectory correction
+
+Extend the visually approved Patriot approach to conventional ground-to-air and air-to-ground missiles. This is a data-only guidance adjustment, not a new ballistic projectile model. It changes simulated flight and may trade damage efficiency for appearance; the maintainer accepted that tradeoff for this direction. Representative Nod SAM, Ixian Air Drone and Patriot comparisons were visually approved.
+
+## Scope and selection
+
+Active mod.yaml includes and resolved actor armaments identify the firing domain. Ordinary missile artwork and weapon roles select the initial cohort; arrows, spells, plasma/railgun projectiles, torpedoes, air mines and kamikaze effects remain outside it. High-cruise profiles (over 1024 world units), steep launches (minimum angle 192 or above), and specially low/high turn rates are preserved. The already approved Patriot Thunderbolt 40 override is unchanged.
+
+Reduce vertical turning only where nominal maximum range exceeds the current launch-speed terminal-guidance threshold. The threshold is `3 * (MaximumLaunchSpeed * 6400 / (157 * VerticalRateOfTurn.Facing))`, with integer arithmetic and the normal Speed fallback. New rates roughly halve facing-unit turning, rounded upward with a floor of 12 angle units. This starts the terminal approach earlier while retaining horizontal steering, speed, homing delay and cruise altitude. The threshold is a selection diagnostic, not a guarantee for upgraded ranges or every target motion.
+
+For weapons used only by aircraft, a positive minimum launch angle is lowered to -128 so a ground target can be aimed at downward immediately. Maximum launch angles remain intact. The Ixian Air Drone changes minimum launch angle 64 to -128 and vertical turning 20 to 12. Its inherited ground-launch tilt previously forced an initial upward pitch despite the target being below the drone. Shared ground/air weapons do not receive the downward-launch adjustment.
+
+Some ground-to-air weapons also attack ground targets; their shared projectile changes both uses. Dedicated air-to-air siblings, artillery, fragments and other unselected descendants have explicit preservation overrides where required. Generic templates are not edited.
+
+## Validation
+
+- 2,896 complete resolved weapon definitions compared.
+- Exactly 203 weapons change, and only the declared vertical-turn/minimum-launch-angle fields.
+- 22 inheritance guards preserve existing descendant behavior.
+- Damage, speed, horizontal turning, reload, burst, target eligibility, effects and audio are unchanged.
+- Independent complete-field comparison passed; the engine loaded the full modified default rules successfully using `--faction-report`.
+- The automatic comparison map now includes Nod SAM and Ixian Air Drone A/B passes before the existing Patriot passes. Lua syntax and engine resolution of the Ixian test actor passed. These checks do not establish in-game visual quality or hit-rate parity.
+- The maintainer visually approved the automatic Nod SAM, Ixian Air Drone and Patriot A/B comparisons. This is representative visual coverage, not an in-game check of all 203 weapons or measured hit-rate parity.
+- See `missile-trajectory-rollout.json` for the exhaustive per-weapon field changes and preservation guards.

--- a/mods/cameo/ContentPacks/D2k/Atreides/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Atreides/yaml/weapons.yaml
@@ -99,6 +99,8 @@ OrniMissile:
 	ValidTargets: Ground, Air
 	BurstDelays: 6
 	Projectile: Missile
+		VerticalRateOfTurn: 12
+		MinimumLaunchAngle: -128
 		Inaccuracy: 666
 		Speed: 333
 		RangeLimit: 33333

--- a/mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml
@@ -441,6 +441,7 @@ D2K_Bazooka2:
 	ReloadDelay: 5
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Blockable: false
 		Inaccuracy: 33
 		InaccuracyType: PerCellIncrement
@@ -506,7 +507,7 @@ D2K_Rocket_Trooper1:
 		MaximumLaunchSpeed: 222
 		MinimumLaunchSpeed: 222
 		HorizontalRateOfTurn: 22
-		VerticalRateOfTurn: 22
+		VerticalRateOfTurn: 12
 		Acceleration: 6
 	Warhead@MissileAP_Light:
 		ValidTargets: Ground, Water, Air
@@ -537,7 +538,7 @@ mtank_pri2:
 		AllowSnapping: true
 		Shadow: true
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		TrailImage: large_trail
 		TrailInterval: 1
 		ContrailLength: 0
@@ -1289,6 +1290,7 @@ D2K_RocketsCymek:
 	Range: 6787
 	Report: vintatta.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 400
 		Arm: 2
 		Inaccuracy: 800
@@ -1614,7 +1616,7 @@ MongooseRocket:
 		RangeLimit: 25000
 		PointDefenseTypes: Missile
 		HorizontalRateOfTurn: 22
-		VerticalRateOfTurn: 22
+		VerticalRateOfTurn: 12
 	Warhead@MissileAP_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 33000

--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1058,7 +1058,7 @@ D2K_Rocket_Trooper_AA:
 		MaximumLaunchSpeed: 222
 		MinimumLaunchSpeed: 222
 		HorizontalRateOfTurn: 22
-		VerticalRateOfTurn: 22
+		VerticalRateOfTurn: 12
 		Acceleration: 8
 	Warhead@MissileAA_Heavy:
 		ValidTargets: Air
@@ -1078,7 +1078,7 @@ D2K_APC_Rocket:
 		MaximumLaunchSpeed: 222
 		MinimumLaunchSpeed: 222
 		HorizontalRateOfTurn: 22
-		VerticalRateOfTurn: 22
+		VerticalRateOfTurn: 12
 	Warhead@MissileAP_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 8000
@@ -1268,6 +1268,9 @@ D2K_APC_Rocket_AA:
 		Range: 0, 32
 	-Warhead@MissileAP_MediumFlatCompatibility:
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 DeviatorMissile:
 	Inherits@collapseflat: ^Compatibility_MissileAP_HeavyFlat
 	Inherits: ^Warhead_CannonHE_Heavy
@@ -1282,6 +1285,7 @@ DeviatorMissile:
 	ValidTargets: Ground, Water, Air
 	# InvalidTargets: Structure, MCImmune
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Inaccuracy: 16
 		Image: d2k_missile
 		Palette: d2keffect
@@ -1341,6 +1345,7 @@ DeviatorMissile_Artillery:
 	Range: 10025
 	ValidTargets: Ground, Water
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		RangeLimit: 12500
 		Inaccuracy: 125
 	Warhead@ShrapnelWeapon: SpreadDamage
@@ -1383,6 +1388,8 @@ Wraith_ToxinMissiles:
 	ValidTargets: Ground, Water, Air
 	# InvalidTargets: MCImmune
 	Projectile: Missile
+		VerticalRateOfTurn: 12
+		MinimumLaunchAngle: -128
 		Blockable: false
 		Inaccuracy: 33
 		InaccuracyType: PerCellIncrement
@@ -1574,6 +1581,7 @@ facedancer_grenade:
 	Report: missile7.aud
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: d2k_RPG
 		TrailImage: bazooka_trail2
 		Palette: effect
@@ -2527,6 +2535,7 @@ D2K_Annihilator_AA:
 	ReloadDelay: 100
 	ValidTargets: Air
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Speed: 280
 		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage

--- a/mods/cameo/ContentPacks/D2k/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Shared/yaml/weapons.yaml
@@ -475,7 +475,7 @@ D2K_TowerMissile:
 		AllowSnapping: true
 		Shadow: true
 		HorizontalRateOfTurn: 80
-		VerticalRateOfTurn: 20
+		VerticalRateOfTurn: 12
 		TrailImage: large_trail
 		TrailInterval: 1
 		MaximumLaunchSpeed: 200

--- a/mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Allies/yaml/weapons.yaml
@@ -119,6 +119,9 @@ Hellfire:
 		ValidTargets: Ground, Water, Air
 		Damage: 16000
 		PercentageScale: 9994
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 HellfireCryo:
 	Inherits@wh: ^Warhead_CryoBlast_Medium
 	Inherits@wh2: ^Warhead_MissileCryo_Heavy
@@ -135,6 +138,9 @@ HellfireCryo:
 	Warhead@MissileCryo_Heavy:
 		ValidTargets: Ground, Water, Air
 		Damage: 8000
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 ChainGunMH60:
 	Inherits@wh: ^Warhead_Bullet_Medium
@@ -233,6 +239,9 @@ SheridanMissiles:
 	Warhead@MissileHE_Medium:
 		ValidTargets: Ground, Water, Air
 		Damage: 16000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 SheridanMissilesCryo:
 	Inherits@wh: ^Warhead_MissileCryo_Medium
 	Inherits@proj: ^Projectile_Missile_Light
@@ -244,6 +253,9 @@ SheridanMissilesCryo:
 	Warhead@MissileCryo_Medium:
 		Damage: 16000
 		ValidTargets: Ground, Water, Air
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 SheridanVulcan:
 	Inherits@roleflat: ^Compatibility_Bullet_MediumFlat
 	Inherits@wh: ^Warhead_Bullet_Light
@@ -539,12 +551,18 @@ APTusk:
 		Damage: 16000
 		PercentageScale: 0
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 APTuskCryo:
 	Inherits: APTusk
 	Inherits@2: ^CryoMissileProjectile
 	Warhead@PhysicalStateCryo: ApplyPhysicalState
 		Amount: -16000
 		Range: 300
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 ChronoTusk:
 	Inherits@collapsewh: ^Warhead_MissileHE_Heavy
@@ -584,12 +602,18 @@ ChronoTusk:
 		Damage: 20000
 		PercentageScale: 0
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 ChronoTuskCryo:
 	Inherits: ChronoTusk
 	Inherits@2: ^CryoMissileProjectile
 	Warhead@PhysicalStateCryo: ApplyPhysicalState
 		Amount: -20000
 		Range: 400
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 155mmCryo:
 	Inherits: 155mm

--- a/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Shared/yaml/weapons.yaml
@@ -206,6 +206,9 @@ RocketsRA:
 		ValidTargets: Ground, Water, Air
 		Damage: 20000
 		PercentageScale: 9995
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RocketsRACryo:
 	Inherits@wh: ^Warhead_MissileCryo_Medium
 	Inherits@proj: ^Projectile_Missile_Light
@@ -216,6 +219,9 @@ RocketsRACryo:
 	Warhead@MissileCryo_Medium:
 		Damage: 20000
 		ValidTargets: Ground, Water, Air
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 DragunovSniper:
 	Inherits@wh: ^Warhead_CannonAP_Heavy
 	Inherits: ^TankDestroyerCannon
@@ -1015,6 +1021,7 @@ MammothTusk:
 	Range: 6412
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 641
 		ContrailStartColor: FF884400
 		ContrailEndColor: 000000FF
@@ -1363,6 +1370,9 @@ MammothTuskGal:
 	ReloadDelay: 55
 	Range: 5675
 	ValidTargets: Air, Ground
+
+	Projectile: Missile
+		VerticalRateOfTurn: 20
 
 DT120mm1:
 	Inherits: DT120mm
@@ -2113,6 +2123,7 @@ Stinger:
 	Burst: 2
 	BurstDelays: 7
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 500
 		MinimumLaunchAngle: 50
 		Acceleration: 5
@@ -2135,6 +2146,7 @@ StingerCryo:
 	Burst: 2
 	BurstDelays: 7
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 500
 		MinimumLaunchAngle: 50
 		Acceleration: 5

--- a/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert/Soviets/yaml/weapons.yaml
@@ -199,6 +199,7 @@ FireRockets:
 	Report: missile6.aud
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		TrailImage: fb2
 		TrailInterval: 1
 		TrailDelay: 0
@@ -210,6 +211,9 @@ FireRocketsExplode:
 	Warhead@MissileFire_Light:
 		ValidTargets: Ground, Water, Air
 		Damage: 16000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 FireRocketsThermobaric:
 	Inherits@wh: ^Warhead_MissileFire_Medium
 	Inherits@proj: ^Projectile_Missile_Heavy
@@ -219,6 +223,7 @@ FireRocketsThermobaric:
 	Report: missile6.aud
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		TrailImage: fb2
 		TrailInterval: 1
 		TrailDelay: 0
@@ -236,6 +241,9 @@ FireRocketsThermobaricExplode:
 	Warhead@MissileFire_Medium:
 		ValidTargets: Ground, Water, Air
 		Damage: 16000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 FireballLauncher:
 	Inherits@wh: ^Warhead_Flame_Medium
 	Inherits@proj: ^Projectile_Flame_Medium
@@ -1210,6 +1218,9 @@ HindMissiles:
 	-Warhead@Demolition_Light:
 	-Warhead@MissileAP_Medium:
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 HindMissilesThermobaric:
 	Inherits@roleflat: ^Compatibility_Thermobaric_MediumFlat
 	Inherits@collapsewh: ^Warhead_Thermobaric_Medium
@@ -1225,6 +1236,7 @@ HindMissilesThermobaric:
 	Range: 5528
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Shadow: true
 		Inaccuracy: 300
@@ -1233,7 +1245,7 @@ HindMissilesThermobaric:
 		TrailDelay: 1
 		TrailInterval: 1
 		Speed: 300
-		MinimumLaunchAngle: 30
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 30
 		ContrailLength: 10
 		ContrailStartColor: FFBB8844
@@ -1314,6 +1326,7 @@ HindMissilesNuclear:
 	Range: 5528
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Shadow: true
 		Inaccuracy: 300
@@ -1322,7 +1335,7 @@ HindMissilesNuclear:
 		TrailDelay: 1
 		TrailInterval: 1
 		Speed: 300
-		MinimumLaunchAngle: 30
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 30
 		ContrailLength: 10
 		ContrailStartColor: FFBB8844
@@ -1386,6 +1399,7 @@ KamovMissilesTesla:
 	Range: 5528
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Shadow: true
 		Inaccuracy: 300
@@ -1394,7 +1408,7 @@ KamovMissilesTesla:
 		TrailDelay: 1
 		TrailInterval: 1
 		Speed: 300
-		MinimumLaunchAngle: 30
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 30
 		ContrailLength: 10
 		ContrailStartColor: 88BBFF44
@@ -2058,8 +2072,9 @@ Maverick:
 	MinRange: 1180
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Acceleration: 5
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -2077,8 +2092,9 @@ TeslaMaverick:
 	Inherits@2: Maverick
 	Inherits@3: ^Effect_Tesla_Impact_RA2
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Acceleration: 5
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -2120,6 +2136,8 @@ TeslaMaverickFragment1:
 	Range: 2950
 	Report: shktrop1.aud
 	Projectile: LightningZap
+		VerticalRateOfTurn: 30
+		MinimumLaunchAngle: 128
 		-Image:
 		-TrailImage:
 	Warhead@Tesla_Heavy:
@@ -2164,6 +2182,10 @@ TeslaMaverickFragment2:
 	-Warhead@MissileAP_Medium:
 	-Warhead@Tesla_Heavy:
 
+	Projectile: LightningZap
+		VerticalRateOfTurn: 30
+		MinimumLaunchAngle: 128
+
 ThermobaricMaverick:
 	Inherits@roleflat: ^Compatibility_Thermobaric_HeavyFlat
 	Inherits@collapsewh: ^Warhead_Thermobaric_Heavy
@@ -2172,8 +2194,9 @@ ThermobaricMaverick:
 	Inherits@3: ^MediumFlameWeapon
 	Inherits@4: Maverick
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Acceleration: 5
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -2243,11 +2266,12 @@ Su57Maverick:
 	MinRange: 1580
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 750
 		Acceleration: 10
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -2271,11 +2295,12 @@ Su57MaverickThermobaric:
 	MinRange: 1580
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 750
 		Acceleration: 10
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -2689,6 +2714,9 @@ MammothTuskTargetingComputer:
 	Inherits: MammothTusk
 	ValidTargets: Ground, Water, Air
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 MammothTuskThermobaric:
 	Inherits@collapsewh: ^Warhead_Thermobaric_Heavy
 	Inherits: ^LightFlameWeapon
@@ -2706,6 +2734,7 @@ MammothTuskThermobaric:
 	Range: 6412
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: smokey
 		TrailDelay: 1
@@ -2823,6 +2852,9 @@ MammothTuskThermobaricTargetingComputer:
 	Inherits: MammothTuskThermobaric
 	ValidTargets: Ground, Water, Air
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 MammothTuskTesla:
 	Inherits@roleflat: ^Compatibility_MissileTesla_HeavyFlat
 	Inherits: ^Grenade
@@ -2837,6 +2869,7 @@ MammothTuskTesla:
 	Range: 6412
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: litning
 		TrailDelay: 1
@@ -2919,6 +2952,7 @@ MammothTuskTeslaFragment1:
 	Range: 3206
 	Report: shktrop1.aud
 	Projectile: LightningZap
+		VerticalRateOfTurn: 20
 		-Image:
 		-TrailImage:
 	Warhead@Grenade: SpreadDamage
@@ -3013,9 +3047,15 @@ MammothTuskTeslaFragment2:
 	-Warhead@TeslaExtraDamage:
 	-Warhead@TeslaWeapon:
 
+	Projectile: LightningZap
+		VerticalRateOfTurn: 20
+
 MammothTuskTeslaTargetingComputer:
 	Inherits: MammothTuskTesla
 	ValidTargets: Ground, Water, Air
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 ra120mm2:
 	Inherits@collapseflat: ^Compatibility_CannonHE_HeavyFlat
@@ -3293,6 +3333,7 @@ MammothTusk2:
 	Range: 6666
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Speed: 666
 	Warhead@LightFlameWeapon: AreaDamage
 		ValidRelationships: Ally, Neutral, Enemy
@@ -3339,6 +3380,9 @@ MammothTusk2TargetingComputer:
 	ReloadDelay: 105
 	ValidTargets: Ground, Water, Air
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 MammothTusk2Thermobaric:
 	Inherits@collapsewh: ^Warhead_Thermobaric_Heavy
 	Inherits: ^HeavyFlameWeapon
@@ -3351,6 +3395,7 @@ MammothTusk2Thermobaric:
 	Range: 6666
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: smokey
 		TrailDelay: 1
@@ -3411,6 +3456,9 @@ MammothTusk2ThermobaricTargetingComputer:
 	Inherits: MammothTusk2Thermobaric
 	ReloadDelay: 105
 	ValidTargets: Ground, Water, Air
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 MonsterTank120mm:
 	Inherits@wh: ^Warhead_CannonNuke_Heavy
@@ -3477,6 +3525,9 @@ MonsterTankTusk:
 		PercentageScale: 9998
 	-Warhead@Demolition_Heavy:
 	-Warhead@MissileHE_Heavy:
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 MonsterTankTuskTesla:
 	Inherits@roleflat: ^Compatibility_MissileTesla_HeavyFlat
 	Inherits: ^Grenade
@@ -3491,6 +3542,7 @@ MonsterTankTuskTesla:
 	Range: 7833
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: litning
 		TrailDelay: 1
@@ -3584,6 +3636,7 @@ MonsterTankTuskThermobaric:
 	Range: 7833
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: smokey
 		TrailDelay: 1
@@ -4275,6 +4328,7 @@ Nike:
 	Range: 12790
 	Report: missile1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Image: MISSILE
 		Acceleration: 6
 		AllowSnapping: true

--- a/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Allies/yaml/weapons.yaml
@@ -7,6 +7,7 @@ RA2Patriot:
 	ValidTargets: Air
 	Report: vifvatta.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 600
 		MinimumLaunchAngle: 60
 	Warhead@MissileAP_Medium:
@@ -61,6 +62,7 @@ HarrierMissiles:
 	Report: vintatta.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 333
 		Speed: 555
 		ContrailStartColor: FF884400
@@ -122,6 +124,7 @@ HarrierMissiles_elite:
 	Burst: 8
 	Range: 6666
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 444
 		Speed: 666
 		Image: red_dragon
@@ -806,6 +809,7 @@ RA2Medusa_AA:
 	BurstDelays: 13
 	ValidTargets: Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 600
 		MinimumLaunchAngle: 60
 		ContrailLength: 35
@@ -819,6 +823,9 @@ RA2MedusaAG:
 	ValidTargets: Ground, Water
 	Warhead@MissileAP_Medium:
 		ValidTargets: Ground, Water
+	Projectile: Missile
+		VerticalRateOfTurn: 30
+
 RA2M60:
 	Inherits: ^RA2SmallArms
 	ReloadDelay: 15

--- a/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Shared/yaml/weapons.yaml
@@ -1028,6 +1028,9 @@ RA2HoverMissile_AA:
 		Damage: 12000
 		PercentageScale: 9992
 
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RA2HoverMissile_AA_elite:
 	Inherits@finalmain: ^Compatibility_MissileAA_LightFlat
 	Inherits: RA2HoverMissile_elite
@@ -1039,6 +1042,9 @@ RA2HoverMissile_AA_elite:
 		Damage: 12000
 		PercentageScale: 9992
 
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RA2ThunderboltMissile:
 	Inherits@roleflat: ^Compatibility_MissileHE_LightFlat
 	Inherits@wh: ^Warhead_MissileHE_Heavy
@@ -1046,6 +1052,7 @@ RA2ThunderboltMissile:
 	Inherits@fx: ^Effect_MissileHE_Light
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Speed: 800
 		Arm: 2
 		Inaccuracy: 400
@@ -1073,6 +1080,7 @@ RA2ThunderboltMissile_elite:
 	Range: 6760
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -1084,11 +1092,17 @@ RA2ThunderboltMissile_AA:
 	ValidTargets: Air
 	Range: 8640
 
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RA2ThunderboltMissile_AA_elite:
 	Inherits: RA2ThunderboltMissile_elite
 	Report: bazook1.aud
 	ValidTargets: Air
 	Range: 9640
+
+	Projectile: Missile
+		VerticalRateOfTurn: 20
 
 RA2MultiHoverMissile:
 	Inherits@finalmain: ^Compatibility_MissileHE_LightFlat
@@ -1102,7 +1116,7 @@ RA2MultiHoverMissile:
 	Report: vifvatta.wav
 	Projectile: Missile
 		HorizontalRateOfTurn: 24
-		VerticalRateOfTurn: 24
+		VerticalRateOfTurn: 12
 		Speed: 384
 		Image: DRAGON
 		ContrailLenght: 16
@@ -1125,6 +1139,7 @@ RA2MultiHoverMissile_elite:
 	Range: 7170
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -1148,6 +1163,9 @@ RA2MultiHoverMissile_AA:
 		Damage: 4000
 		PercentageScale: 9975
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 RA2MultiHoverMissile_AA_elite:
 	Inherits@finalmain: ^Compatibility_MissileAA_LightFlat
 	Inherits: RA2MultiHoverMissile_elite
@@ -1162,6 +1180,9 @@ RA2MultiHoverMissile_AA_elite:
 		Damage: 4000
 		PercentageScale: 9975
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 RA2MultiThunderboltMissile:
 	Inherits@roleflat: ^Compatibility_MissileHE_LightFlat
 	Inherits@wh: ^Warhead_MissileHE_Heavy
@@ -1169,6 +1190,7 @@ RA2MultiThunderboltMissile:
 	Inherits@fx: ^Effect_MissileHE_Light
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Speed: 800
 		Arm: 2
 		Inaccuracy: 400
@@ -1196,6 +1218,7 @@ RA2MultiThunderboltMissile_elite:
 	Range: 7170
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -1207,11 +1230,17 @@ RA2MultiThunderboltMissile_AA:
 	ValidTargets: Air
 	Range: 9255
 
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RA2MultiThunderboltMissile_AA_elite:
 	Inherits: RA2MultiThunderboltMissile_elite
 	Report: bazook1.aud
 	ValidTargets: Air
 	Range: 10255
+
+	Projectile: Missile
+		VerticalRateOfTurn: 20
 
 RA2DepthCharge:
 	Inherits: DepthCharge
@@ -2053,6 +2082,7 @@ RA2HornetMissile:
 	MinRange: 1000
 	Report: vospatta.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 500
 		Arm: 2
 		HorizontalRateOfTurn: 32
@@ -2097,6 +2127,7 @@ MigMissiles:
 	Report: vmigatta.wav
 	ValidTargets: Ground, Water
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 400
 		Arm: 2
 		Inaccuracy: 1000
@@ -2104,7 +2135,7 @@ MigMissiles:
 		Image: d2k_missile2
 		Palette: d2keffect
 		TrailImage: large_trail
-		MinimumLaunchAngle: 25
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 125
 		MaximumLaunchSpeed: 384
 		MinimumLaunchSpeed: 384
@@ -2135,6 +2166,8 @@ MigMissiles_rad:
 	Inherits@3: MigMissiles
 	Inherits@rad: ^RA2RadShell
 	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
 		TrailImage: green_smokey
 		TrailPalette: effect
 		ContrailStartColor: 00EE00
@@ -2155,6 +2188,8 @@ MigMissiles_fire:
 	Inherits: MigMissiles
 	Inherits@fx: ^Effect_Terrorist_Explosion_RA2
 	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
 		TrailImage: red_smokey
 		TrailPalette: effect
 		ContrailStartColor: EE0000
@@ -2170,6 +2205,8 @@ MigMissiles_tesla:
 	Inherits: MigMissiles
 	Inherits@fx: ^Effect_Kirov_Tesla_RA2
 	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
 		TrailImage: blue_smokey
 		TrailPalette: effect
 		ContrailStartColor: 0000EE
@@ -2186,6 +2223,8 @@ MigMissiles_elite:
 	Range: 8600
 	Burst: 8
 	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
 		Image: red_dragon
 		TrailImage: red_smokey
 		ContrailColor: e60000
@@ -2198,15 +2237,25 @@ MigMissiles_rad_elite:
 	Range: 8600
 	Burst: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
+
 MigMissiles_fire_elite:
 	Inherits: MigMissiles_fire
 	Range: 8600
 	Burst: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
+
 MigMissiles_AA:
 	Inherits: MigMissiles
 	ValidTargets: Air
 	Projectile: Missile
+		VerticalRateOfTurn: 30
+		MinimumLaunchAngle: 25
 		Speed: 500
 		Inaccuracy: 250
 	Warhead@HeavyBombPercentage: AreaDamagePercentage
@@ -2223,6 +2272,8 @@ MigMissiles_AA_elite:
 	Inherits: MigMissiles_elite
 	ValidTargets: Air
 	Projectile: Missile
+		VerticalRateOfTurn: 30
+		MinimumLaunchAngle: 25
 		Speed: 500
 		Inaccuracy: 250
 	Warhead@HeavyBombPercentage: AreaDamagePercentage

--- a/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2/Soviets/yaml/weapons.yaml
@@ -994,6 +994,10 @@ MigMissiles_tesla_elite:
 	Range: 8600
 	Burst: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+		MinimumLaunchAngle: -128
+
 RA2MammothTusk_AA:
 	Inherits: ^RA2MediumMissile
 	ValidTargets: Air
@@ -1004,10 +1008,16 @@ RA2MammothTusk_AA:
 	Warhead@MissileAP_Medium:
 		ValidTargets: Air
 		Damage: 16000
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 RA2MammothTusk_AA_elite:
 	Inherits: RA2MammothTusk_AA
 	Range: 7100
 	Burst: 4
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 V3Launch_elite:
 	ReloadDelay: 50

--- a/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/AsianAlliance/yaml/weapons.yaml
@@ -2394,11 +2394,15 @@ AsianPelicanMissile:
 		ValidTargets: Ground, Water, Air
 		Damage: 12000
 		PercentageScale: 9992
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 AsianPelicanMissile_elite:
 	Inherits: AsianPelicanMissile
 	Range: 7100
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		TrailImage: red_smokey
 		ContrailColor: e60000
@@ -2555,6 +2559,7 @@ AsianPhoenixRocket:
 	Report: vmigatta.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: V2
 		TrailImage: ra2_smokey
 		TrailPalette: ra2effect
@@ -2577,6 +2582,7 @@ AsianPhoenixRocket_elite:
 	MinRange: 1500
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: V2
 		TrailImage: red_smokey
 		ContrailColor: e60000
@@ -2856,6 +2862,7 @@ AsianMLRS:
 	TargetActorCenter: true
 	Report: vaegatta.wav, vaegattb.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Image: DRAGON
 		Shadow: true
@@ -2927,6 +2934,9 @@ AsianSpitfireRockets:
 		PercentageScale: 2494
 	-Warhead@Demolition_Light:
 	-Warhead@MissileAP_Medium:
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 AsianKamikazeImpactTargeting:
 	ReloadDelay: 25
 	Range: 7500

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Consortium/yaml/weapons.yaml
@@ -151,6 +151,7 @@ ConsortiumMissileSystem:
 	ValidTargets: Air
 	Report: vifvatta.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 600
 		MinimumLaunchAngle: 60
 	Warhead@TeslaWeapon: SpreadDamage
@@ -209,6 +210,9 @@ ConsortiumMissileSystem_EMP:
 		ValidTargets: Air
 		Damage: 34000
 		PercentageScale: 0
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 SteelQuantumCannon:
 	Inherits@finalmain: ^Compatibility_Quantum_HeavyFlat
@@ -2384,6 +2388,9 @@ SteelHoverMissile:
 		DamageTypes: Prone75Percent, TriggerProne, ExplosionDeath
 	Warhead@Effect: CreateEffect
 		ImpactActors: false
+
+	Projectile: Missile
+		VerticalRateOfTurn: 20
 
 SteelKatyCannons:
 	Inherits@finalmain: ^Compatibility_CannonFire_HeavyFlat

--- a/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/FutureTech/yaml/weapons.yaml
@@ -135,6 +135,9 @@ Future_Cryocopter_Rocket:
 		ValidTargets: Ground, Water, Air
 		Volume: 0.5
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 Future_Cryocopter_Cryo:
 	Inherits@roleflat: ^Compatibility_Cryo_MediumFlat
 	Inherits: ^LightMissile
@@ -655,6 +658,9 @@ Future_MultiMissile:
 		ValidTargets: Ground, Water, Air
 		Damage: 8000
 		PercentageScale: 9988
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 Future_MultiMissile_Javelin:
 	Inherits@wh: ^Warhead_MissileAP_Heavy
 	Inherits@proj: ^Projectile_Missile_Heavy
@@ -674,7 +680,7 @@ Future_MultiMissile_Javelin:
 		Image: d2k_RPG
 		Shadow: true
 		HorizontalRateOfTurn: 30
-		VerticalRateOfTurn: 30
+		VerticalRateOfTurn: 16
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
@@ -773,7 +779,7 @@ Future_MultiMissile_Sigma:
 		MaximumLaunchSpeed: 256
 		MinimumLaunchSpeed: 128
 		HorizontalRateOfTurn: 24
-		VerticalRateOfTurn: 24
+		VerticalRateOfTurn: 12
 		Image: MISSILE
 		TrailImage: blue_smokey
 		ContrailLength: 12
@@ -930,7 +936,7 @@ FutureJavelinRockets:
 		Image: d2k_RPG
 		Shadow: true
 		HorizontalRateOfTurn: 30
-		VerticalRateOfTurn: 30
+		VerticalRateOfTurn: 16
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
@@ -985,14 +991,23 @@ FutureJavelinRockets_elite:
 	Range: 7000
 	Burst: 2
 	BurstDelays: 3
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 FutureJavelinRocketsDeployed:
 	Inherits: FutureJavelinRockets
 	Range: 7500
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 FutureJavelinRocketsDeployed_elite:
 	Inherits: FutureJavelinRocketsDeployed
 	Range: 8500
 	Burst: 2
 	BurstDelays: 3
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 Future_Wheel_MG:
 	Inherits@roleflat: ^Compatibility_Bullet_MediumFlat
 	Inherits: ^RA2SmallArms
@@ -1152,12 +1167,16 @@ MissileAttackRobotGun:
 		ValidTargets: Ground, Water, Air
 		Damage: 24000
 		PercentageScale: 9996
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 MissileAttackRobotGun_elite:
 	Inherits: MissileAttackRobotGun
 	Inherits@fx: ^Effect_Grey_Explosion_Medium_RA2
 	Range: 9000
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Naxis/yaml/weapons.yaml
@@ -320,6 +320,7 @@ LunarNaxiDroneMissile:
 	Report: vifvatta.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Speed: 800
 		Arm: 2
 		Inaccuracy: 400
@@ -327,7 +328,7 @@ LunarNaxiDroneMissile:
 		Image: d2k_missile2
 		Palette: d2keffect
 		TrailImage: large_trail
-		MinimumLaunchAngle: 25
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 125
 		MaximumLaunchSpeed: 400
 		MinimumLaunchSpeed: 400
@@ -1133,8 +1134,9 @@ NaxPlaneRockets_elite:
 	Range: 6090
 	Report: missile7.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Acceleration: 5
-		MinimumLaunchAngle: 128
+		MinimumLaunchAngle: -128
 		MaximumLaunchAngle: 128
 		Image: d2k_RPG
 		Palette: d2keffect
@@ -1167,6 +1169,10 @@ NaxInterceptorRockets:
 		ValidTargets: Air
 		Damage: 20000
 		PercentageScale: 9995
+
+	Projectile: Missile
+		VerticalRateOfTurn: 30
+		MinimumLaunchAngle: 128
 
 NaxiInterceptorGun:
 	Inherits@collapseflat: ^Compatibility_Bullet_MediumFlat

--- a/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/SchwarzerMond/yaml/weapons.yaml
@@ -867,6 +867,7 @@ NaxCorrosionRocket:
 	SoundVolume: 2.0
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 600
 		Speed: 600
 		Image: red_dragon
@@ -1077,6 +1078,9 @@ NaxCorrosionRocketTrooper_elite:
 		PercentageScale: 0
 		FriendlyFireDamage: 75
 		FriendlyFireSpread: 75
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 NaxCorrosionBeast:
 	Inherits: NaxCorrosionRocket
 	Range: 7984
@@ -1084,6 +1088,7 @@ NaxCorrosionBeast:
 	Burst: 8
 	BurstDelays: 2
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 400
 
 	MinRange: 1595
@@ -1091,6 +1096,9 @@ NaxCorrosionBeast_elite:
 	Inherits: NaxCorrosionBeast
 	Range: 8984
 	Burst: 16
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 NaxCrystalLeech:
 	Inherits@wh: ^Warhead_Tesla_Heavy
@@ -2425,3 +2433,5 @@ Naxis_Komet_AA:
 	ValidTargets: Air
 	Range: 11740
 	MinRange: 2350
+	Projectile: Missile
+		VerticalRateOfTurn: 16

--- a/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/Syndicate/yaml/weapons.yaml
@@ -244,6 +244,7 @@ RA2FreedomRocket:
 	Report: vaegatta.wav, vaegattb.wav
 	ValidTargets: Ground, Water, Air, Garrisoned
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 800
 		MinimumLaunchAngle: 60
 		ContrailLength: 35
@@ -274,6 +275,7 @@ RA2FreedomRocket_elite:
 	Inherits: RA2FreedomRocket
 	Range: 8130
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -723,6 +725,7 @@ RA2LarsRocket:
 	Report: vmigatta.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 1000
 		Arm: 2
 		Inaccuracy: 50
@@ -809,6 +812,7 @@ LatinRusherRocket:
 	Report: vaegatta.wav, vaegattb.wav
 	InvalidTargets: Infantry
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 800
 		MinimumLaunchAngle: 60
 		ContrailLength: 35
@@ -818,6 +822,7 @@ LatinRusherRocket_elite:
 	Inherits: LatinRusherRocket
 	Range: 6031
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -940,6 +945,7 @@ LatinSmokerRocket:
 	Report: vaegatta.wav, vaegattb.wav
 	InvalidTargets: Infantry
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 800
 		MinimumLaunchAngle: 60
 		ContrailLength: 35
@@ -949,6 +955,7 @@ LatinSmokerRocket_elite:
 	Inherits: LatinSmokerRocket
 	Range: 7550
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -2025,11 +2032,15 @@ RA2APCRocket_AA:
 	ValidTargets: Air
 	Range: 8610
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 RA2APCRocket_AA_elite:
 	Inherits: RA2APCRocket_AA
 	Range: 9610
 	Burst: 8
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: red_dragon
 		TrailImage: red_smokey
 		ContrailColor: e60000

--- a/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/RedAlert2Mod/TKM/yaml/weapons.yaml
@@ -105,6 +105,9 @@ HueyMissiles:
 	Report: bazook1.aud
 	Warhead@MissileAP_Medium:
 		Damage: 8000
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 tkmtechnicalmgap:
 	Inherits: tkmjuggap
 	ValidTargets: Ground, Water
@@ -118,9 +121,15 @@ tkmtwinrockets:
 	Report: bazook1.aud
 	Warhead@MissileAP_Light:
 		Damage: 18000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 tkmtwinrocketstechnicaltank:
 	Inherits: tkmtwinrockets
 	Range: 5243
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 tkmfirerockets:
 	Inherits: ^Warhead_MissileAP_Light
 	Inherits@2: ^Warhead_Flame_Light
@@ -285,6 +294,9 @@ tkmrockets:
 	Report: bazook1.aud
 	Warhead@MissileAP_Light:
 		Damage: 18000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 as42rockets:
 	Inherits@wh: ^Warhead_MissileAP_Light
 	Inherits@proj: ^Projectile_Missile_Light
@@ -293,6 +305,7 @@ as42rockets:
 	Range: 6379
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 	Warhead@MissileAP_Light:
 		Damage: 20000
 tkmcryorockets:
@@ -303,6 +316,7 @@ tkmcryorockets:
 	Range: 6214
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		TrailImage: blue_smokey
 		TrailInterval: 1
 		ContrailStartColor: 77CCFF
@@ -479,6 +493,9 @@ tkmstrykerrockets:
 	Warhead@MissileAP_Medium:
 		Damage: 24000
 		ValidTargets: Ground, Water, Air
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 tkmstrykercryorockets:
 	Inherits@wh: ^Warhead_MissileAP_Light
 	Inherits@proj: ^Projectile_Missile_Light
@@ -572,6 +589,7 @@ HueyCryoMissiles:
 	MinRange: 1105
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailImage: blue_smokey
 		TrailInterval: 1
 		ContrailStartColor: 77CCFF
@@ -640,6 +658,9 @@ HueyTwinMissiles:
 		ValidTargets: Ground, Water, Air
 		Damage: 6000
 		PercentageScale: 9984
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 sandmarinemortar:
 	Inherits@finalmain: ^Compatibility_Demolition_HeavyFlat
 	Inherits: ^Warhead_Demolition_Heavy
@@ -1221,6 +1242,7 @@ tkmstrykerfirerockets:
 	Report: bazook1.aud
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailInterval: 1
 		TrailDelay: 0
 	Warhead@MissileAP_Medium:

--- a/mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/StarCraft/Terran/yaml/weapons.yaml
@@ -186,6 +186,7 @@ CycloneRockets:
 	ValidTargets: Ground, Water, Air
 	TargetActorCenter: true
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Blockable: false
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250
@@ -219,6 +220,9 @@ CycloneRocketsLockOn:
 	Inherits: CycloneRockets
 	ValidTargets: lockon
 	Range: 10000
+
+	Projectile: Missile
+		VerticalRateOfTurn: 40
 
 MarauderMissiles:
 	Inherits@collapseflat: ^Compatibility_MissileAP_MediumFlat
@@ -340,6 +344,7 @@ SCTyrAA:
 	Range: 7156
 	Report: vintatta.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 400
 		Arm: 2
 		Inaccuracy: 800
@@ -1126,7 +1131,7 @@ GoliathMk2Rockets:
 		Arm: 0
 		Shadow: true
 		HorizontalRateOfTurn: 30
-		VerticalRateOfTurn: 30
+		VerticalRateOfTurn: 16
 		HomingActivationDelay: 2
 		PointDefenseTypes: Missile
 		ContrailZOffset: 4000
@@ -1278,6 +1283,7 @@ SunDogRockets:
 	Range: 6060
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		MinimumLaunchAngle: -128
 		Blockable: false
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250
@@ -1371,6 +1377,7 @@ WyvernRockets:
 	Burst: 4
 	BurstDelays: 15
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250
@@ -1736,6 +1743,7 @@ MissileTurret:
 	Range: 11626
 	ValidTargets: Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Blockable: false
 		MaximumLaunchSpeed: 250
 		MinimumLaunchSpeed: 250

--- a/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/GDI/yaml/weapons.yaml
@@ -432,6 +432,9 @@ M1A1Missiles:
 	Warhead@Effect: CreateEffect
 		Explosions: small_frag
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 M1A1MissilesAMT:
 	Inherits: M1A1Missiles
 	Inherits@2: ^AMTProjectile
@@ -483,6 +486,7 @@ MammothMissiles:
 	Range: 6141
 	Report: rocket1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: DRAGON
 	Warhead@MissileAP_Heavy:
 		Damage: 8000
@@ -497,6 +501,9 @@ MammothMissilesAMT:
 227mmAMT:
 	Inherits: 227mm
 	Inherits@2: ^AMTProjectile
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 OrcaMissiles:
 	Inherits@collapsewh: ^Warhead_MissileHE_Heavy
@@ -564,9 +571,15 @@ OrcaMissiles:
 		Damage: 12000
 		PercentageScale: 0
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 OrcaMissilesAMT:
 	Inherits: OrcaMissiles
 	Inherits@2: ^AMTProjectile
+
+	Projectile: Missile
+		MinimumLaunchAngle: -128
 
 Vulcan:
 	Inherits@wh: ^Warhead_Bullet_Medium
@@ -711,6 +724,7 @@ TowerMissile:
 	Range: 8772
 	Report: rocket2.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Acceleration: 5
 		AllowSnapping: true
 		CloseEnough: 500
@@ -800,6 +814,9 @@ TowerMissile:
 TowerMissileAMT:
 	Inherits: TowerMissile
 	Inherits@2: ^AMTProjectile
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 MissileSoldierWeapon:
 	Inherits@collapsewh: ^Warhead_MissileAP_Heavy
@@ -1179,6 +1196,9 @@ RocketsHumvee2_AA:
 	ValidTargets: Air
 	Warhead@MissileAP_Light:
 		ValidTargets: Air
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 RocketsHumvee2AMT:
 	Inherits@finalmain: ^Compatibility_MissileAP_HeavyFlat
 	Inherits@wh: ^Warhead_MissileAP_Heavy
@@ -1208,6 +1228,9 @@ RocketsHumvee2AMT_AA:
 		ValidTargets: Air
 		Damage: 32000
 		PercentageScale: 9997
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 TDShotgun:
 	Inherits@collapsewh: ^Warhead_Bullet_Medium
 	Inherits@collapseexplosive: ^Warhead_Concussion_Medium
@@ -1291,6 +1314,9 @@ GDIPredatorTankMissiles:
 	Warhead@Effect: CreateEffect
 		Explosions: small_frag
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 GDIPredatorTankMissilesAMT:
 	Inherits: GDIPredatorTankMissiles
 	Inherits@2: ^AMTProjectile
@@ -1364,6 +1390,7 @@ MammothTank3Missiles:
 	Range: 6340
 	Report: rocket1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Image: DRAGON
 	Warhead@MissileAP_Heavy:
 		Damage: 12000
@@ -1552,6 +1579,7 @@ GDIRigMissilePod:
 	TargetActorCenter: true
 	Report: rocket1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Image: DRAGON
 		Shadow: true
@@ -1578,6 +1606,9 @@ GDIRigMissilePod:
 GDIRigMissilePodAMT:
 	Inherits: GDIRigMissilePod
 	Inherits@2: ^AMTProjectile
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 CommandoSniper:
 	Inherits@wh: ^Warhead_Bullet_Heavy
@@ -1666,6 +1697,7 @@ CommandoRocketLauncher:
 	ReloadDelay: 100
 	Range: 7750
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		TrailImage: blue_smokey
 		TrailInterval: 1
 		Image: bhreddragon

--- a/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianDawn/Nod/yaml/weapons.yaml
@@ -255,6 +255,7 @@ BikeRockets:
 	Range: 6000
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 	Warhead@TankDestroyerCannon: SpreadDamage
@@ -323,6 +324,9 @@ LTNKMissiles:
 	Warhead@Effect: CreateEffect
 		Explosions: small_frag
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 HonestJohn:
 	Inherits@wh: ^Warhead_MissileFire_Heavy
 	Inherits@fx: ^Effect_Flame_Heavy
@@ -372,9 +376,13 @@ StealthTankMissiles:
 		Explosions: small_poof
 		ImpactSounds: xplobig4.aud
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 StealthTankMissilesBlackMarket:
 	Inherits: StealthTankMissiles
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: d2k_missile2
 		Palette: d2keffect
 		TrailImage: large_trail
@@ -444,6 +452,9 @@ HeliMissiles:
 	Warhead@MissileAP_Medium:
 		ValidTargets: Ground, Water, Air
 		Damage: 2000
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TurretGun:
 	Inherits@collapsewh: ^Warhead_Concussion_Medium
 	Inherits: ^ShrapnelWeapon
@@ -520,7 +531,7 @@ Dragon:
 		AllowSnapping: true
 		Shadow: true
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		TrailImage: smokey
 		TrailInterval: 1
 		MaximumLaunchSpeed: 200
@@ -627,6 +638,7 @@ ChemRockets:
 	Range: 6006
 	Report: bazook1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		TrailImage: spittrail
 	Warhead@GrenadePercentage: AreaDamagePercentage
 		ValidTargets: Ground, Water, Air
@@ -677,6 +689,9 @@ ChemRocketsExplosion:
 		AddsResourceType: Tiberium
 		Size: 0,0
 
+	Projectile: Missile
+		VerticalRateOfTurn: 40
+
 ChemicalBikeRockets:
 	Inherits@collapsewh: ^Warhead_MissileChem_Medium
 	Inherits: ^TankDestroyerCannon
@@ -690,6 +705,7 @@ ChemicalBikeRockets:
 	Range: 6000
 	Report: missile6.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailImage: spittrail
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
@@ -732,6 +748,9 @@ ChemicalBikeRocketsExplosion:
 		AddsResourceType: Tiberium
 		Size: 0,0
 
+	Projectile: Missile
+		VerticalRateOfTurn: 30
+
 ChemicalStealthTankMissiles:
 	Inherits@collapsewh: ^Warhead_MissileChem_Medium
 	Inherits: ^ShrapnelWeapon
@@ -742,6 +761,7 @@ ChemicalStealthTankMissiles:
 	Range: 6962
 	Report: rocket2.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Image: MISSILE
 		TrailImage: spittrail
 	Warhead@ShrapnelWeaponPercentage: AreaDamagePercentage
@@ -781,6 +801,9 @@ ChemicalStealthTankExplosion:
 	Warhead@Resource: CreateResource
 		AddsResourceType: Tiberium
 		Size: 1,1
+
+	Projectile: Missile
+		VerticalRateOfTurn: 30
 
 ChemicalHonestJohn:
 	Inherits@collapsewh: ^Warhead_MissileChem_Heavy
@@ -1061,6 +1084,9 @@ LightTank2Missiles:
 	Warhead@Effect: CreateEffect
 		Explosions: small_frag
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 PDLaserLTNK2:
 	Inherits: PDLaser
 	Range: 4903
@@ -1232,6 +1258,7 @@ BHRedDarts:
 	ValidTargets: Ground, Water, Air
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailImage: red_smokey
 		Image: bhreddragon
 		ContrailLength: 8
@@ -1604,7 +1631,7 @@ CorvetteDragon:
 		Speed: 500
 		HorizontalRateOfTurn: 50
 		MinimumLaunchAngle: 50
-		VerticalRateOfTurn: 50
+		VerticalRateOfTurn: 24
 		Acceleration: 5
 		AllowSnapping: true
 		CloseEnough: 500

--- a/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/weapons.yaml
@@ -322,6 +322,9 @@ TSHellfireTwin:
 		ValidTargets: Ground, Water, Air
 		Damage: 24000
 		PercentageScale: 0
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSCABALEnlightedLaser:
 	Inherits@collapsewh: ^Warhead_Laser_Heavy
 	Inherits@collapseextra: ^Compatibility_Laser_ExtraDamage

--- a/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Forgotten/yaml/weapons.yaml
@@ -775,6 +775,7 @@ TSChemBazooka:
 	Range: 6694
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		TrailImage: spittrail
 	Warhead@MissileChem_Light:
 		Damage: 30000
@@ -982,7 +983,7 @@ TSMammothTusk:
 	Projectile: Missile
 		Speed: 500
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		MinimumLaunchAngle: 75
 		Acceleration: 5
 		AllowSnapping: true
@@ -1020,6 +1021,9 @@ TSRuinerMissile:
 		ValidTargets: Ground, Water, Air
 		Damage: 36000
 		PercentageScale: 9998
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSChemRuinerMissile:
 	Inherits@collapsewh: ^Warhead_MissileChem_Medium
 	Inherits: ^LightChemicalWeapon
@@ -1030,6 +1034,7 @@ TSChemRuinerMissile:
 	ReloadDelay: 50
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 		TrailImage: spittrail
@@ -1088,6 +1093,9 @@ TSApacheMissile:
 	Warhead@ShieldHit:
 		Duration: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSChemApacheMissile:
 	Inherits@wh: ^Warhead_MissileChem_Medium
 	Inherits@proj: ^Projectile_Missile_Medium
@@ -1098,6 +1106,7 @@ TSChemApacheMissile:
 	Range: 4688
 	Report: orcamis1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailImage: spittrail
 	Warhead@MissileChem_Medium:
 		Damage: 36000
@@ -1165,6 +1174,9 @@ TSCobraMissile:
 	Warhead@ShieldHit:
 		Duration: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSChemCobraMissile:
 	Inherits@wh: ^Warhead_MissileChem_Medium
 	Inherits@proj: ^Projectile_Missile_Medium
@@ -1175,6 +1187,7 @@ TSChemCobraMissile:
 	Range: 5052
 	Report: orcamis1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		TrailImage: spittrail
 	Warhead@MissileChem_Medium:
 		Damage: 36000
@@ -1252,6 +1265,9 @@ TSAdatsMissile_AA:
 		Damage: 8000
 		PercentageScale: 9988
 		ValidTargets: Air
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 MutFlamer:
 	Inherits@wh: ^Warhead_Flame_Medium
 	Inherits@proj: ^Projectile_Flame_Medium

--- a/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/GDI/yaml/weapons.yaml
@@ -545,6 +545,9 @@ PitbullRockets:
 	Report: rketinf1.aud
 	Warhead@MissileAP_Light:
 		Damage: 20000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 TSHoverMissile:
 	Inherits@collapsewh: ^Warhead_MissileHE_Medium
 	Inherits: ^FlakWeapon
@@ -560,7 +563,7 @@ TSHoverMissile:
 		RangeLimit: 22c512
 		HorizontalRateOfTurn: 20
 		Inaccuracy: 32
-		VerticalRateOfTurn: 20
+		VerticalRateOfTurn: 12
 	Warhead@FlakWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 4000
@@ -606,7 +609,7 @@ TSDestroyerMissiles:
 		RangeLimit: 22c512
 		HorizontalRateOfTurn: 20
 		Inaccuracy: 32
-		VerticalRateOfTurn: 20
+		VerticalRateOfTurn: 12
 	Warhead@FlakWeapon: SpreadDamage
 		ValidTargets: Ground, Water, Air
 		Damage: 4000
@@ -645,7 +648,7 @@ TSMammothTusk2:
 	Projectile: Missile
 		Speed: 500
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		MinimumLaunchAngle: 75
 		Acceleration: 5
 		AllowSnapping: true
@@ -670,7 +673,7 @@ TSMammothTusk2II_AA:
 	Projectile: Missile
 		Speed: 500
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		MinimumLaunchAngle: 75
 		Acceleration: 5
 		AllowSnapping: true
@@ -715,6 +718,9 @@ TSZoneHellfire:
 	ReloadDelay: 28
 	Range: 6138
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSZoneHellfireSonic:
 	Inherits: TSZoneHellfire
 	Inherits@wh: ^Warhead_Sonic_Heavy
@@ -740,7 +746,7 @@ TSGDIRedEye:
 	Projectile: Missile
 		Speed: 500
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		MinimumLaunchAngle: 75
 		Acceleration: 5
 		AllowSnapping: true

--- a/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/TiberianSun/Nod/yaml/weapons.yaml
@@ -112,6 +112,7 @@ TSTibBazooka:
 	Range: 6694
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		TrailImage: spittrail
 	Warhead@MissileChem_Light:
 		Damage: 30000
@@ -147,6 +148,7 @@ TSStankTusk:
 	ReloadDelay: 60
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 	Warhead@MissileHE_Medium:
@@ -173,6 +175,7 @@ TSSBoatTusk:
 	ReloadDelay: 60
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 	Warhead@MissileHE_Medium:
@@ -202,6 +205,7 @@ TSStankTibTusk:
 	ReloadDelay: 60
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 		TrailImage: spittrail
@@ -248,7 +252,7 @@ TSNODRedEye:
 	Projectile: Missile
 		Speed: 500
 		HorizontalRateOfTurn: 25
-		VerticalRateOfTurn: 25
+		VerticalRateOfTurn: 12
 		MinimumLaunchAngle: 75
 		Acceleration: 5
 		AllowSnapping: true
@@ -263,6 +267,7 @@ TSNODRedEye:
 TSNODTibRedEye:
 	Inherits: TSNODRedEye
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		TrailImage: spittrail
 	Warhead@MissileAP_Heavy:
 		Damage: 18000

--- a/mods/cameo/weapons/d2k.yaml
+++ b/mods/cameo/weapons/d2k.yaml
@@ -319,6 +319,7 @@ D2K_Rocket_AA:
 	ValidTargets: Air
 	ReloadDelay: 30
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Blockable: false
 		Speed: 300
 		Inaccuracy: 96
@@ -358,7 +359,7 @@ D2K_Rocket_Trooper:
 		MaximumLaunchSpeed: 222
 		MinimumLaunchSpeed: 222
 		HorizontalRateOfTurn: 22
-		VerticalRateOfTurn: 22
+		VerticalRateOfTurn: 12
 		Acceleration: 6
 	Warhead@MissileAP_Light:
 		ValidTargets: Ground, Water, Air
@@ -464,6 +465,7 @@ D2K_Rocket_ultimate:
 	Inherits: D2K_Bazooka2
 	Burst: 1
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		RangeLimit: 36c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
@@ -474,6 +476,9 @@ D2K_Rocket_Fremen:
 	InvalidTargets: Infantry
 
 	MinRange: 1280
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 mtank_pri:
 	Inherits: ^D2KMissile
 	ReloadDelay: 150
@@ -482,6 +487,7 @@ mtank_pri:
 	Range: 10240
 	ValidTargets: Ground, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		RangeLimit: 30c0
 		HorizontalRateOfTurn: 100
 	Warhead@1Dam: SpreadDamage
@@ -1582,6 +1588,8 @@ ixian_airdrone:
 	Burst: 4
 	BurstDelays: 5
 	Projectile: Missile
+		VerticalRateOfTurn: 12
+		MinimumLaunchAngle: -128
 		HorizontalRateOfTurn: 40
 		RangeLimit: 24000
 		Speed: 800

--- a/mods/cameo/weapons/outpost2.yaml
+++ b/mods/cameo/weapons/outpost2.yaml
@@ -367,6 +367,9 @@ eden_EMP_AA:
 	MinRange: 1650
 	ValidTargets: Air
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 edenTiger_EMP:
 	Inherits: eden_EMP
 	ReloadDelay: 41
@@ -378,6 +381,9 @@ edenTiger_EMP_AA:
 	Range: 9000
 	MinRange: 1800
 	ValidTargets: Air
+
+	Projectile: Missile
+		VerticalRateOfTurn: 12
 
 eden_GP_EMP:
 	Inherits: plymouth_EMP
@@ -463,6 +469,7 @@ plymouthRPG:
 	Report: bazook1.aud
 	ValidTargets: Ground, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 12
 		Arm: 0
 		Blockable: false
 		Inaccuracy: 128
@@ -501,12 +508,18 @@ plymouthTigerRPG:
 	Inherits: plymouthRPG
 	ReloadDelay: 40
 
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 plymouthDefenceRPG:
 	Inherits: plymouthRPG
 	Range: 7168
 	ReloadDelay: 50
 
 	MinRange: 1435
+	Projectile: Missile
+		VerticalRateOfTurn: 12
+
 plymouthSticky:
 	Inherits@collapsewh: ^Warhead_Chemical_Light
 	Inherits: ^LightChemicalWeapon

--- a/mods/cameo/weapons/redalert2mod.yaml
+++ b/mods/cameo/weapons/redalert2mod.yaml
@@ -345,6 +345,7 @@ SteelHoverMissile_elite:
 	Range: 7000
 	Burst: 4
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		Image: red_dragon
 		Shadow: true
 		TrailImage: red_smokey
@@ -402,6 +403,7 @@ SteelTwisterMissiles:
 	Report: twisterfire.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 500
 	Warhead@Grenade: SpreadDamage
 		ValidTargets: Ground, Water, Air
@@ -469,6 +471,7 @@ SteelTwisterMissiles_elite:
 	Range: 6000
 	Burst: 10
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Inaccuracy: 600
 		Image: red_dragon
 		TrailImage: red_smokey
@@ -1320,6 +1323,7 @@ LatinBuggyRocket:
 	Report: vintatta.wav
 	ValidTargets: Ground, Water, Air
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Speed: 480
 		Arm: 2
 		Inaccuracy: 120
@@ -1459,6 +1463,9 @@ LatinBuggyRocket_elite:
 	Range: 7000
 	Burst: 2
 	BurstDelays: 3
+
+	Projectile: Missile
+		VerticalRateOfTurn: 16
 
 12MissilesActivate:
 	Warhead@1Dam: FireFragment

--- a/mods/cameo/weapons/tiberiandawn.yaml
+++ b/mods/cameo/weapons/tiberiandawn.yaml
@@ -69,6 +69,9 @@ Rockets:
 	Report: bazook1.aud
 	Warhead@MissileAP_Light:
 		Damage: 18000
+	Projectile: Missile
+		VerticalRateOfTurn: 20
+
 Flamethrower:
 	Inherits@wh: ^Warhead_Flame_Light
 	Inherits@proj: ^Projectile_Flame_Light
@@ -188,6 +191,7 @@ FlametankExplode:
 	TargetActorCenter: true
 	Report: rocket1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		Blockable: false
 		Image: DRAGON
 		Shadow: true

--- a/mods/cameo/weapons/tiberiansun.yaml
+++ b/mods/cameo/weapons/tiberiansun.yaml
@@ -878,11 +878,15 @@ TSBazooka:
 	ReloadDelay: 52
 	Range: 6694
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 	Warhead@MissileAP_Light:
 		Damage: 24000
 TSBazookaG:
 	Inherits: TSBazooka
 	Range: 9216
+
+	Projectile: Missile
+		VerticalRateOfTurn: 40
 
 TSReaperTusk:
 	Inherits: ^TSDefaultMissile
@@ -933,6 +937,7 @@ TSAegisMissile:
 	Range: 9216
 	Report: vaegatta.wav, vaegattb.wav
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		RangeLimit: 18c0
 	-Warhead@MediumMissile:
 	-Warhead@LightMissile:
@@ -952,6 +957,9 @@ TSMammothTusk_elite:
 	Burst: 8
 	Range: 9216
 
+	Projectile: Missile
+		VerticalRateOfTurn: 25
+
 TSBikeMissile:
 	Inherits@finalmain: ^Compatibility_MissileHE_MediumFlat
 	Inherits@wh: ^Warhead_MissileHE_Light
@@ -964,6 +972,7 @@ TSBikeMissile:
 	ReloadDelay: 40
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 	Warhead@MissileHE_Medium:
@@ -987,6 +996,7 @@ TSBikeTibMissile:
 	ReloadDelay: 40
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 16
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 		TrailImage: spittrail
@@ -1039,6 +1049,7 @@ TSSAPCMissiles:
 	ReloadDelay: 18
 	Report: misl1.aud
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 	Warhead@Grenade: SpreadDamage
@@ -1071,6 +1082,7 @@ TSSAPCCoreMissiles:
 	Inherits@fx: ^Effect_Chem_Light
 	Inherits: TSSAPCMissiles
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 		TrailImage: spittrail
@@ -1115,6 +1127,9 @@ TSHellfire:
 	Warhead@ShieldHit:
 		Duration: 8
 
+	Projectile: Missile
+		VerticalRateOfTurn: 16
+
 TSRedEye2:
 	Inherits: Dragon
 	Report: rocket2.aud
@@ -1122,6 +1137,9 @@ TSRedEye2:
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: expnew13.aud
 		ImpactActors: false
+
+	Projectile: Missile
+		VerticalRateOfTurn: 25
 
 TSChemAdatsMissile:
 	Inherits@collapsewh: ^Warhead_MissileChem_Light
@@ -1169,6 +1187,7 @@ TSChemAdatsMissile:
 TSChemAdatsMissileAA:
 	Inherits: TSAdatsMissile_AA
 	Projectile: Missile
+		VerticalRateOfTurn: 20
 		MinimumLaunchAngle: 75
 		MaximumLaunchAngle: 75
 		TrailImage: spittrail


### PR DESCRIPTION
Conventional anti-air missiles can cruise horizontally before climbing sharply, while some aircraft missiles inherit an upward launch restriction even when attacking ground targets. This extends the Patriot correction from #332 to 203 missile weapons across 29 YAML files, bringing terminal steering forward and allowing downward launch for 23 aircraft-only weapons, including the Ixian Air Drone.

- Covers 152 ground-launcher weapons, 50 aircraft weapons and one shared weapon. Twenty-two descendant overrides preserve unselected inherited behavior; generic projectile templates and deliberate special flight profiles remain unchanged.
- Only vertical turning and minimum launch angle change. Damage, speed, horizontal steering, reload, burst, targeting, effects and audio remain unchanged. Some dual-purpose ground weapons also change their ground-to-ground flight.
- This changes simulated flight, not just rendering. Hit efficiency may change; the maintainer accepts that tradeoff for the improved appearance. This is guided missile tuning, not a new ballistic projectile model.

Validation: independently compared all 2,896 resolved weapon definitions and confirmed exactly the 203 declared behavioral changes; engine loading of the modified default rules passed; diff whitespace checks passed. The maintainer approved automatic Nod SAM, Ixian Air Drone and Patriot A/B comparisons. This is representative visual coverage, not all-weapon gameplay testing or measured damage-efficiency parity.

The included audit Markdown and JSON record every changed field and preservation override. The local comparison map is not included in this production change. No engine or pin changes are required.