### PR TITLE
Fail closed when warhead audit source coverage is incomplete

### DIFF
--- a/tools/audit/audit_dead_warhead_fields.py
+++ b/tools/audit/audit_dead_warhead_fields.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """audit_dead_warhead_fields.py — yaml keys the engine SILENTLY THROWS AWAY.
 
-    python tools/audit/audit_dead_warhead_fields.py [--json out.json]
+    python tools/audit/audit_dead_warhead_fields.py [--root REPO] [--engine-root DIR]
+                                                    [--json out.json]
 
 ⛔ WHY THIS EXISTS (2026-08-22). 2059 `Warhead@…Percentage` nodes across 1284 weapons carry a
 `Falloff:` line — on `HealthPercentageDamage`, a type that HAS NO SUCH FIELD. 104 more carry
@@ -15,14 +16,29 @@ the leftover yaml keys. Warheads load through `Load` (`WeaponInfo.LoadWarheads`,
 WeaponInfo.cs:178), so a misplaced field is discarded in silence. The linter (`--check-yaml`)
 swaps the action and would catch it — it is not part of `run_all.sh`.
 
-HOW: parse every `*Warhead.cs` in every assembly, resolve the inheritance chain, and compare
+HOW: parse every `*.cs` in the mod's six assemblies, resolve the inheritance chain, and compare
 each resolved warhead node's keys against the fields its type actually owns. Assembly
 precedence follows mod.yaml (AS, CA, Cameo, Cnc, D2k, Common), so a shadowed type resolves the
-way `ObjectCreator.FindType` resolves it.
+way `ObjectCreator.FindType` resolves it. Source locations: CA and Cameo are vendored at the
+REPOSITORY ROOT; AS, Cnc, D2k and Common live in the engine checkout (`<root>/engine`, or
+`--engine-root` when running from a worktree that has no engine/ of its own).
 
-EXIT CODE: 1 above the RATCHET. A discarded field is never intentional, but the tree starts
-with a known backlog, so DEAD_FIELD_BASELINE holds today's count and may only ever FALL. Lower
-it as each kind is fixed; never raise it to make the suite green.
+⚠ THIS IS A LINE-REGEX PARSER, NOT A C# COMPILER. It reads class declarations and public
+instance field declarations line by line. Concrete-type precedence follows mod.yaml assembly
+order, but inherited bases are bound by UNQUALIFIED class name: namespace resolution,
+preprocessor/`#if` handling, partial classes spread over files and everything else a compiler
+does are beyond it, and it does NOT claim to detect every construct it cannot parse. What it
+cannot verify it says so: a warhead type absent from the scanned sources, a chain broken at
+an unknown base, an inheritance cycle, a base that continues on the next line, an unreadable
+source file or a missing assembly all make the run INCOMPLETE instead of "every field is read".
+
+EXIT CODES:
+    0  complete, trustworthy scan — dead kinds within the ratchet (OK, or WARN below it)
+    1  complete, trustworthy scan — dead kinds above the RATCHET (lower-only; never raise)
+    2  INCOMPLETE — schema coverage is partial (see above). Dead-field diagnostics found so
+       far are still printed, but `--json` is NOT rewritten: any previous file is preserved
+       so a partial run can never masquerade as a current result. Only a completed
+       trustworthy scan writes the mapping — including `{}` when nothing is dead.
 """
 from __future__ import annotations
 
@@ -39,50 +55,83 @@ if hasattr(sys.stdout, "reconfigure"):          # Windows consoles default to cp
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from cameo_model import Model  # noqa: E402
 
+EXIT_OK = 0
+EXIT_RATCHET = 1
+EXIT_INCOMPLETE = 2
+
 # Distinct (warhead type, dead field) pairs present when this audit was written (2026-08-22).
 # ⚠ RATCHET — LOWER ONLY. Raising it hides a field the engine is throwing away.
 DEAD_FIELD_BASELINE = 15
 
 # mod.yaml `Assemblies:` order — first hit wins, exactly like ObjectCreator.FindType.
-ASSEMBLY_DIRS = [
-    ("AS", "engine/OpenRA.Mods.AS"),
-    ("CA", "OpenRA.Mods.CA"),
-    ("Cameo", "OpenRA.Mods.Cameo"),
-    ("Cnc", "engine/OpenRA.Mods.Cnc"),
-    ("D2k", "engine/OpenRA.Mods.D2k"),
-    ("Common", "engine/OpenRA.Mods.Common"),
+# location "repo" = vendored at the repository root (NOT under engine/ — that trap cost
+# audit_unique_traits 14 trait types, see LESSONS_LEARNED 2026-08-23); "engine" = in the
+# engine checkout, rooted at <root>/engine by default or --engine-root when given.
+ASSEMBLY_DIRS: list[tuple[str, str, str]] = [
+    ("AS", "engine", "OpenRA.Mods.AS"),
+    ("CA", "repo", "OpenRA.Mods.CA"),
+    ("Cameo", "repo", "OpenRA.Mods.Cameo"),
+    ("Cnc", "engine", "OpenRA.Mods.Cnc"),
+    ("D2k", "engine", "OpenRA.Mods.D2k"),
+    ("Common", "engine", "OpenRA.Mods.Common"),
 ]
+ASSEMBLY_ORDER = [name for name, _loc, _sub in ASSEMBLY_DIRS]
 
-CLASS_RE = re.compile(r"^\s*(?:public|internal)\s+(?:abstract\s+|sealed\s+)?class\s+(\w+)\s*:\s*([\w<>, .]+)")
+# Bases OUTSIDE the scanned assemblies that are known to contribute no serialisable fields,
+# so a chain ending there is COMPLETE:
+#   object / System.Object — the C# root type
+#   IWarhead               — OpenRA.Game/Traits/TraitsInterfaces.cs:563, an interface, and
+#                            C# interfaces cannot declare instance fields
+# (The other concrete bases in the warhead chains — Warhead and WarheadAS — live in the
+# scanned assemblies: OpenRA.Mods.Common/Warheads/Warhead.cs and
+# OpenRA.Mods.AS/Warheads/WarheadAS.cs.)
+# ANY other unknown base means the chain broke mid-way: the field set collected so far may
+# be missing inherited fields, so the type is reported incomplete, never trusted.
+SAFE_TERMINAL_BASES = {"object", "system.object", "iwarhead"}
+
+# Sentinel base for a class whose `: Base` list continues on the NEXT line — the line
+# parser cannot read it, so the chain must stop here as INCOMPLETE (never as "no base",
+# which would wrongly pass as a valid terminal and hide the missing inherited fields).
+UNPARSED_BASE = "<base-continues-on-next-line>"
+
+CLASS_RE = re.compile(
+    r"^\s*(?:public|internal)\s+(?:abstract\s+|sealed\s+)?class\s+(\w+)(?:\s*:\s*([\w<>, .]+))?")
 # ⚠ NOT just `public readonly` — FieldLoader loads any public instance field, and some AS
 # warheads declare mutable ones (CreateTintedCellsWarhead: `public int Level = 100;`).
 # Matching only readonly fields reported 45 live radiation settings as dead.
 # Requires the declaration to end in `=` or `;` so methods and properties are excluded.
+# The keyword exclusions carry \b so a type merely NAMED like a keyword prefix
+# (`public eventPayload Thing;`) still parses as a field.
 FIELD_RE = re.compile(
     r"^\s*public\s+(?!readonly\s+static)(?:readonly\s+)?"
-    r"(?!class|struct|enum|const|static|delegate|event|abstract|override|virtual|sealed)"
+    r"(?!class\b|struct\b|enum\b|const\b|static\b|delegate\b|event\b"
+    r"|abstract\b|override\b|virtual\b|sealed\b)"
     r"[\w<>\[\]\,\.\?\s]+?\s+(\w+)\s*(?:=|;)")
 IGNORE_RE = re.compile(r"\[FieldLoader\.Ignore\]")
 
 
 def parse_assembly(root: pathlib.Path) -> dict[str, tuple[str | None, set[str]]]:
-    """{class name: (base class, own serialisable field names)} for one assembly."""
+    """{class name: (base class, own serialisable field names)} for one assembly.
+
+    Raises OSError if a source file cannot be read — the caller must never fabricate a
+    complete schema from a partially readable directory.
+    """
     out: dict[str, tuple[str | None, set[str]]] = {}
     if not root.is_dir():
         return out
     for path in root.rglob("*.cs"):
-        try:
-            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        except OSError:
-            continue
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
         cur: str | None = None
         ignore_next = False
         for line in lines:
             m = CLASS_RE.match(line)
             if m:
                 cur = m.group(1)
-                base = m.group(2).split(",")[0].strip()
-                out.setdefault(cur, (base or None, set()))
+                if line.rstrip().endswith(":"):
+                    base = UNPARSED_BASE          # base list continues on the next line
+                else:
+                    base = (m.group(2) or "").split(",")[0].strip() or None
+                out.setdefault(cur, (base, set()))
                 continue
             if cur is None:
                 continue
@@ -99,39 +148,120 @@ def parse_assembly(root: pathlib.Path) -> dict[str, tuple[str | None, set[str]]]
     return out
 
 
-def build_index() -> dict[str, dict[str, tuple[str | None, set[str]]]]:
-    return {name: parse_assembly(pathlib.Path(d)) for name, d in ASSEMBLY_DIRS}
+def assembly_source_dirs(root: pathlib.Path,
+                         engine_root: pathlib.Path | None = None,
+                         ) -> list[tuple[str, pathlib.Path]]:
+    """(assembly, source directory), every path ROOTED at `root`/`engine_root` — never CWD
+    relative, which was the 2026-09-09 defect: run from any other directory the index came
+    back empty and the audit answered "OK — every warhead field is read" on zero coverage."""
+    engine_root = engine_root if engine_root is not None else root / "engine"
+    return [(name, (root if loc == "repo" else engine_root) / sub)
+            for name, loc, sub in ASSEMBLY_DIRS]
 
 
-def resolve_fields(index, cls: str) -> tuple[set[str], str] | None:
-    """All serialisable field names on `cls` and its bases, plus the winning assembly."""
-    for asm, _ in ASSEMBLY_DIRS:
-        if cls in index[asm]:
-            fields: set[str] = set()
-            name, seen = cls, set()
-            while name and name not in seen:
-                seen.add(name)
-                found = next((index[a][name] for a, _ in ASSEMBLY_DIRS if name in index[a]), None)
-                if found is None:
-                    break
-                base, own = found
-                fields |= own
-                name = base
-            return fields, asm
+def build_index(root: pathlib.Path | str = ".",
+                engine_root: pathlib.Path | str | None = None,
+                ) -> dict[str, dict[str, tuple[str | None, set[str]]]]:
+    """{assembly: {class: (base, own fields)}} for every assembly that exists.
+
+    Default `root="."` keeps the historical behaviour (paths relative to the CWD when run
+    from the repository root). A missing directory yields an empty entry; gate on
+    `missing_assemblies` before trusting the result.
+    """
+    root = pathlib.Path(root)
+    engine_root = pathlib.Path(engine_root) if engine_root is not None else None
+    return {name: parse_assembly(d) for name, d in assembly_source_dirs(root, engine_root)}
+
+
+def missing_assemblies(root: pathlib.Path | str,
+                       engine_root: pathlib.Path | str | None = None,
+                       ) -> list[tuple[str, pathlib.Path]]:
+    """Assemblies whose C# source directory is absent or empty — with any of these the
+    field schema cannot be fully covered and the audit must refuse a passing verdict."""
+    return [(name, d) for name, d in assembly_source_dirs(pathlib.Path(root),
+                                                          pathlib.Path(engine_root)
+                                                          if engine_root is not None else None)
+            if not (d.is_dir() and any(d.rglob("*.cs")))]
+
+
+def resolve_fields(index, cls: str) -> tuple[set[str], str, bool] | None:
+    """All serialisable field names on `cls` and its bases, plus the winning assembly.
+
+    Returns None if `cls` is defined in no scanned assembly. The bool is False when the
+    chain broke at an unknown, non-safe base: `fields` is then PARTIAL (it can be missing
+    inherited fields) and must not be used to judge yaml keys dead.
+    """
+    for asm in ASSEMBLY_ORDER:
+        if cls not in index.get(asm, {}):
+            continue
+        fields: set[str] = set()
+        name, seen, complete = cls, set(), True
+        while name and name not in seen:
+            seen.add(name)
+            found = next((index[a][name] for a in ASSEMBLY_ORDER if name in index[a]), None)
+            if found is None:
+                complete = name.lower() in SAFE_TERMINAL_BASES
+                break
+            base, own = found
+            fields |= own
+            name = base
+        else:
+            # The loop ended without break: either the chain reached a class declared
+            # with no base (name is None — a valid terminal), or it returned to a class
+            # already visited. An inheritance cycle cannot be verified — incomplete.
+            if name:
+                complete = False
+        return fields, asm, complete
     return None
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--root", default=".")
+    ap.add_argument("--root", default=".",
+                    help="mod repository root (default: CWD). All source paths resolve under it.")
+    ap.add_argument("--engine-root", default=None,
+                    help="engine checkout holding OpenRA.Mods.AS/Common/Cnc/D2k "
+                         "(default: <root>/engine). For worktrees without their own engine/.")
     ap.add_argument("--json")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
-    index = build_index()
-    rs = Model(pathlib.Path(args.root)).rs
+    root = pathlib.Path(args.root).resolve()
+    engine_root = (pathlib.Path(args.engine_root).resolve() if args.engine_root
+                   else root / "engine")
+
+    # Pre-scan schema gate: with any assembly source missing the field sets are partial,
+    # the audit under-reports and still says OK — the exact failure mode it exists to
+    # prevent (docs/audit/SUMMARY.md). Fail BEFORE scanning, and before --json could
+    # overwrite anything with data that was never scanned. An unreadable source file
+    # counts the same: a partially readable directory must not fabricate a schema.
+    try:
+        missing = missing_assemblies(root, engine_root)
+        index = build_index(root, engine_root)
+    except OSError as exc:
+        print(f"INCOMPLETE — could not read the C# sources under {root}: {exc}")
+        if args.json:
+            print(f"--json {args.json} NOT written (no scan performed).")
+        return EXIT_INCOMPLETE
+    if missing:
+        print("INCOMPLETE — assembly C# sources missing, the field schema cannot be trusted:")
+        for name, d in missing:
+            print(f"    {name}: {d} (no *.cs found)")
+        print("Point --engine-root at an engine checkout (one containing "
+              "OpenRA.Mods.Common et al) or run from a tree that has engine/ built.")
+        if args.json:
+            print(f"--json {args.json} NOT written (no scan performed).")
+        return EXIT_INCOMPLETE
+    try:
+        rs = Model(root).rs
+    except Exception as exc:  # any model failure is a pre-scan failure, not a clean scan
+        print(f"INCOMPLETE — could not load the ruleset under {root}: {exc}")
+        if args.json:
+            print(f"--json {args.json} NOT written (no scan performed).")
+        return EXIT_INCOMPLETE
 
     dead: dict[tuple[str, str], set[str]] = collections.defaultdict(set)
     unresolved: collections.Counter = collections.Counter()
+    broken_chains: collections.Counter = collections.Counter()
     nodes_scanned = 0
 
     for name in rs.weapons:
@@ -150,7 +280,10 @@ def main() -> int:
             if got is None:
                 unresolved[wtype] += 1
                 continue
-            fields, _asm = got
+            fields, _asm, complete = got
+            if not complete:
+                broken_chains[wtype] += 1
+                continue
             nodes_scanned += 1
             for c in wh.children:
                 key = c.key.split("@")[0].strip()
@@ -163,10 +296,38 @@ def main() -> int:
         for t, n in unresolved.most_common():
             print(f"    {n:5d}  {t}")
         print()
+    if broken_chains:
+        print("⚠ warhead types whose inheritance chain breaks at an unknown base, a cycle, "
+              "or an unreadable base continuation — inherited fields may be missing "
+              "(not checked):")
+        for t, n in broken_chains.most_common():
+            print(f"    {n:5d}  {t}")
+        print()
+
+    if unresolved or broken_chains:
+        weapons_hit = len(set().union(*dead.values())) if dead else 0
+        print(f"INCOMPLETE — {len(dead)} dead field kind(s) on {weapons_hit} weapons found so "
+              "far, but the schema coverage above is partial: this is NOT a complete audit.")
+        if dead:
+            print("Dead fields found so far (raw diagnostics):")
+            for (wtype, key), weapons in sorted(dead.items(), key=lambda kv: -len(kv[1])):
+                print(f"  {len(weapons):5d} weapons   {wtype}.{key}")
+        if args.json:
+            print(f"--json {args.json} NOT written — incomplete scan "
+                  f"({sum(unresolved.values())} unresolved, "
+                  f"{sum(broken_chains.values())} broken-chain nodes); "
+                  "any previous file is preserved.")
+        return EXIT_INCOMPLETE
+
+    # Complete, trustworthy scan: emit the CURRENT mapping (even empty) so a stale file
+    # from an earlier run can never masquerade as this run's result.
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(
+            {f"{t}.{k}": sorted(v) for (t, k), v in dead.items()}, indent=1), encoding="utf-8")
 
     if not dead:
         print("OK — every warhead field is read by the type that declares it.")
-        return 0
+        return EXIT_OK
 
     print("DEAD FIELDS — written in yaml, silently discarded by FieldLoader.Load:\n")
     rows = sorted(dead.items(), key=lambda kv: -len(kv[1]))
@@ -184,10 +345,7 @@ def main() -> int:
     else:
         print("Lower `DEAD_FIELD_BASELINE` as each kind is fixed; never raise it.")
 
-    if args.json:
-        pathlib.Path(args.json).write_text(json.dumps(
-            {f"{t}.{k}": sorted(v) for (t, k), v in dead.items()}, indent=1), encoding="utf-8")
-    return 1 if over else 0
+    return EXIT_RATCHET if over else EXIT_OK
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_dead_warhead_fields.py
+++ b/tools/tests/test_dead_warhead_fields.py
@@ -1,0 +1,478 @@
+"""Regression tests for audit_dead_warhead_fields.py.
+
+Every fixture is a minimal fake repository — tiny C# source roots plus a stub Model — so the
+suite is cheap and never touches the real ruleset. The original defects are reproduced as
+BEHAVIOUR (exit codes, emitted json), never as implementation strings:
+
+  - source paths were CWD-relative and ignored --root: run from any other directory the
+    field index came back EMPTY and the audit answered "OK — every warhead field is read";
+  - missing assembly sources produced those empty indexes just as silently (same false OK);
+  - unresolved warhead types were skipped silently and still allowed success;
+  - an unknown base class silently ended the inherited-field walk, so a partial field set
+    was trusted (false dead verdicts possible);
+  - a scan that was NOT trustworthy (unresolved types, broken chains, cycles, unreadable
+    sources) rewrote --json, so partial results could masquerade as current — now only a
+    completed trustworthy scan writes the mapping (a clean scan resets stale output to {}).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import _bootstrap  # noqa: F401 — sys.path side effect
+
+import audit_dead_warhead_fields as audit
+
+# --- minimal C# fixtures --------------------------------------------------- #
+# Mirrors the real layout: CA/Cameo vendored at the repo root, AS/Common/Cnc/D2k
+# under the engine checkout. Warhead's base IWarhead lives outside every scanned
+# assembly (OpenRA.Game) and is the audit's one safe non-object terminal.
+
+CAMEO_CS = "namespace OpenRA.Mods.Cameo {\n}\n"
+CNC_CS = "namespace OpenRA.Mods.Cnc {\n}\n"
+D2K_CS = "namespace OpenRA.Mods.D2k {\n}\n"
+
+COMMON_CS = """namespace OpenRA.Mods.Common.Warheads {
+	public abstract class Warhead : IWarhead {
+	}
+
+	public abstract class DamageWarhead : Warhead {
+		public readonly int Damage = 0;
+
+		public int Spread;  // mutable public — FieldLoader reads it too
+	}
+}
+"""
+
+AS_CS = """namespace OpenRA.Mods.AS.Warheads {
+	public class CreateTintedCellsWarhead : DamageWarhead {
+		public int Level = 100;
+
+		[FieldLoader.Ignore]
+		public readonly int Ignored = 0;
+	}
+
+	public class ShadowWarhead : DamageWarhead {
+		public readonly int FromAS = 0;
+	}
+}
+"""
+
+CA_CS = """namespace OpenRA.Mods.CA.Warheads {
+	public class AreaDamageWarhead : DamageWarhead {
+		public readonly int Radius = 0;
+	}
+
+	public class ShadowWarhead : DamageWarhead {
+		public readonly int FromCA = 0;
+	}
+
+	public class GhostWarhead : NoSuchBaseAnywhere {
+		public readonly int Own = 0;
+	}
+
+	public class CycleA : CycleB {
+		public readonly int FromA = 0;
+	}
+
+	public class CycleB : CycleA {
+		public readonly int FromB = 0;
+	}
+
+	public class ContinuationWarhead :
+		DamageWarhead
+	{
+		public readonly int Own = 0;
+	}
+}
+"""
+
+
+def write_cs(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_repo_assemblies(root: pathlib.Path) -> None:
+    """The two assemblies vendored at the repository root."""
+    write_cs(root / "OpenRA.Mods.CA" / "Warheads" / "ca.cs", CA_CS)
+    write_cs(root / "OpenRA.Mods.Cameo" / "cameo.cs", CAMEO_CS)
+
+
+def write_engine_assemblies(engine: pathlib.Path) -> pathlib.Path:
+    """The four engine-checkout assemblies; returns the engine root."""
+    write_cs(engine / "OpenRA.Mods.AS" / "Warheads" / "as.cs", AS_CS)
+    write_cs(engine / "OpenRA.Mods.Common" / "Warheads" / "common.cs", COMMON_CS)
+    write_cs(engine / "OpenRA.Mods.Cnc" / "cnc.cs", CNC_CS)
+    write_cs(engine / "OpenRA.Mods.D2k" / "d2k.cs", D2K_CS)
+    return engine
+
+
+# --- stub Model ------------------------------------------------------------ #
+
+class Yaml:
+    """Stand-in for a miniyaml Node: only key/value/children are consulted."""
+
+    def __init__(self, key, value=None, children=()):
+        self.key = key
+        self.value = value
+        self.children = list(children)
+
+
+class FakeRuleset:
+    def __init__(self, weapons):
+        self._weapons = dict(weapons)
+        self.weapons = list(weapons)
+
+    def resolve_weapon(self, name):
+        return self._weapons.get(name)
+
+
+@contextlib.contextmanager
+def stub_model(ruleset):
+    class FakeModel:
+        def __init__(self, root):
+            self.rs = ruleset
+    with mock.patch.object(audit, "Model", FakeModel):
+        yield
+
+
+def warhead_node(suffix, wtype, keys):
+    return Yaml(f"Warhead@{suffix}", wtype, [Yaml(k, "0") for k in keys])
+
+
+def read_json(path: pathlib.Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class ParseTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = pathlib.Path(self._tmp.name)
+        write_repo_assemblies(self.root)
+        self.engine = write_engine_assemblies(self.root / "engine")
+
+    def test_mutable_public_field_is_recognized(self):
+        # CreateTintedCellsWarhead declares `public int Level = 100;` — matching only
+        # readonly once reported 45 live radiation settings as dead.
+        fields = audit.parse_assembly(self.engine / "OpenRA.Mods.AS")
+        self.assertIn("Level", fields["CreateTintedCellsWarhead"][1])
+
+    def test_fieldloader_ignore_is_skipped(self):
+        fields = audit.parse_assembly(self.engine / "OpenRA.Mods.AS")
+        self.assertNotIn("Ignored", fields["CreateTintedCellsWarhead"][1])
+
+    def test_class_without_base_is_parsed_with_none_base(self):
+        src = self.root / "OpenRA.Mods.CA" / "Warheads" / "loner.cs"
+        write_cs(src, "namespace X {\n\tpublic class Loner {\n\t\tpublic int A;\n\t}\n}\n")
+        fields = audit.parse_assembly(src.parent)
+        self.assertEqual(fields["Loner"], (None, {"A"}))
+        # A class with truly no inheritance is a VALID terminal — never flagged incomplete.
+        got = audit.resolve_fields(audit.build_index(self.root), "Loner")
+        self.assertIsNotNone(got)
+        self.assertTrue(got[2])
+
+    def test_keyword_prefix_type_name_is_a_field(self):
+        # A type merely NAMED like a keyword prefix must not be dropped as a field —
+        # dropping it would make every yaml use of it look dead.
+        src = self.root / "OpenRA.Mods.CA" / "Warheads" / "kwprefix.cs"
+        write_cs(src, "namespace X {\n\tpublic class Kw {\n\t\tpublic eventPayload Thing;\n"
+                      "\t\tpublic eventishCount Count = 0;\n\t}\n}\n")
+        fields = audit.parse_assembly(src.parent)["Kw"][1]
+        self.assertEqual(fields, {"Thing", "Count"})
+
+    def test_real_keyword_declarations_are_excluded(self):
+        src = self.root / "OpenRA.Mods.CA" / "Warheads" / "keywords.cs"
+        write_cs(src, "namespace X {\n\tpublic class Kw {\n"
+                      "\t\tpublic static int S = 0;\n"
+                      "\t\tpublic const int C = 0;\n"
+                      "\t\tpublic event System.EventHandler Boom;\n"
+                      "\t\tpublic delegate void Handler(int x);\n"
+                      "\t\tpublic struct Inner { }\n"
+                      "\t}\n}\n")
+        self.assertEqual(audit.parse_assembly(src.parent)["Kw"][1], set())
+
+
+class IndexAndResolveTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = pathlib.Path(self._tmp.name)
+        write_repo_assemblies(self.root)
+        self.engine = write_engine_assemblies(self.root / "engine")
+
+    def test_build_index_roots_at_root_argument(self):
+        index = audit.build_index(self.root)
+        self.assertIn("AreaDamageWarhead", index["CA"])
+
+    def test_build_index_default_resolves_from_cwd(self):
+        # Historical default contract: with no arguments the paths resolve from the CWD.
+        old = os.getcwd()
+        self.addCleanup(os.chdir, old)
+        os.chdir(self.root)
+        index = audit.build_index()
+        self.assertIn("CreateTintedCellsWarhead", index["AS"])
+
+    def test_missing_assemblies_names_the_absent_engine_dirs(self):
+        # Repo-root assemblies only; engine checkout absent entirely.
+        shutil.rmtree(self.root / "engine")
+        missing = dict(audit.missing_assemblies(self.root))
+        self.assertEqual(set(missing), {"AS", "Cnc", "D2k", "Common"})
+        self.assertNotIn("CA", missing)
+
+    def test_missing_assemblies_empty_on_complete_repo(self):
+        self.assertEqual(audit.missing_assemblies(self.root), [])
+
+    def test_precedence_first_assembly_wins(self):
+        index = audit.build_index(self.root)
+        got = audit.resolve_fields(index, "ShadowWarhead")
+        self.assertIsNotNone(got)
+        fields, asm, complete = got
+        self.assertEqual(asm, "AS")
+        self.assertIn("FromAS", fields)
+        self.assertNotIn("FromCA", fields)
+        self.assertTrue(complete)
+
+    def test_chain_through_iwarhead_terminal_is_complete(self):
+        index = audit.build_index(self.root)
+        got = audit.resolve_fields(index, "AreaDamageWarhead")
+        fields, _asm, complete = got
+        self.assertTrue(complete)
+        # Own field plus the whole inherited chain (DamageWarhead, Warhead).
+        self.assertLessEqual({"Radius", "Damage", "Spread"}, fields)
+
+    def test_unknown_base_makes_chain_incomplete(self):
+        index = audit.build_index(self.root)
+        got = audit.resolve_fields(index, "GhostWarhead")
+        _fields, _asm, complete = got
+        self.assertFalse(complete)
+
+    def test_inheritance_cycle_is_incomplete(self):
+        # A -> B -> A: the old walk exited the cycle with complete=True, trusting a
+        # field set it could not verify. Now: incomplete.
+        index = audit.build_index(self.root)
+        got = audit.resolve_fields(index, "CycleA")
+        self.assertIsNotNone(got)
+        fields, _asm, complete = got
+        self.assertFalse(complete)
+        self.assertEqual(fields, {"FromA", "FromB"})
+
+    def test_newline_base_continuation_is_incomplete(self):
+        # `public class X :` with the base on the NEXT line: the line parser cannot
+        # read the base, so the class must be incomplete — never silently baseless.
+        index = audit.build_index(self.root)
+        got = audit.resolve_fields(index, "ContinuationWarhead")
+        self.assertIsNotNone(got)
+        fields, _asm, complete = got
+        self.assertFalse(complete)
+        self.assertIn("Own", fields)
+
+    def test_missing_intermediate_base_makes_chain_incomplete(self):
+        # Common holds DamageWarhead/Warhead; without it the CA chain breaks mid-way.
+        index = audit.build_index(self.root, self.root / "missing-engine")
+        got = audit.resolve_fields(index, "AreaDamageWarhead")
+        fields, _asm, complete = got
+        self.assertFalse(complete)
+        self.assertIn("Radius", fields)  # own fields still collected
+
+
+class AuditRunTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = pathlib.Path(self._tmp.name)
+        write_repo_assemblies(self.root)
+        self.engine = write_engine_assemblies(self.root / "engine")
+        self.json_path = self.root / "dead.json"
+        self.ruleset = FakeRuleset({})
+
+    def set_weapons(self, weapons):
+        self.ruleset = FakeRuleset(weapons)
+
+    def run_audit(self, *extra):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), stub_model(self.ruleset):
+            code = audit.main(["--root", str(self.root), *extra])
+        return code, out.getvalue()
+
+    def chdir_away_from_repo(self):
+        # Any directory that is not the repository — exercises the CWD independence.
+        old = os.getcwd()
+        self.addCleanup(os.chdir, old)
+        os.chdir(self._tmp.name)
+
+    def write_json_sentinel(self) -> bytes:
+        """Pre-existing --json content that an incomplete run must leave byte-identical."""
+        sentinel = b'{"sentinel": ["do-not-touch"]}'
+        self.json_path.write_bytes(sentinel)
+        return sentinel
+
+    # -- the CWD-relative path defect ---------------------------------------- #
+
+    def test_explicit_root_wins_over_cwd(self):
+        # Reproduces the original bug: run from a foreign CWD with an explicit --root,
+        # the old script ignored --root when building the field index and, with the
+        # empty index it got, reported "OK" on zero coverage.
+        self.chdir_away_from_repo()
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [
+                warhead_node("main", "AreaDamage", ["Damage", "Radius", "Spread", "Bogus"]),
+            ]),
+        })
+        with mock.patch.object(audit, "DEAD_FIELD_BASELINE", 0):
+            code, _out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_RATCHET)   # 1 — complete scan, above ratchet
+        self.assertEqual(read_json(self.json_path), {"AreaDamage.Bogus": ["ttnk"]})
+
+    # -- engine root --------------------------------------------------------- #
+
+    def test_repo_without_engine_is_incomplete_without_flag(self):
+        # A worktree whose engine/ is not checked out: the four engine assemblies are
+        # missing and the audit must refuse a passing verdict.
+        shutil.rmtree(self.root / "engine")
+        elsewhere = write_engine_assemblies(self.root / "engine-elsewhere")
+        self.ruleset = FakeRuleset({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Damage"])])
+        })
+        code, _out = self.run_audit()
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+
+        code, _out = self.run_audit("--engine-root", str(elsewhere))
+        self.assertEqual(code, audit.EXIT_OK)
+
+    # -- missing assemblies --------------------------------------------------- #
+
+    def test_missing_assembly_fails_prescan_without_touching_json(self):
+        # Reproduces the original bug: a missing assembly silently produced an empty
+        # index and the audit answered "OK". Also: a pre-scan failure must not
+        # overwrite an existing --json file with data that was never scanned.
+        stale = {"StaleType.Stale": ["weapon"]}
+        self.json_path.write_text(json.dumps(stale), encoding="utf-8")
+        for cs in (self.engine / "OpenRA.Mods.Common" / "Warheads").glob("*.cs"):
+            cs.unlink()
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Damage"])])
+        })
+        code, _out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertEqual(read_json(self.json_path), stale)
+
+    # -- unresolved types / broken chains ------------------------------------- #
+
+    def test_unresolved_type_withholds_json_but_prints_findings(self):
+        # Reproduces the original bug: unresolved types were skipped silently and the
+        # run could still report success. Raw partial findings stay on stdout, but the
+        # pre-existing --json must survive byte-identical — no partial masquerade.
+        sentinel = self.write_json_sentinel()
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [
+                warhead_node("main", "AreaDamage", ["Bogus"]),
+                warhead_node("alt", "Mystery", ["Whatever"]),
+            ]),
+        })
+        code, out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertIn("Mystery", out)
+        self.assertIn("AreaDamage.Bogus", out)
+        self.assertEqual(self.json_path.read_bytes(), sentinel)
+
+    def test_unresolved_type_alone_is_not_success(self):
+        sentinel = self.write_json_sentinel()
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "Mystery", ["Whatever"])])
+        })
+        code, _out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertEqual(self.json_path.read_bytes(), sentinel)
+
+    def test_broken_chain_partial_fields_are_not_trusted(self):
+        # GhostWarhead's base is unknown, so its field set is partial: a yaml key it
+        # does not own may live on that base. The old code trusted the partial set and
+        # reported "Bogus" dead — a false positive. Now: incomplete, never judged, and
+        # the previous --json is preserved.
+        sentinel = self.write_json_sentinel()
+        self.set_weapons({
+            "gh": Yaml("gh", None, [warhead_node("main", "Ghost", ["Own", "Bogus"])])
+        })
+        code, _out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertEqual(self.json_path.read_bytes(), sentinel)
+
+    def test_inheritance_cycle_is_incomplete_and_withholds_json(self):
+        sentinel = self.write_json_sentinel()
+        self.set_weapons({
+            "ca": Yaml("ca", None, [warhead_node("main", "CycleA", ["FromA", "Whatever"])])
+        })
+        code, out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertIn("CycleA", out)
+        self.assertEqual(self.json_path.read_bytes(), sentinel)
+
+    def test_unreadable_source_fails_before_scan_and_json(self):
+        # A partially readable source directory must never fabricate a complete schema:
+        # the read failure propagates to an INCOMPLETE verdict before any scan or
+        # --json overwrite.
+        sentinel = self.write_json_sentinel()
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Damage"])])
+        })
+
+        def denied(_path, *_args, **_kwargs):
+            raise PermissionError(13, "denied")
+
+        with mock.patch.object(pathlib.Path, "read_text", denied):
+            code, out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_INCOMPLETE)
+        self.assertIn("denied", out)
+        self.assertEqual(self.json_path.read_bytes(), sentinel)
+
+    # -- ratchet & json freshness ---------------------------------------------- #
+
+    def test_warn_below_ratchet_exits_zero(self):
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Bogus"])])
+        })
+        code, _out = self.run_audit()
+        self.assertEqual(code, audit.EXIT_OK)
+
+    def test_dead_above_ratchet_fails(self):
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Bogus"])])
+        })
+        with mock.patch.object(audit, "DEAD_FIELD_BASELINE", 0):
+            code, _out = self.run_audit()
+        self.assertEqual(code, audit.EXIT_RATCHET)
+
+    def test_clean_scan_rewrites_stale_json_empty(self):
+        # Reproduces the original bug: a clean scan never touched --json, so the file
+        # from an earlier failing run kept masquerading as the current result.
+        self.json_path.write_text('{"AreaDamage.Bogus": ["ttnk"]}', encoding="utf-8")
+        self.set_weapons({
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage",
+                                                     ["Damage", "Radius", "Spread"])])
+        })
+        code, _out = self.run_audit("--json", str(self.json_path))
+        self.assertEqual(code, audit.EXIT_OK)
+        self.assertEqual(read_json(self.json_path), {})
+
+    def test_template_weapons_are_skipped(self):
+        self.set_weapons({
+            "^BaseWeapon": Yaml("^BaseWeapon", None,
+                                [warhead_node("main", "Mystery", ["Whatever"])]),
+            "ttnk": Yaml("ttnk", None, [warhead_node("main", "AreaDamage", ["Damage"])]),
+        })
+        code, _out = self.run_audit()
+        self.assertEqual(code, audit.EXIT_OK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Prevents missing engine sources or unresolved C# inheritance from producing a misleading clean dead-field audit. Honors explicit roots, recognizes mutable public fields, and preserves the existing report on incomplete scans (exit 2). Complete-source finding output remains byte-identical; no ratchet changed.

## Scope and recommendation

Draft for integration review. **Recommendation: merge after normal PR review/checks**, because this is a bounded correctness fix with independently challenged implementation and no live gameplay change. It does not authorize a balance import, anchor sign-off, or applying proposals. No YAML rules, engine/C#, prices, HP, weapons, reserved producer files, or generated audit reports are included.

Split from the reviewed non-AI batch to respect the repository's PR-size guidance; related dossier improvements stay in #335. Implemented with OpenCode GLM 5.3 Flash; coordinated and independently reviewed through Codex for Blackrobe.

## Validation

- 27 focused regression tests pass on the isolated publication branch. Published file contents match the independently reviewed batch; diff checks pass.
- The exact combined master-based batch was tested at base `5f170ba07a95620ce4324553600bce3ed7bfb723`: 1,148 tests, 44 skipped, 15 failing modules / 22 failure signatures, identical to the untouched-master baseline. All 169 added tests pass. **The full suite is not green.** This is combined-batch evidence, not a claim that each split branch reran the entire suite.
- 33 balance ledgers: zero drift. Percentage checks pass. Weapon structure/shape ratchets unchanged; raw exceptions remain visible. These gates were run on the combined batch.
- Independent source and test challenge found no remaining blocker in the owned changes. Static tests do not prove gameplay balance.
- Tools/data-for-tools only; no game launch. Existing full-suite debt is disclosed, not waived.
