### PR TITLE
Add conservative release weapon identity triage

### DIFF
--- a/tools/audit/triage_release_identities.py
+++ b/tools/audit/triage_release_identities.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""triage_release_identities.py - C19 diagnostic: classify the D4 unmatched ids.
+
+`audit_release_drift` reports 335 baseline ids (playtest-20260709) that no
+longer exist under their original name in the measured snapshot, so the drift
+gate is blind to them. Two of them (E1Droppod, E2Droppod) still exist verbatim
+in the active Ruleset - the snapshot metric just excludes them (no measurable
+main warheads), so "unmatched" does NOT mean deleted. This tool partitions the
+raw unmatched set into exactly one row per id:
+
+  ACTIVE_UNMEASURED  the exact name still exists in the active Ruleset, still
+                     resolves cleanly, and is excluded from the snapshot metric
+                     only because it has no eligible main. Says nothing about
+                     damage - not "zero damage", not "deleted". If resolving
+                     the name RAISES (or returns None), the row is UNRESOLVED
+                     with reason `resolution_failed` - a broken weapon is never
+                     dressed up as a harmless metric-only exclusion.
+  RENAMED_CANDIDATE  an EXACT literal top-level header rename (-OldName:/+NewName:)
+                     is proven in one of the --rename-commit commits, in a
+                     KNOWN WEAPON LAYOUT file only (mods/cameo/weapons/*.yaml
+                     or mods/cameo/ContentPacks/**/yaml/weapons.yaml - actor,
+                     rules, chrome and sequence yamls are never evidence), the
+                     final target is present in the current measured snapshot,
+                     and the target is not itself a release baseline name
+                     (that would be a double assignment - ambiguous instead).
+                     ⚠ Historical rename evidence restores the IDENTITY LINK
+                     only. It is not gameplay equivalence, not damage
+                     equivalence, and NEVER licenses an accepted-drift ruling.
+  UNRESOLVED         no safe evidence, or ambiguity. Fan-in is computed over
+                     ALL raw edges, including edges of sources already
+                     rejected as one-to-many: A->X, B->X and B->Y makes A
+                     ambiguous too, not an approved unique link. Never labelled
+                     DELETED/MERGED: absence from the tree alone is not proof
+                     of deletion.
+
+Evidence rules (hard):
+  * Only adjacent literal top-level `-OldName:`/`+NewName:` pairs inside a diff
+    hunk that contains exactly one removed and one added top-level header.
+    Field edits, `^`-templates, `-Key:` cancellations and multi-header hunks
+    are never evidence. Names are never inferred from fuzzy similarity.
+  * Rename chains are NOT followed by default; --follow-rename-chains opts
+    into the strict chain mode defined below.
+
+Chain mode (--follow-rename-chains, default OFF):
+  With the flag, a first-hop target that is itself unmatched may be followed
+  through further EXACT adjacent rename edges from the supplied commits:
+    * only edges the existing parser already produced - never fuzzy, never
+      non-adjacent, never multi-header hunks;
+    * the global fan-in / one-to-many / cycle rejections still apply, over
+      ALL raw edges including edges of already-rejected sources; every node
+      consults the rejected-evidence map FIRST - rejected evidence is never
+      routed around;
+    * one unambiguous provenance tuple (commit, path) per hop: duplicate
+      identical records are harmless, the same old->new pair bound to
+      distinct commits or paths is ambiguity - never "pick the first";
+    * successive hop commits must be DISTINCT and strictly proper ancestors
+      (git merge-base --is-ancestor, cached per ordered pair, fail-closed
+      with exit 2 on any git error), independent of ref input order - same
+      commit, reverse chronology or incomparable branches reject;
+    * traversal is bounded and cycle-checked; no string similarity anywhere;
+      any post-origin node present in the measured baseline population
+      rejects; still-active intermediates reject even when excluded from
+      the snapshot;
+    * the terminal must be active and resolve cleanly, and be measured in
+      the current snapshot; anything else is UNRESOLVED with a precise
+      reason, the partial traversed chain (`evidence_chain`) and, when the
+      chain walks into rejected evidence, a separate `rejection_evidence`
+      field;
+    * two release ids may not both claim one terminal - converging paths
+      downgrade BOTH rows.
+  ⚠ Collision coverage is ONLY the measured baseline population plus the
+  PROVIDED historical evidence - not exhaustive history, not full
+  historical-namespace proof, not identity certification. Confidence stays
+  RENAMED_CANDIDATE: never harmless, never equivalent, never accepted drift.
+  * Draft rename maps (e.g. tools/rename/rename_map_weapons.yaml) are plans,
+    not evidence - only committed git hunks count.
+
+Every git invocation is bound to the repository with `git -C <repo>` so the
+external CWD can never point the tool at another repo, and commit refs are
+resolved through `git rev-parse --verify --end-of-options` into validated
+40-hex immutable hashes before any other use.
+
+⚠ MEASUREMENT BASIS: the snapshot and Ruleset are read from the CURRENT
+WORKING TREE, not from gitHEAD. The report carries a `worktree_dirty` flag and
+a caveat; a dirty worktree means the measured values are NOT certified by
+gitHEAD, and dirty-tree values never certify gitHEAD.
+
+Read-only: prints one JSON document to stdout, writes nothing, changes no
+ratchet in audit_release_drift.py and no baseline/reference file. Exit code is
+0 whenever the triage ran (UNRESOLVED rows are information, not failures);
+unknown refs, non-ancestor commits and git failures are refused with exit 2.
+
+Usage: python tools/audit/triage_release_identities.py \
+         [--rename-commit <commit>]...      # e.g. 7a296c96d bcb1a8f05
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import miniyaml
+from audit_release_drift import load_baseline
+from gen_release_baseline import snapshot
+
+# A top-level yaml header is a bare `Name:` in column 0. Current ids are
+# underscore-only per DESIGN, but the legacy release corpus also carries
+# dotted/hyphenated names (e.g. EMPDisable.anim, TSCABAL_EMP_Disable.end):
+# interior dots/hyphens are accepted literally, still with no leading
+# whitespace, no leading -/^, no inline value.
+TOP_HEADER = re.compile(r"^([A-Za-z0-9_][A-Za-z0-9_.-]*):$")
+FULL_HASH = re.compile(r"^[0-9a-f]{40}$")
+
+# Known weapon layouts. Anything else (actor rules, chrome, sequences, audio,
+# maps, docs) is never weapon-rename evidence, however convincing it looks.
+ROOT_WEAPONS_PREFIX = "mods/cameo/weapons/"
+PACK_WEAPONS_PREFIX = "mods/cameo/ContentPacks/"
+PACK_WEAPONS_SUFFIX = "/yaml/weapons.yaml"
+
+# Non-content lines that can appear inside a git show body; never diff payload.
+DIFF_META_PREFIXES = (
+    "index ", "old mode ", "new mode ", "deleted file mode ", "new file mode ",
+    "rename from ", "rename to ", "copy from ", "copy to ",
+    "similarity index ", "dissimilarity index ", "\\ No newline",
+)
+
+STATUS_ACTIVE = "ACTIVE_UNMEASURED"
+STATUS_RENAMED = "RENAMED_CANDIDATE"
+STATUS_UNRESOLVED = "UNRESOLVED"
+
+
+def _git(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _refuse(msg: str) -> None:
+    """Hard refusal: message on stderr, process exit code 2."""
+    print(f"triage: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _first_err(cp: subprocess.CompletedProcess) -> str:
+    return ((cp.stderr or "").strip().splitlines() or ["<no stderr>"])[0]
+
+
+def _validated_hash(commit: str) -> str:
+    if not FULL_HASH.match(commit):
+        _refuse(f"refusing non-immutable commit value {commit!r} - expected a "
+                "full 40-hex hash")
+    return commit
+
+
+def is_weapon_yaml(path: str) -> bool:
+    """True only for the two documented weapon layouts.
+
+    mods/cameo/weapons/<name>.yaml (exactly one level) and
+    mods/cameo/ContentPacks/<pack>[/<faction>]/yaml/weapons.yaml.
+    Conservative by design: no broad alias proof is invented.
+    """
+    p = str(path).replace("\\", "/")
+    if p.startswith(ROOT_WEAPONS_PREFIX) and p.endswith(".yaml"):
+        rest = p[len(ROOT_WEAPONS_PREFIX):]
+        return bool(rest) and "/" not in rest
+    if p.startswith(PACK_WEAPONS_PREFIX) and p.endswith(PACK_WEAPONS_SUFFIX):
+        rest = p[len(PACK_WEAPONS_PREFIX):-len(PACK_WEAPONS_SUFFIX)]
+        return bool(rest)
+    return False
+
+
+def resolve_commit(ref: str, repo: pathlib.Path | str, run=_git) -> str:
+    """Turn any commit-ish into the full immutable commit hash git resolves.
+
+    Refuses anything git cannot resolve as a commit (exit 2) - a typo or an
+    unknown ref must never silently yield empty evidence. `--end-of-options`
+    keeps a hostile/odd ref from being parsed as a flag.
+    """
+    cp = run(["git", "-C", str(repo), "rev-parse", "--verify",
+              "--end-of-options", f"{ref}^{{commit}}"])
+    if cp.returncode != 0:
+        _refuse(f"refusing unknown commit '{ref}' - git cannot resolve it as "
+                f"a commit ({_first_err(cp)})")
+    return _validated_hash(cp.stdout.strip())
+
+
+def head_commit(repo: pathlib.Path | str, run=_git) -> str:
+    """Validated 40-hex HEAD of the bound repo; failure is fatal (exit 2)."""
+    cp = run(["git", "-C", str(repo), "rev-parse", "--verify",
+              "--end-of-options", "HEAD"])
+    if cp.returncode != 0:
+        _refuse(f"cannot resolve HEAD for {repo} ({_first_err(cp)})")
+    return _validated_hash(cp.stdout.strip())
+
+
+def worktree_dirty(repo: pathlib.Path | str, run=_git) -> bool:
+    """Whole-worktree dirty flag backing the measurement-basis caveat."""
+    cp = run(["git", "-C", str(repo), "status", "--porcelain"])
+    if cp.returncode != 0:
+        _refuse(f"git status failed for {repo} ({_first_err(cp)})")
+    return bool(cp.stdout.strip())
+
+
+def require_ancestor(commit: str, repo: pathlib.Path | str, run=_git) -> None:
+    """Refuse commits that are not ancestors of the current HEAD (exit 2)."""
+    _validated_hash(commit)
+    cp = run(["git", "-C", str(repo), "merge-base", "--is-ancestor",
+              commit, "HEAD"])
+    if cp.returncode != 0:
+        _refuse(f"refusing commit {commit} - not an ancestor of the current "
+                "HEAD, so its hunks do not describe this tree's history")
+
+
+def parse_rename_pairs(diff_text: str) -> list[dict]:
+    """Extract exact top-level rename pairs from `git show` output.
+
+    Per hunk: record an {path, old, new} item ONLY if the path is a known
+    weapon layout, the hunk contains exactly one removed and one added
+    top-level header, and those two lines are adjacent in the diff. Everything
+    else (field edits, templates, cancellations, multiple headers, non-weapon
+    yaml such as actor/rules/chrome/sequence files, non-yaml files) yields
+    nothing. Old/new are bare ids without the trailing colon.
+    """
+    pairs: list[dict] = []
+    path: str | None = None
+    hunk: list[str] = []
+
+    def headers(marker: str) -> list[tuple[int, str]]:
+        out = []
+        for i, line in enumerate(hunk):
+            if not line.startswith(marker):
+                continue
+            m = TOP_HEADER.match(line[1:])
+            if m:
+                out.append((i, m.group(1)))
+        return out
+
+    def flush() -> None:
+        if path is None or not is_weapon_yaml(path) or not hunk:
+            return
+        removed = headers("-")
+        added = headers("+")
+        if len(removed) == 1 and len(added) == 1 and removed[0][0] + 1 == added[0][0]:
+            pairs.append({"path": path, "old": removed[0][1],
+                          "new": added[0][1]})
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            flush()
+            # take the b/ side so renames of files themselves still resolve
+            path = line.split(" b/", 1)[-1] if " b/" in line else None
+            hunk = []
+        elif line.startswith("@@"):
+            flush()
+            hunk = []
+        elif line.startswith(DIFF_META_PREFIXES) or line.startswith("--- ") \
+                or line.startswith("+++ "):
+            continue
+        elif line[:1] in ("-", "+", " ") and path is not None:
+            hunk.append(line)
+    flush()
+    return pairs
+
+
+def extract_commit_pairs(commit: str, repo: pathlib.Path | str,
+                         run=_git) -> list[dict]:
+    """Exact rename evidence from one commit's weapon-yaml hunks under mods/cameo."""
+    _validated_hash(commit)
+    cp = run(["git", "-C", str(repo), "show", "--no-color", "--format=",
+              "--unified=0", commit, "--", "mods/cameo"])
+    if cp.returncode != 0:
+        _refuse(f"git show failed for {commit} ({_first_err(cp)})")
+    return parse_rename_pairs(cp.stdout)
+
+
+def resolve_evidence(evidences: list[dict]) -> tuple[dict, dict]:
+    """Fold raw pair evidence into {old: edge} plus {old: rejection}.
+
+    Rejects ambiguous mappings up front - one-to-many (the same old name bound
+    to different targets) and many-to-one (two old names claiming one target,
+    a merge without proof) - and any cycle among the surviving edges. Fan-in
+    is computed over ALL raw edges, including edges of sources already
+    rejected as one-to-many: A->X, B->X, B->Y rejects A as well. Rejections
+    preserve their raw source evidence for review.
+    """
+    edges: dict[str, dict] = {}
+    rejected: dict[str, dict] = {}
+    raw_by_old: dict[str, list[dict]] = {}
+    for e in evidences:
+        raw_by_old.setdefault(e["old"], []).append(e)
+    for old, items in raw_by_old.items():
+        if len({e["new"] for e in items}) > 1:
+            rejected[old] = {"reason": "ambiguous_multiple_targets",
+                             "evidence": items}
+    raw_by_new: dict[str, set[str]] = {}
+    for e in evidences:
+        raw_by_new.setdefault(e["new"], set()).add(e["old"])
+    for new, olds in raw_by_new.items():
+        if len(olds) > 1:
+            for old in olds:
+                if old not in rejected:
+                    rejected[old] = {"reason": "ambiguous_shared_target",
+                                     "evidence": raw_by_old[old]}
+    for old, items in raw_by_old.items():
+        if old in rejected:
+            continue
+        if items[0]["new"] == old:
+            rejected[old] = {"reason": "ambiguous_cycle", "evidence": items}
+        else:
+            edges[old] = dict(items[0])
+    for old in list(edges):
+        walk: list[str] = []
+        seen: set[str] = set()
+        node = old
+        while node in edges and node not in seen:
+            seen.add(node)
+            walk.append(node)
+            node = edges[node]["new"]
+        if node in seen:
+            for cycle_node in walk[walk.index(node):]:
+                if cycle_node in edges:
+                    rejected[cycle_node] = {
+                        "reason": "ambiguous_cycle",
+                        "evidence": [edges[cycle_node]]}
+                    del edges[cycle_node]
+    return edges, rejected
+
+
+def _hop_view(edge: dict) -> dict:
+    return {k: edge[k] for k in ("commit", "path", "old", "new")}
+
+
+def resolve_evidence_strict(evidences: list[dict]) -> tuple[dict, dict]:
+    """Chain-mode fold: resolve_evidence + per-hop provenance unambiguity.
+
+    A surviving edge (old -> new) must carry exactly ONE distinct provenance
+    tuple (commit, path). Duplicate identical records are harmless; the same
+    pair bound to distinct commits or paths is ambiguity - never "pick the
+    convenient first". Fan-in / one-to-many / cycle rejections are unchanged
+    and still computed over ALL raw edges, including edges of rejected
+    sources.
+    """
+    edges, rejected = resolve_evidence(evidences)
+    raw_by_old: dict[str, list[dict]] = {}
+    for e in evidences:
+        raw_by_old.setdefault(e["old"], []).append(e)
+    for old in list(edges):
+        provs = {(e["commit"], e["path"]) for e in raw_by_old[old]}
+        if len(provs) > 1:
+            rejected[old] = {"reason": "ambiguous_multiple_provenance",
+                             "evidence": raw_by_old[old]}
+            del edges[old]
+    return edges, rejected
+
+
+class AncestryChecker:
+    """Cached `git merge-base --is-ancestor`, fail-closed on git error.
+
+    Returncode 0 = strictly ancestral, 1 = not ancestral, anything else is a
+    git failure and refuses with exit 2 - a broken git must never silently
+    classify as "no ancestry"/"no evidence". Hop commits are validated 40-hex
+    hashes. Results are cached per ordered pair; no history scan is run.
+    """
+
+    def __init__(self, repo: pathlib.Path | str, run=_git):
+        self.repo = str(repo)
+        self._run = run
+        self._cache: dict[tuple[str, str], bool] = {}
+
+    def strictly_ancestral(self, earlier: str, later: str) -> bool:
+        """True iff `earlier` is a PROPER ancestor of `later` (never itself)."""
+        _validated_hash(earlier)
+        _validated_hash(later)
+        if earlier == later:
+            return False  # proper ancestor: a commit is never its own ancestor
+        key = (earlier, later)
+        if key in self._cache:
+            return self._cache[key]
+        cp = self._run(["git", "-C", self.repo, "merge-base", "--is-ancestor",
+                        earlier, later])
+        if cp.returncode == 0:
+            result = True
+        elif cp.returncode == 1:
+            result = False
+        else:
+            _refuse(f"git merge-base --is-ancestor failed for "
+                    f"{earlier[:12]}..{later[:12]} ({_first_err(cp)})")
+        self._cache[key] = result
+        return result
+
+
+def resolve_chain(origin: str, edges: dict, rejected: dict, base: dict,
+                  active_names: set[str], ancestry) -> dict:
+    """Walk exact adjacent edges from `origin` (chain mode only).
+
+    Returns {"ok", "terminal", "hops", "reason", "rejection_evidence"}.
+    Every node consults the SAME conservative evidence maps - an intermediate
+    whose own outgoing evidence sits in `rejected` is never routed around.
+    Traversal is bounded by a seen-set (cycles/repeated nodes reject),
+    successive hop commits must be DISTINCT and strictly ancestral
+    (independent of ref input order), post-origin baseline-population nodes
+    reject, and still-active intermediates reject. No string guessing.
+    On failure `hops` includes the failing edge (full traversed chain).
+    """
+    hops: list[dict] = []
+    seen = {origin}
+    node = origin
+    while True:
+        # Rejected evidence is consulted BEFORE any outgoing edge is
+        # considered, at every node - a rejected node is never routed around.
+        if node in rejected:
+            return {"ok": False, "terminal": None, "hops": hops,
+                    "reason": rejected[node]["reason"],
+                    "rejection_evidence": rejected[node]["evidence"]}
+        edge = edges.get(node)
+        if edge is None:
+            return {"ok": True, "terminal": node, "hops": hops,
+                    "reason": None, "rejection_evidence": None}
+        nxt = edge["new"]
+        failure = None
+        if hops and edge["commit"] == hops[-1]["commit"]:
+            failure = "chain_same_commit"
+        elif hops and not ancestry.strictly_ancestral(hops[-1]["commit"],
+                                                      edge["commit"]):
+            failure = "chain_not_ancestrally_ordered"
+        elif nxt in seen:
+            failure = "chain_cycle"
+        elif nxt in base:
+            failure = ("intermediate_in_baseline_collision"
+                       if (nxt in edges or nxt in rejected)
+                       else "target_in_baseline_collision")
+        elif nxt in edges and nxt in active_names:
+            failure = "intermediate_still_active"
+        if failure:
+            return {"ok": False, "terminal": None, "hops": hops + [edge],
+                    "reason": failure, "rejection_evidence": None}
+        hops.append(edge)
+        seen.add(nxt)
+        node = nxt
+
+
+def _reject_converging_terminals(rows: list[dict], counts: dict) -> None:
+    """Two release ids must not both claim one candidate terminal.
+
+    Chain mode's final global guard: if two rows classified RENAMED_CANDIDATE
+    converge on the same terminal, BOTH are downgraded to UNRESOLVED with the
+    full traversed chains kept visible. The edge-level fan-in rule already
+    rejects shared direct targets; this closes the chain-level merge case.
+    """
+    by_terminal: dict[str, list[str]] = {}
+    for row in rows:
+        if row["status"] == STATUS_RENAMED:
+            by_terminal.setdefault(row["renamed_to"], []).append(row["id"])
+    for terminal, origins in by_terminal.items():
+        if len(origins) < 2:
+            continue
+        for row in rows:
+            if (row["status"] == STATUS_RENAMED and row["id"] in origins
+                    and row["renamed_to"] == terminal):
+                row["chain_terminal"] = row.pop("renamed_to")
+                for key in ("current_flat", "current_mains", "ratio"):
+                    row.pop(key, None)
+                row["status"] = STATUS_UNRESOLVED
+                row["reason"] = "ambiguous_converging_terminal"
+                row["converging_origins"] = sorted(origins)
+                counts[STATUS_RENAMED] -= 1
+                counts[STATUS_UNRESOLVED] += 1
+
+
+def classify(raw_ids: list[str], base: dict, now: dict,
+             active_names: set[str], edges: dict, rejected: dict,
+             active_resolver, follow_chains=False, ancestry=None
+             ) -> tuple[list[dict], dict]:
+    """Exactly one classification row per raw unmatched id; counts sum to raw.
+
+    `active_resolver(name)` re-resolves an active name through the Ruleset:
+    an exception or a None return means the weapon is BROKEN, so the row is
+    UNRESOLVED/resolution_failed - never a harmless metric-only claim.
+    With `follow_chains=True` (opt-in), first-hop targets that are themselves
+    unmatched are followed through `resolve_chain` (needs `ancestry`);
+    the default one-hop path is untouched.
+    """
+    if follow_chains and ancestry is None:
+        raise ValueError("follow_chains=True requires an AncestryChecker")
+    rows: list[dict] = []
+    counts = {STATUS_ACTIVE: 0, STATUS_RENAMED: 0, STATUS_UNRESOLVED: 0}
+    for name in raw_ids:
+        was = base.get(name, {})
+        row: dict = {
+            "id": name,
+            "baseline_flat": was.get("flat"),
+            "baseline_mains": was.get("mains"),
+        }
+        if name in active_names:
+            try:
+                resolved = active_resolver(name)
+            except Exception as exc:  # noqa: BLE001 - any failure is a refusal
+                row["status"] = STATUS_UNRESOLVED
+                row["reason"] = "resolution_failed"
+                row["error"] = f"{type(exc).__name__}: {exc}"
+            else:
+                if resolved is None:
+                    row["status"] = STATUS_UNRESOLVED
+                    row["reason"] = "resolution_failed"
+                    row["error"] = ("resolve_weapon returned None - "
+                                    "unresolvable inheritance or cycle")
+                else:
+                    row["status"] = STATUS_ACTIVE
+                    row["reason"] = ("exists_in_active_ruleset_but_excluded_"
+                                     "from_snapshot_metric")
+        elif name in edges:
+            if not follow_chains:
+                edge = edges[name]
+                target = edge["new"]
+                if target in base:
+                    row["status"] = STATUS_UNRESOLVED
+                    row["reason"] = "target_in_baseline_collision"
+                    row["evidence"] = {k: edge[k] for k in ("commit", "path", "old", "new")}
+                elif target not in now:
+                    row["status"] = STATUS_UNRESOLVED
+                    row["reason"] = "target_not_measured"
+                    row["evidence"] = {k: edge[k] for k in ("commit", "path", "old", "new")}
+                else:
+                    cur = now[target]
+                    baseline_flat = was.get("flat") or 0
+                    row.update({
+                        "status": STATUS_RENAMED,
+                        "renamed_to": target,
+                        "current_flat": cur["flat"],
+                        "current_mains": cur["mains"],
+                        "ratio": (round(cur["flat"] / baseline_flat, 4)
+                                  if baseline_flat else None),
+                        "evidence": {k: edge[k] for k in ("commit", "path", "old", "new")},
+                    })
+            else:
+                walked = resolve_chain(name, edges, rejected, base,
+                                       active_names, ancestry)
+                chain_view = [_hop_view(h) for h in walked["hops"]]
+                if not walked["ok"]:
+                    row["status"] = STATUS_UNRESOLVED
+                    row["reason"] = walked["reason"]
+                    if chain_view:
+                        row["evidence_chain"] = chain_view
+                        row["evidence"] = chain_view[0]
+                    if walked["rejection_evidence"] is not None:
+                        row["rejection_evidence"] = walked["rejection_evidence"]
+                else:
+                    terminal = walked["terminal"]
+                    row["evidence_chain"] = chain_view
+                    row["evidence"] = chain_view[0]
+                    if terminal not in active_names:
+                        row["status"] = STATUS_UNRESOLVED
+                        row["reason"] = "terminal_not_active"
+                        row["chain_terminal"] = terminal
+                    else:
+                        try:
+                            resolved = active_resolver(terminal)
+                        except Exception as exc:  # noqa: BLE001 - refusal
+                            row["status"] = STATUS_UNRESOLVED
+                            row["reason"] = "terminal_resolution_failed"
+                            row["chain_terminal"] = terminal
+                            row["error"] = f"{type(exc).__name__}: {exc}"
+                        else:
+                            if resolved is None:
+                                row["status"] = STATUS_UNRESOLVED
+                                row["reason"] = "terminal_resolution_failed"
+                                row["chain_terminal"] = terminal
+                                row["error"] = (
+                                    "resolve_weapon returned None - "
+                                    "unresolvable inheritance or cycle")
+                            elif terminal not in now:
+                                row["status"] = STATUS_UNRESOLVED
+                                row["reason"] = "target_not_measured"
+                                row["chain_terminal"] = terminal
+                            else:
+                                cur = now[terminal]
+                                baseline_flat = was.get("flat") or 0
+                                row.update({
+                                    "status": STATUS_RENAMED,
+                                    "renamed_to": terminal,
+                                    "current_flat": cur["flat"],
+                                    "current_mains": cur["mains"],
+                                    "ratio": (round(cur["flat"] / baseline_flat, 4)
+                                              if baseline_flat else None),
+                                })
+        elif name in rejected:
+            row["status"] = STATUS_UNRESOLVED
+            row["reason"] = rejected[name]["reason"]
+            row["evidence"] = rejected[name]["evidence"]
+        else:
+            row["status"] = STATUS_UNRESOLVED
+            row["reason"] = "no_rename_evidence"
+        counts[row["status"]] += 1
+        rows.append(row)
+    if follow_chains:
+        _reject_converging_terminals(rows, counts)
+    return rows, counts
+
+
+def build_report(repo: pathlib.Path, rename_refs: list[str],
+                 run=_git, follow_chains=False) -> dict:
+    """Assemble the full stdout JSON document."""
+    head = head_commit(repo, run)
+    dirty = worktree_dirty(repo, run)
+    meta, base = load_baseline(repo)
+    now = snapshot(repo)
+    rs = miniyaml.Ruleset(repo)
+    raw_ids = sorted(n for n in base if n not in now)
+
+    commit_evidence: list[dict] = []
+    evidences: list[dict] = []
+    for ref in rename_refs:
+        commit = resolve_commit(ref, repo, run)
+        require_ancestor(commit, repo, run)
+        pairs = extract_commit_pairs(commit, repo, run)
+        commit_evidence.append({"ref": ref, "commit": commit, "pairs": len(pairs)})
+        for pair in pairs:
+            evidences.append({"commit": commit, **pair})
+    if follow_chains:
+        edges, rejected = resolve_evidence_strict(evidences)
+        ancestry = AncestryChecker(repo, run)
+    else:
+        edges, rejected = resolve_evidence(evidences)
+        ancestry = None
+    rows, counts = classify(raw_ids, base, now, set(rs.weapons), edges,
+                            rejected, rs.resolve_weapon,
+                            follow_chains=follow_chains, ancestry=ancestry)
+
+    report = {
+        "what": "C19 diagnostic triage of audit_release_drift D4 unmatched "
+                "ids. Read-only; identity evidence only - a RENAMED_CANDIDATE "
+                "is NOT damage equivalence, NOT accepted drift, NOT deletion "
+                "proof.",
+        "measurement_basis": "working_tree",
+        "worktree_dirty": dirty,
+        "caveat": "Snapshot and active-Ruleset measurements are taken from the "
+                  "CURRENT WORKING TREE, not from gitHEAD. A dirty worktree "
+                  "means the measured values are not certified by gitHEAD, and "
+                  "dirty-tree values never certify gitHEAD. Historical rename "
+                  "evidence never licenses accepted drift.",
+        "gitHEAD": head,
+        "releasecommit": meta["_release_commit"],
+        "release_tag": meta["_release_tag"],
+        "raw_unmatched": len(raw_ids),
+        "classified": counts,
+        "classified_sum": sum(counts.values()),
+        "rename_commits": commit_evidence,
+        "rows": rows,
+    }
+    if follow_chains:
+        report["follow_rename_chains"] = True
+        report["chain_collision_coverage"] = (
+            "Chain mode consults ONLY the measured baseline population and "
+            "the historical evidence supplied via --rename-commit. It is not "
+            "exhaustive history, not full historical namespace proof, and "
+            "not identity certification; RENAMED_CANDIDATE is never accepted "
+            "drift.")
+    return report
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--rename-commit", action="append", default=[],
+                    metavar="COMMIT",
+                    help="commit holding exact top-level weapon renames "
+                         "(repeatable; e.g. 7a296c96d, bcb1a8f05)")
+    ap.add_argument("--follow-rename-chains", action="store_true",
+                    default=False,
+                    help="opt-in: follow exact adjacent one-hop rename edges "
+                         "through unmatched intermediates (strict chronology, "
+                         "provenance, fan-in and cycle rejection; the terminal "
+                         "must be measured, active and resolve cleanly)")
+    args = ap.parse_args()
+
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    report = build_report(repo, args.rename_commit,
+                          follow_chains=args.follow_rename_chains)
+    print(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_release_identity_triage.py
+++ b/tools/tests/test_release_identity_triage.py
@@ -1,0 +1,1100 @@
+"""Focused tests for the C19 release-identity triage diagnostic.
+
+Pure helpers + stubbed git/fixtures only (plus one tiny real-git binding
+test) - no real repo parse, no network.
+Run: python tools/tests/test_release_identity_triage.py
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "tools/audit"))
+import triage_release_identities as tri
+
+FULL = "a" * 40
+
+
+def diff_text(*lines):
+    return "\n".join(lines) + "\n"
+
+
+def file_header(path):
+    return [
+        f"diff --git a/{path} b/{path}",
+        "index 1111111..2222222 100644",
+        f"--- a/{path}",
+        f"+++ b/{path}",
+    ]
+
+
+WEAPONS = "mods/cameo/ContentPacks/X/yaml/weapons.yaml"
+ROOT_WEAPONS = "mods/cameo/weapons/tier1.yaml"
+ACTOR_YAML = "mods/cameo/ContentPacks/RA/Allies/yaml/aircraft.yaml"
+VEHICLES_YAML = "mods/cameo/ContentPacks/RA/Allies/yaml/vehicles.yaml"
+
+GOOD_RENAME = diff_text(*file_header(WEAPONS), "@@ -10 +10 @@", "-HydraSpit:",
+                        "+HydraSpit_AA:")
+
+FIELD_EDITS = diff_text(*file_header(WEAPONS), "@@ -10 +10 @@",
+                        "-\t\tWeapon: Aphid", "+\t\tWeapon: Aphid_AA")
+
+MULTI_HEADER = diff_text(*file_header(WEAPONS), "@@ -10,4 +10,4 @@",
+                         "-HydraSpit:", "+HydraSpit_AA:", "-Aphid:", "+Aphid_AA:")
+
+NONADJACENT = diff_text(*file_header(WEAPONS), "@@ -10,3 +10,3 @@",
+                        "-HydraSpit:", " \tInherits: ^Base", "+HydraSpit_AA:")
+
+TEMPLATE_HEADER = diff_text(*file_header(WEAPONS), "@@ -10 +10 @@",
+                            "-^BaseWeapon:", "+^BaseWeapon_AA:")
+
+CANCELLATION = diff_text(*file_header(WEAPONS), "@@ -10 +10 @@",
+                         "--StaleWeapon:", "+StaleWeaponReborn:")
+
+NON_YAML = diff_text(*file_header("docs/notes.md"), "@@ -10 +10 @@",
+                     "-HydraSpit:", "+HydraSpit_AA:")
+
+ACTOR_RENAME = diff_text(*file_header(ACTOR_YAML), "@@ -10 +10 @@",
+                         "-Aphid:", "+Aphid_AA:")
+
+NONCONFORMING_YAML = diff_text(*file_header(VEHICLES_YAML), "@@ -10 +10 @@",
+                               "-Aphid:", "+Aphid_AA:")
+
+DOTTED_LEGACY = diff_text(
+    *file_header("mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml"),
+    "@@ -530 +530 @@", "-EMPDisable.anim:", "+Ixian_EMP_charge:")
+
+HYPHEN_LEGACY = diff_text(*file_header(WEAPONS), "@@ -7 +7 @@",
+                          "-TSCABAL_EMP_Disable.end:", "+TSCABAL_EMP_disable:")
+
+DOTTED_CANCELLATION = diff_text(*file_header(WEAPONS), "@@ -9 +9 @@",
+                                "--EMPDisable.anim:", "+EMPDisable.anim2:")
+
+NEGATIVE_HYPHEN = diff_text(*file_header(WEAPONS), "@@ -11 +11 @@",
+                            "--Weapon-hack:", "+Weapon-hack2:")
+
+INLINE_VALUE = diff_text(*file_header(WEAPONS), "@@ -13 +13 @@",
+                         "-Dotted.legacy: inherit-me", "+Dotted.legacy2:")
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+def fake_git(responses):
+    """run(cmd) -> first CompletedProcess whose needle appears in the cmd."""
+    def run(cmd):
+        joined = " ".join(cmd)
+        for needle, cp in responses.items():
+            if needle in joined:
+                return cp
+        raise AssertionError(f"unexpected git call: {joined}")
+    return run
+
+
+def recording_run(returncode=0, stdout=""):
+    calls = []
+
+    def run(cmd):
+        calls.append(list(cmd))
+        return completed(returncode, stdout)
+
+    return run, calls
+
+
+class WeaponLayoutTests(unittest.TestCase):
+    def test_pack_weapons_yaml_accepted(self):
+        self.assertTrue(tri.is_weapon_yaml(WEAPONS))
+
+    def test_root_weapons_yaml_accepted(self):
+        self.assertTrue(tri.is_weapon_yaml(ROOT_WEAPONS))
+
+    def test_actor_yaml_refused(self):
+        self.assertFalse(tri.is_weapon_yaml(ACTOR_YAML))
+
+    def test_non_weapons_pack_yaml_refused(self):
+        self.assertFalse(tri.is_weapon_yaml(VEHICLES_YAML))
+
+    def test_root_rules_sequences_chrome_refused(self):
+        for path in ("mods/cameo/rules/redalert2.yaml",
+                     "mods/cameo/sequences/315custom.yaml",
+                     "mods/cameo/audio/advancewars.yaml",
+                     "mods/cameo/chrome/lobby.yaml"):
+            self.assertFalse(tri.is_weapon_yaml(path))
+
+    def test_nested_root_weapons_subdir_refused(self):
+        self.assertFalse(tri.is_weapon_yaml("mods/cameo/weapons/sub/x.yaml"))
+
+    def test_contentpacks_yaml_weapons_without_faction_refused(self):
+        self.assertFalse(
+            tri.is_weapon_yaml("mods/cameo/ContentPacks/yaml/weapons.yaml"))
+
+    def test_outside_cameo_refused(self):
+        self.assertFalse(tri.is_weapon_yaml("mods/other/weapons/x.yaml"))
+
+
+class ParseRenamePairsTests(unittest.TestCase):
+    def test_exact_adjacent_rename_is_evidence_with_path(self):
+        pairs = tri.parse_rename_pairs(GOOD_RENAME)
+        self.assertEqual(1, len(pairs))
+        self.assertEqual({"path": WEAPONS, "old": "HydraSpit",
+                          "new": "HydraSpit_AA"}, pairs[0])
+
+    def test_root_weapons_layout_accepted(self):
+        pairs = tri.parse_rename_pairs(
+            diff_text(*file_header(ROOT_WEAPONS), "@@ -3 +3 @@",
+                      "-OldGun:", "+NewGun:"))
+        self.assertEqual([{"path": ROOT_WEAPONS, "old": "OldGun",
+                           "new": "NewGun"}], pairs)
+
+    def test_actor_yaml_with_matching_weapon_names_refused(self):
+        self.assertEqual([], tri.parse_rename_pairs(ACTOR_RENAME))
+
+    def test_nonconforming_pack_yaml_refused(self):
+        self.assertEqual([], tri.parse_rename_pairs(NONCONFORMING_YAML))
+
+    def test_field_edits_are_never_name_pairs(self):
+        self.assertEqual([], tri.parse_rename_pairs(FIELD_EDITS))
+
+    def test_hunk_with_multiple_headers_is_ignored(self):
+        self.assertEqual([], tri.parse_rename_pairs(MULTI_HEADER))
+
+    def test_nonadjacent_headers_are_ignored(self):
+        self.assertEqual([], tri.parse_rename_pairs(NONADJACENT))
+
+    def test_template_headers_excluded(self):
+        self.assertEqual([], tri.parse_rename_pairs(TEMPLATE_HEADER))
+
+    def test_cancellation_node_removal_is_not_a_rename(self):
+        self.assertEqual([], tri.parse_rename_pairs(CANCELLATION))
+
+    def test_non_yaml_path_ignored(self):
+        self.assertEqual([], tri.parse_rename_pairs(NON_YAML))
+
+    def test_names_are_bare_ids_without_colon(self):
+        for pair in tri.parse_rename_pairs(GOOD_RENAME):
+            self.assertFalse(pair["old"].endswith(":"))
+            self.assertFalse(pair["new"].endswith(":"))
+
+    def test_dotted_legacy_pair_accepted(self):
+        pairs = tri.parse_rename_pairs(DOTTED_LEGACY)
+        self.assertEqual([{"path": "mods/cameo/ContentPacks/D2k/Ixian/yaml/weapons.yaml",
+                           "old": "EMPDisable.anim",
+                           "new": "Ixian_EMP_charge"}], pairs)
+
+    def test_hyphenated_legacy_pair_accepted(self):
+        pairs = tri.parse_rename_pairs(HYPHEN_LEGACY)
+        self.assertEqual([{"path": WEAPONS,
+                           "old": "TSCABAL_EMP_Disable.end",
+                           "new": "TSCABAL_EMP_disable"}], pairs)
+
+    def test_dotted_cancellation_removal_still_rejected(self):
+        self.assertEqual([], tri.parse_rename_pairs(DOTTED_CANCELLATION))
+
+    def test_leading_hyphen_name_never_a_header(self):
+        # A diff line `--Name:` is a cancellation removal (content `-Name:`);
+        # a name can never begin with `-`, so this is never a rename pair.
+        self.assertEqual([], tri.parse_rename_pairs(NEGATIVE_HYPHEN))
+
+    def test_inline_value_never_a_header(self):
+        self.assertEqual([], tri.parse_rename_pairs(INLINE_VALUE))
+
+    def test_dotted_legacy_survives_full_pipeline(self):
+        pairs = tri.parse_rename_pairs(DOTTED_LEGACY)
+        edges, rejected = tri.resolve_evidence(
+            [dict(p, commit=FULL) for p in pairs])
+        base = {"EMPDisable.anim": {"flat": 500, "mains": 1}}
+        now = {"Ixian_EMP_charge": {"flat": 500, "mains": 1}}
+        rows, counts = tri.classify(["EMPDisable.anim"], base, now, set(),
+                                    edges, rejected, lambda n: object())
+        self.assertEqual(tri.STATUS_RENAMED, rows[0]["status"])
+        self.assertEqual("Ixian_EMP_charge", rows[0]["renamed_to"])
+        self.assertEqual(1, sum(counts.values()))
+
+
+class ParseToClassifyIntegrationTests(unittest.TestCase):
+    """Regression: a colon retained anywhere in old/new must not classify."""
+
+    def test_parse_resolve_classify_produces_renamed_candidate(self):
+        pairs = tri.parse_rename_pairs(GOOD_RENAME)
+        evidences = [dict(p, commit=FULL) for p in pairs]
+        edges, rejected = tri.resolve_evidence(evidences)
+        self.assertEqual({}, rejected)
+        base = {"HydraSpit": {"flat": 8000, "mains": 4}}
+        now = {"HydraSpit_AA": {"flat": 8000, "mains": 4}}
+        rows, counts = tri.classify(["HydraSpit"], base, now, set(), edges,
+                                    rejected, lambda n: object())
+        self.assertEqual(tri.STATUS_RENAMED, rows[0]["status"])
+        self.assertEqual("HydraSpit_AA", rows[0]["renamed_to"])
+        self.assertEqual(FULL, rows[0]["evidence"]["commit"])
+        self.assertEqual(WEAPONS, rows[0]["evidence"]["path"])
+        self.assertEqual(1.0, rows[0]["ratio"])
+
+    def test_colon_contaminated_names_cannot_classify(self):
+        edges = {"HydraSpit:": {"commit": FULL, "path": WEAPONS,
+                                "old": "HydraSpit:", "new": "HydraSpit_AA:"}}
+        base = {"HydraSpit": {"flat": 8000, "mains": 4}}
+        now = {"HydraSpit_AA": {"flat": 8000, "mains": 4}}
+        rows, counts = tri.classify(["HydraSpit"], base, now, set(), edges,
+                                    {}, lambda n: object())
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual(1, counts[tri.STATUS_UNRESOLVED])
+
+
+class ResolveEvidenceTests(unittest.TestCase):
+    @staticmethod
+    def ev(old, new, commit="c1"):
+        return {"commit": commit, "path": WEAPONS, "old": old, "new": new}
+
+    def test_unique_edge_survives(self):
+        edges, rejected = tri.resolve_evidence([self.ev("A", "B")])
+        self.assertEqual("B", edges["A"]["new"])
+        self.assertEqual({}, rejected)
+
+    def test_one_to_many_rejected(self):
+        edges, rejected = tri.resolve_evidence(
+            [self.ev("A", "B", "c1"), self.ev("A", "C", "c2")])
+        self.assertNotIn("A", edges)
+        self.assertEqual("ambiguous_multiple_targets", rejected["A"]["reason"])
+        self.assertEqual(2, len(rejected["A"]["evidence"]))
+
+    def test_many_to_one_rejected(self):
+        edges, rejected = tri.resolve_evidence(
+            [self.ev("A", "Z"), self.ev("B", "Z")])
+        self.assertNotIn("A", edges)
+        self.assertNotIn("B", edges)
+        self.assertEqual("ambiguous_shared_target", rejected["A"]["reason"])
+        self.assertEqual("ambiguous_shared_target", rejected["B"]["reason"])
+
+    def test_fan_in_uses_edges_of_one_to_many_rejected_source(self):
+        # A->X, B->X, B->Y: B is one-to-many, but A->X must STILL be rejected.
+        edges, rejected = tri.resolve_evidence(
+            [self.ev("A", "X"), self.ev("B", "X", "c2"), self.ev("B", "Y", "c2")])
+        self.assertEqual({}, edges)
+        self.assertEqual("ambiguous_shared_target", rejected["A"]["reason"])
+        self.assertIn("A", {e["old"] for e in rejected["A"]["evidence"]})
+
+    def test_cycle_rejected(self):
+        edges, rejected = tri.resolve_evidence(
+            [self.ev("A", "B"), self.ev("B", "A")])
+        self.assertEqual({}, edges)
+        self.assertEqual("ambiguous_cycle", rejected["A"]["reason"])
+        self.assertEqual("ambiguous_cycle", rejected["B"]["reason"])
+
+    def test_longer_cycle_rejected(self):
+        edges, rejected = tri.resolve_evidence(
+            [self.ev("A", "B"), self.ev("B", "C"), self.ev("C", "A")])
+        self.assertEqual({}, edges)
+        self.assertEqual({"A", "B", "C"}, set(rejected))
+
+    def test_self_loop_rejected(self):
+        edges, rejected = tri.resolve_evidence([self.ev("A", "A")])
+        self.assertNotIn("A", edges)
+        self.assertEqual("ambiguous_cycle", rejected["A"]["reason"])
+
+
+class ClassifyTests(unittest.TestCase):
+    def setUp(self):
+        self.base = {
+            "Active1": {"flat": 100, "mains": 1},
+            "Old1": {"flat": 8000, "mains": 4},
+            "NoEv": {"flat": 500, "mains": 2},
+            "Old2": {"flat": 300, "mains": 1},
+            "Old3": {"flat": 300, "mains": 1},
+            "Survivor": {"flat": 900, "mains": 3},
+        }
+        self.now = {"New1": {"flat": 16000, "mains": 4},
+                    "Survivor": {"flat": 900, "mains": 3}}
+        self.active = {"Active1"}
+        self.edge = {"commit": "c1", "path": WEAPONS, "old": "Old1", "new": "New1"}
+        self.resolver = lambda name: object()  # noqa: E731 - healthy resolve
+
+    def rows(self, ids, edges=None, rejected=None, resolver=None):
+        return tri.classify(ids, self.base, self.now, self.active,
+                            edges or {}, rejected or {},
+                            resolver or self.resolver)
+
+    def test_active_unmeasured(self):
+        rows, counts = self.rows(["Active1"])
+        self.assertEqual(tri.STATUS_ACTIVE, rows[0]["status"])
+        self.assertEqual(1, counts[tri.STATUS_ACTIVE])
+
+    def test_active_wins_over_rename_evidence(self):
+        edges = {"Active1": dict(self.edge, old="Active1")}
+        rows, _ = self.rows(["Active1"], edges=edges)
+        self.assertEqual(tri.STATUS_ACTIVE, rows[0]["status"])
+
+    def test_resolver_exception_is_resolution_failed_not_harmless(self):
+        def broken(name):
+            raise RuntimeError("boom")
+        rows, _ = self.rows(["Active1"], resolver=broken)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("resolution_failed", rows[0]["reason"])
+        self.assertIn("RuntimeError: boom", rows[0]["error"])
+
+    def test_resolver_none_is_resolution_failed(self):
+        rows, _ = self.rows(["Active1"], resolver=lambda name: None)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("resolution_failed", rows[0]["reason"])
+
+    def test_renamed_candidate_reports_flats_mains_ratio_and_evidence(self):
+        rows, _ = self.rows(["Old1"], edges={"Old1": dict(self.edge)})
+        row = rows[0]
+        self.assertEqual(tri.STATUS_RENAMED, row["status"])
+        self.assertEqual("New1", row["renamed_to"])
+        self.assertEqual(8000, row["baseline_flat"])
+        self.assertEqual(4, row["baseline_mains"])
+        self.assertEqual(16000, row["current_flat"])
+        self.assertEqual(4, row["current_mains"])
+        self.assertEqual(2.0, row["ratio"])
+        self.assertEqual({"commit": "c1", "path": WEAPONS,
+                          "old": "Old1", "new": "New1"}, row["evidence"])
+
+    def test_unresolved_without_evidence(self):
+        rows, _ = self.rows(["NoEv"])
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("no_rename_evidence", rows[0]["reason"])
+
+    def test_target_in_baseline_is_collision_not_double_assignment(self):
+        edges = {"Old2": {"commit": "c1", "path": WEAPONS, "old": "Old2",
+                          "new": "Survivor"}}
+        rows, _ = self.rows(["Old2"], edges=edges)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("target_in_baseline_collision", rows[0]["reason"])
+
+    def test_target_not_measured_is_unresolved_no_chains(self):
+        edges = {"Old2": {"commit": "c1", "path": WEAPONS, "old": "Old2",
+                          "new": "GhostTarget"}}
+        rows, _ = self.rows(["Old2"], edges=edges)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("target_not_measured", rows[0]["reason"])
+
+    def test_rejected_ambiguity_lands_on_unresolved_with_evidence(self):
+        raw = [{"commit": "c1", "path": WEAPONS, "old": "Old3", "new": "A"},
+               {"commit": "c1", "path": WEAPONS, "old": "Old3", "new": "B"}]
+        _, rejected = tri.resolve_evidence(raw)
+        rows, _ = self.rows(["Old3"], rejected=rejected)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("ambiguous_multiple_targets", rows[0]["reason"])
+        self.assertEqual(raw, rows[0]["evidence"])
+
+    def test_partition_one_row_per_raw_id_and_sum_matches(self):
+        ids = ["Active1", "Old1", "NoEv", "Old2", "Old3"]
+        edges = {"Old1": dict(self.edge)}
+        _, rejected = tri.resolve_evidence(
+            [{"commit": "c1", "path": WEAPONS, "old": "Old2", "new": "P"},
+             {"commit": "c1", "path": WEAPONS, "old": "Old3", "new": "P"}])
+        rows, counts = self.rows(ids, edges=edges, rejected=rejected)
+        self.assertEqual([r["id"] for r in rows], ids)
+        self.assertEqual(len(set(r["id"] for r in rows)), len(ids))
+        self.assertEqual(len(ids), sum(counts.values()))
+
+
+class GitGuardTests(unittest.TestCase):
+    def test_all_git_calls_bind_repo_explicitly(self):
+        run, calls = recording_run(0, FULL + "\n")
+        tri.resolve_commit("7a296c96d", "R:/repo", run)
+        tri.require_ancestor(FULL, "R:/repo", run)
+        tri.extract_commit_pairs(FULL, "R:/repo", run)
+        tri.head_commit("R:/repo", run)
+        tri.worktree_dirty("R:/repo", run)
+        self.assertTrue(calls)
+        for cmd in calls:
+            self.assertEqual(["git", "-C", "R:/repo"], cmd[:3])
+        joined = [" ".join(cmd) for cmd in calls]
+        self.assertTrue(any("rev-parse" in c for c in joined))
+        self.assertTrue(any("merge-base" in c for c in joined))
+        self.assertTrue(any(" show " in c for c in joined))
+        self.assertTrue(any("status" in c for c in joined))
+
+    def test_rev_parse_uses_end_of_options(self):
+        run, calls = recording_run(0, FULL + "\n")
+        tri.resolve_commit("-weird-ref", "R:/repo", run)
+        self.assertIn("--end-of-options", calls[0])
+
+    def test_unknown_commit_refused_with_exit_2(self):
+        run = fake_git({"bogus^{commit}": completed(
+            128, stderr="fatal: ambiguous argument")})
+        with self.assertRaises(SystemExit) as cm:
+            tri.resolve_commit("bogus", "R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_valid_commit_resolves_to_full_hash(self):
+        run = fake_git({"7a296c96d^{commit}": completed(0, stdout=FULL + "\n")})
+        self.assertEqual(FULL, tri.resolve_commit("7a296c96d", "R:/repo", run))
+
+    def test_non_hash_resolution_refused(self):
+        run = fake_git({"^{commit}": completed(0, stdout="abc123\n")})
+        with self.assertRaises(SystemExit) as cm:
+            tri.resolve_commit("abc123", "R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_head_failure_refused(self):
+        run = fake_git({"rev-parse": completed(128, stderr="fatal: not a repo")})
+        with self.assertRaises(SystemExit) as cm:
+            tri.head_commit("R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_non_ancestor_refused_with_exit_2(self):
+        run = fake_git({"merge-base": completed(1)})
+        with self.assertRaises(SystemExit) as cm:
+            tri.require_ancestor(FULL, "R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_git_show_failure_refused_with_exit_2(self):
+        run = fake_git({"show": completed(128, stderr="fatal: bad object")})
+        with self.assertRaises(SystemExit) as cm:
+            tri.extract_commit_pairs(FULL, "R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_git_status_failure_refused_with_exit_2(self):
+        run = fake_git({"status": completed(128, stderr="fatal")})
+        with self.assertRaises(SystemExit) as cm:
+            tri.worktree_dirty("R:/repo", run)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_worktree_dirty_flag(self):
+        clean, _ = recording_run(0, "")
+        dirty, _ = recording_run(0, " M tools/audit/x.py\n")
+        self.assertFalse(tri.worktree_dirty("R:/repo", clean))
+        self.assertTrue(tri.worktree_dirty("R:/repo", dirty))
+
+
+class RealGitBindingTests(unittest.TestCase):
+    """Real git, external CWD: commands must address the bound repo only."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name) / "bound-repo"
+        self.repo.mkdir()
+        for args in (["init"],
+                     ["-c", "user.email=t@example.com",
+                      "-c", "user.name=t", "commit", "--allow-empty",
+                      "-m", "init"]):
+            subprocess.run(["git", "-C", str(self.repo)] + args,
+                           capture_output=True, text=True, check=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_resolve_and_ancestry_from_external_cwd(self):
+        head = tri.head_commit(self.repo)
+        self.assertRegex(head, r"^[0-9a-f]{40}$")
+        self.assertEqual(head, tri.resolve_commit("HEAD", self.repo))
+        tri.require_ancestor(head, self.repo)
+        with self.assertRaises(SystemExit) as cm:
+            tri.resolve_commit("does-not-exist", self.repo)
+        self.assertEqual(2, cm.exception.code)
+
+
+class ChainCoreTests(unittest.TestCase):
+    """Opt-in chain mode (--follow-rename-chains): 6 core behaviours."""
+
+    H1, H2, H3 = "1" * 40, "2" * 40, "3" * 40
+
+    def setUp(self):
+        self.base = {"Orig": {"flat": 8000, "mains": 4},
+                     "Orig2": {"flat": 400, "mains": 2}}
+        self.now = {"Final": {"flat": 8000, "mains": 4},
+                    "Final2": {"flat": 400, "mains": 2},
+                    "Measured": {"flat": 100, "mains": 1}}
+        self.active = {"Final", "Final2", "Measured"}
+        self.resolver = lambda name: object()  # noqa: E731 - healthy resolve
+
+    @staticmethod
+    def hop(old, new, commit, path=WEAPONS):
+        return {"commit": commit, "path": path, "old": old, "new": new}
+
+    class FakeAncestry:
+        def __init__(self, ok=True, allowed=None):
+            self.ok = ok
+            self.allowed = dict(allowed or {})
+            self.calls = []
+
+        def strictly_ancestral(self, earlier, later):
+            self.calls.append((earlier, later))
+            if (earlier, later) in self.allowed:
+                return self.allowed[(earlier, later)]
+            return self.ok
+
+    def chain_classify(self, ids, edges, rejected=None, ancestry=None,
+                       resolver=None, active=None, base=None):
+        return tri.classify(
+            ids, base if base is not None else self.base, self.now,
+            self.active if active is None else active,
+            edges, rejected or {}, resolver or self.resolver,
+            follow_chains=True, ancestry=ancestry or self.FakeAncestry())
+
+    def test_valid_two_hop_chain_followed(self):
+        edges = {"Orig": self.hop("Orig", "Mid", self.H1),
+                 "Mid": self.hop("Mid", "Final", self.H2)}
+        rows, counts = self.chain_classify(["Orig"], edges)
+        row = rows[0]
+        self.assertEqual(tri.STATUS_RENAMED, row["status"])
+        self.assertEqual("Final", row["renamed_to"])
+        self.assertEqual(8000, row["baseline_flat"])
+        self.assertEqual(8000, row["current_flat"])
+        self.assertEqual(1.0, row["ratio"])
+        self.assertEqual([{"commit": self.H1, "path": WEAPONS,
+                           "old": "Orig", "new": "Mid"},
+                          {"commit": self.H2, "path": WEAPONS,
+                           "old": "Mid", "new": "Final"}],
+                         row["evidence_chain"])
+        self.assertEqual(row["evidence_chain"][0], row["evidence"])
+        self.assertEqual(1, counts[tri.STATUS_RENAMED])
+        self.assertEqual(1, sum(counts.values()))
+
+    def test_no_flag_one_hop_unchanged_schema(self):
+        edges = {"Orig": self.hop("Orig", "Final", self.H1)}
+        rows, counts = tri.classify(["Orig"], self.base, self.now,
+                                    self.active, edges, {}, self.resolver)
+        row = rows[0]
+        self.assertEqual(tri.STATUS_RENAMED, row["status"])
+        self.assertEqual("Final", row["renamed_to"])
+        self.assertEqual(1.0, row["ratio"])
+        self.assertNotIn("evidence_chain", row)
+        self.assertEqual({"id", "baseline_flat", "baseline_mains", "status",
+                          "renamed_to", "current_flat", "current_mains",
+                          "ratio", "evidence"}, set(row))
+        self.assertEqual({"commit": self.H1, "path": WEAPONS,
+                          "old": "Orig", "new": "Final"}, row["evidence"])
+
+    def test_same_commit_hop_rejected(self):
+        edges = {"Orig": self.hop("Orig", "Mid", self.H1),
+                 "Mid": self.hop("Mid", "Final", self.H1)}
+        anc = self.FakeAncestry()
+        rows, _ = self.chain_classify(["Orig"], edges, ancestry=anc)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("chain_same_commit", rows[0]["reason"])
+        self.assertEqual([], anc.calls)
+        self.assertEqual(2, len(rows[0]["evidence_chain"]))
+
+    def test_reverse_chronology_rejected_independent_of_input_order(self):
+        # Hop 1 commits later than hop 2: ancestry must fail regardless of
+        # the order refs/evidence were supplied.
+        edges = {"Orig": self.hop("Orig", "Mid", self.H2),
+                 "Mid": self.hop("Mid", "Final", self.H1)}
+        anc = self.FakeAncestry(ok=False, allowed={(self.H1, self.H2): True})
+        rows, _ = self.chain_classify(["Orig"], edges, ancestry=anc)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("chain_not_ancestrally_ordered", rows[0]["reason"])
+        self.assertEqual([(self.H2, self.H1)], anc.calls)
+
+    def test_active_unmeasured_intermediate_rejected(self):
+        edges = {"Orig": self.hop("Orig", "Mid", self.H1),
+                 "Mid": self.hop("Mid", "Final", self.H2)}
+        rows, _ = self.chain_classify(["Orig"], edges,
+                                      active=self.active | {"Mid"})
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("intermediate_still_active", rows[0]["reason"])
+        self.assertEqual([{"commit": self.H1, "path": WEAPONS,
+                           "old": "Orig", "new": "Mid"}],
+                         rows[0]["evidence_chain"])
+
+    def test_conflicting_provenance_edge_quarantined(self):
+        # Same old->new bound to two distinct commits is ambiguity - the hop
+        # must never "pick the convenient first".
+        raw = [self.hop("Orig", "Mid", self.H1),
+               self.hop("Orig", "Mid", self.H2)]
+        edges, rejected = tri.resolve_evidence_strict(raw)
+        self.assertEqual({}, edges)
+        self.assertEqual("ambiguous_multiple_provenance",
+                         rejected["Orig"]["reason"])
+        rows, _ = self.chain_classify(["Orig"], edges, rejected)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("ambiguous_multiple_provenance", rows[0]["reason"])
+        self.assertEqual(raw, rows[0]["evidence"])
+
+
+class ChainFoldTests(unittest.TestCase):
+    """resolve_evidence_strict: provenance unambiguity + unchanged globals."""
+
+    H1, H2 = "1" * 40, "2" * 40
+
+    @staticmethod
+    def hop(old, new, commit, path=WEAPONS):
+        return {"commit": commit, "path": path, "old": old, "new": new}
+
+    def test_duplicate_identical_evidence_collapses_harmlessly(self):
+        edges, rejected = tri.resolve_evidence_strict(
+            [self.hop("A", "B", self.H1), self.hop("A", "B", self.H1)])
+        self.assertEqual({}, rejected)
+        self.assertEqual("B", edges["A"]["new"])
+
+    def test_same_pair_distinct_paths_rejected(self):
+        raw = [self.hop("A", "B", self.H1),
+               self.hop("A", "B", self.H1, "mods/cameo/weapons/tier1.yaml")]
+        edges, rejected = tri.resolve_evidence_strict(raw)
+        self.assertEqual({}, edges)
+        self.assertEqual("ambiguous_multiple_provenance",
+                         rejected["A"]["reason"])
+        self.assertEqual(raw, rejected["A"]["evidence"])
+
+    def test_fan_in_uses_all_raw_edges_including_rejected_sources(self):
+        edges, rejected = tri.resolve_evidence_strict(
+            [self.hop("A", "X", self.H1), self.hop("B", "X", self.H2),
+             self.hop("B", "Y", self.H2)])
+        self.assertEqual({}, edges)
+        self.assertEqual("ambiguous_shared_target", rejected["A"]["reason"])
+        self.assertEqual("ambiguous_multiple_targets", rejected["B"]["reason"])
+
+    def test_cycles_still_rejected_in_strict_fold(self):
+        edges, rejected = tri.resolve_evidence_strict(
+            [self.hop("A", "B", self.H1), self.hop("B", "A", self.H2)])
+        self.assertEqual({}, edges)
+        self.assertEqual({"A", "B"}, set(rejected))
+        self.assertTrue(all(r["reason"] == "ambiguous_cycle"
+                            for r in rejected.values()))
+
+
+class ChainNegativeTests(unittest.TestCase):
+    """Remaining opt-in chain-mode coverage (negative + accounting)."""
+
+    H1, H2, H3 = "1" * 40, "2" * 40, "3" * 40
+
+    def setUp(self):
+        self.base = {"Orig": {"flat": 8000, "mains": 4},
+                     "Orig2": {"flat": 400, "mains": 2},
+                     "MidBase": {"flat": 100, "mains": 1}}
+        self.now = {"Final": {"flat": 8000, "mains": 4},
+                    "Final2": {"flat": 400, "mains": 2}}
+        self.active = {"Final", "Final2"}
+        self.resolver = lambda name: object()  # noqa: E731 - healthy resolve
+
+    @staticmethod
+    def hop(old, new, commit, path=WEAPONS):
+        return {"commit": commit, "path": path, "old": old, "new": new}
+
+    class FakeAncestry:
+        def __init__(self, ok=True, allowed=None):
+            self.ok = ok
+            self.allowed = dict(allowed or {})
+            self.calls = []
+
+        def strictly_ancestral(self, earlier, later):
+            self.calls.append((earlier, later))
+            if (earlier, later) in self.allowed:
+                return self.allowed[(earlier, later)]
+            return self.ok
+
+    def chain_classify(self, ids, edges, rejected=None, ancestry=None,
+                       resolver=None, active=None, base=None, now=None):
+        return tri.classify(
+            ids, base if base is not None else self.base,
+            now if now is not None else self.now,
+            self.active if active is None else active,
+            edges, rejected or {}, resolver or self.resolver,
+            follow_chains=True, ancestry=ancestry or self.FakeAncestry())
+
+    def test_valid_three_hop_chain(self):
+        edges = {"Orig": self.hop("Orig", "M1", self.H1),
+                 "M1": self.hop("M1", "M2", self.H2),
+                 "M2": self.hop("M2", "Final", self.H3)}
+        rows, counts = self.chain_classify(["Orig"], edges)
+        self.assertEqual(tri.STATUS_RENAMED, rows[0]["status"])
+        self.assertEqual("Final", rows[0]["renamed_to"])
+        self.assertEqual(3, len(rows[0]["evidence_chain"]))
+        self.assertEqual(1, counts[tri.STATUS_RENAMED])
+
+    def test_ref_input_order_independence(self):
+        # Evidence gathered in reverse ref order folds and walks the same.
+        ev = [self.hop("M1", "Final", self.H2),
+              self.hop("Orig", "M1", self.H1)]
+        edges, rejected = tri.resolve_evidence_strict(ev)
+        rows, _ = self.chain_classify(["Orig"], edges, rejected)
+        self.assertEqual(tri.STATUS_RENAMED, rows[0]["status"])
+        self.assertEqual("Final", rows[0]["renamed_to"])
+        self.assertEqual([self.H1, self.H2],
+                         [h["commit"] for h in rows[0]["evidence_chain"]])
+
+    def test_incomparable_branches_rejected(self):
+        edges = {"Orig": self.hop("Orig", "M", self.H1),
+                 "M": self.hop("M", "Final", self.H2)}
+        rows, _ = self.chain_classify(["Orig"], edges,
+                                      ancestry=self.FakeAncestry(ok=False))
+        self.assertEqual("chain_not_ancestrally_ordered", rows[0]["reason"])
+
+    def test_repeated_node_cycle_rejected_with_full_chain(self):
+        edges = {"Orig": self.hop("Orig", "M", self.H1),
+                 "M": self.hop("M", "Orig", self.H2)}
+        rows, _ = self.chain_classify(["Orig"], edges)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("chain_cycle", rows[0]["reason"])
+        self.assertEqual(2, len(rows[0]["evidence_chain"]))
+
+    def test_self_loop_repeated_node_rejected(self):
+        edges = {"Orig": self.hop("Orig", "M", self.H1),
+                 "M": self.hop("M", "M", self.H2)}
+        rows, _ = self.chain_classify(["Orig"], edges)
+        self.assertEqual("chain_cycle", rows[0]["reason"])
+
+    def test_fan_in_from_rejected_source_blocks_chain(self):
+        raw = [self.hop("A", "X", self.H1), self.hop("B", "X", self.H2),
+               self.hop("B", "Y", self.H2)]
+        edges, rejected = tri.resolve_evidence_strict(raw)
+        rows, _ = self.chain_classify(["A"], edges, rejected)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("ambiguous_shared_target", rows[0]["reason"])
+
+    def test_intermediate_outgoing_ambiguity_never_routed_around(self):
+        edges = {"Orig": self.hop("Orig", "Mid", self.H1)}
+        rejected = {"Mid": {"reason": "ambiguous_multiple_targets",
+                            "evidence": [self.hop("Mid", "X", self.H2),
+                                         self.hop("Mid", "Y", self.H2)]}}
+        rows, _ = self.chain_classify(["Orig"], edges, rejected)
+        row = rows[0]
+        self.assertEqual(tri.STATUS_UNRESOLVED, row["status"])
+        self.assertEqual("ambiguous_multiple_targets", row["reason"])
+        self.assertEqual([{"commit": self.H1, "path": WEAPONS,
+                           "old": "Orig", "new": "Mid"}],
+                         row["evidence_chain"])
+        self.assertEqual(row["evidence"], row["evidence_chain"][0])
+        self.assertEqual(rejected["Mid"]["evidence"], row["rejection_evidence"])
+
+    def test_baseline_measured_intermediate_rejected(self):
+        edges = {"Orig": self.hop("Orig", "MidBase", self.H1),
+                 "MidBase": self.hop("MidBase", "Final", self.H2)}
+        rows, _ = self.chain_classify(["Orig"], edges)
+        self.assertEqual("intermediate_in_baseline_collision",
+                         rows[0]["reason"])
+
+    def test_baseline_measured_terminal_rejected(self):
+        edges = {"Orig": self.hop("Orig", "MidBase", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges)
+        self.assertEqual("target_in_baseline_collision", rows[0]["reason"])
+        self.assertEqual(1, len(rows[0]["evidence_chain"]))
+
+    def test_missing_hop_no_fuzzy_bridging(self):
+        # Ghost has no evidence anywhere: no fuzzy bridging, precise reason,
+        # partial chain visible.
+        edges = {"Orig": self.hop("Orig", "Ghost", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges)
+        row = rows[0]
+        self.assertEqual(tri.STATUS_UNRESOLVED, row["status"])
+        self.assertEqual("terminal_not_active", row["reason"])
+        self.assertEqual("Ghost", row["chain_terminal"])
+        self.assertEqual([{"commit": self.H1, "path": WEAPONS,
+                           "old": "Orig", "new": "Ghost"}],
+                         row["evidence_chain"])
+
+    def test_active_unmeasured_terminal_is_target_not_measured(self):
+        edges = {"Orig": self.hop("Orig", "ActGhost", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges,
+                                      active=self.active | {"ActGhost"})
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("target_not_measured", rows[0]["reason"])
+
+    def test_inactive_measured_terminal_is_terminal_not_active(self):
+        edges = {"Orig": self.hop("Orig", "Final", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges, active=set())
+        self.assertEqual("terminal_not_active", rows[0]["reason"])
+
+    def test_terminal_resolver_none_is_explicit_failure(self):
+        edges = {"Orig": self.hop("Orig", "Final", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges,
+                                      resolver=lambda name: None)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("terminal_resolution_failed", rows[0]["reason"])
+        self.assertIn("None", rows[0]["error"])
+
+    def test_terminal_resolver_raises_is_explicit_failure(self):
+        def boom(name):
+            raise RuntimeError("boom")
+        edges = {"Orig": self.hop("Orig", "Final", self.H1)}
+        rows, _ = self.chain_classify(["Orig"], edges, resolver=boom)
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("terminal_resolution_failed", rows[0]["reason"])
+        self.assertIn("RuntimeError: boom", rows[0]["error"])
+
+    def test_two_origins_one_terminal_both_downgraded(self):
+        h4 = "4" * 40
+        edges = {"Orig": self.hop("Orig", "M1", self.H1),
+                 "M1": self.hop("M1", "Final", self.H2),
+                 "Orig2": self.hop("Orig2", "M2", self.H3),
+                 "M2": self.hop("M2", "Final", h4)}
+        rows, counts = self.chain_classify(["Orig", "Orig2"], edges)
+        for row in rows:
+            self.assertEqual(tri.STATUS_UNRESOLVED, row["status"])
+            self.assertEqual("ambiguous_converging_terminal", row["reason"])
+            self.assertEqual("Final", row["chain_terminal"])
+            self.assertNotIn("renamed_to", row)
+            self.assertEqual(2, len(row["evidence_chain"]))
+        self.assertEqual(["Orig", "Orig2"], rows[0]["converging_origins"])
+        self.assertEqual(0, counts[tri.STATUS_RENAMED])
+        self.assertEqual(2, counts[tri.STATUS_UNRESOLVED])
+
+    def test_raw_sum_and_one_row_per_id_with_chains(self):
+        base = dict(self.base, NoEv={"flat": 5, "mains": 1},
+                    Act1={"flat": 6, "mains": 1})
+        active = self.active | {"Act1"}
+        edges = {"Orig": self.hop("Orig", "M1", self.H1),
+                 "M1": self.hop("M1", "Final", self.H2),
+                 "Orig2": self.hop("Orig2", "MidBase", self.H3),
+                 "MidBase": self.hop("MidBase", "Gone", self.H3)}
+        ids = ["Orig", "Orig2", "MidBase", "NoEv", "Act1"]
+        rows, counts = self.chain_classify(ids, edges, active=active,
+                                           base=base)
+        self.assertEqual(ids, [r["id"] for r in rows])
+        self.assertEqual(len(ids), sum(counts.values()))
+        self.assertEqual(1, counts[tri.STATUS_RENAMED])   # Orig
+        self.assertEqual(1, counts[tri.STATUS_ACTIVE])    # Act1
+        self.assertEqual(3, counts[tri.STATUS_UNRESOLVED])
+
+    def test_invalid_hop_commit_hash_refused_exit_2(self):
+        anc = tri.AncestryChecker("R:/repo",
+                                  run=lambda cmd: completed(0, "y"))
+        edges = {"Orig": self.hop("Orig", "Mid", self.H1),
+                 "Mid": self.hop("Mid", "Final", "abc")}
+        with self.assertRaises(SystemExit) as cm:
+            self.chain_classify(["Orig"], edges, ancestry=anc)
+        self.assertEqual(2, cm.exception.code)
+
+
+class AncestryCheckerTests(unittest.TestCase):
+    def test_binds_repo_and_uses_merge_base(self):
+        run, calls = recording_run(0, "y\n")
+        anc = tri.AncestryChecker("R:/repo", run=run)
+        anc.strictly_ancestral(FULL, "b" * 40)
+        self.assertTrue(calls)
+        for cmd in calls:
+            self.assertEqual(["git", "-C", "R:/repo"], cmd[:3])
+        joined = [" ".join(cmd) for cmd in calls]
+        self.assertTrue(any("merge-base" in c and "--is-ancestor" in c
+                            for c in joined))
+
+    def test_rc0_true_rc1_false(self):
+        run = fake_git({"is-ancestor": completed(0, "")})
+        anc = tri.AncestryChecker("R:/repo", run=run)
+        self.assertTrue(anc.strictly_ancestral(FULL, "b" * 40))
+        run1 = fake_git({"is-ancestor": completed(1, "")})
+        anc1 = tri.AncestryChecker("R:/repo", run=run1)
+        self.assertFalse(anc1.strictly_ancestral(FULL, "b" * 40))
+
+    def test_rc_above_one_refuses_exit_2(self):
+        run = fake_git({"is-ancestor": completed(2, stderr="fatal")})
+        anc = tri.AncestryChecker("R:/repo", run=run)
+        with self.assertRaises(SystemExit) as cm:
+            anc.strictly_ancestral(FULL, "b" * 40)
+        self.assertEqual(2, cm.exception.code)
+
+    def test_same_hash_false_without_git_call(self):
+        run, calls = recording_run(0, "")
+        anc = tri.AncestryChecker("R:/repo", run=run)
+        self.assertFalse(anc.strictly_ancestral(FULL, FULL))
+        self.assertEqual([], calls)
+
+    def test_cached_per_ordered_pair(self):
+        calls = []
+
+        def counting(cmd):
+            calls.append(list(cmd))
+            return completed(0 if len(calls) == 1 else 1, "")
+
+        anc = tri.AncestryChecker("R:/repo", run=counting)
+        self.assertTrue(anc.strictly_ancestral(FULL, "b" * 40))
+        self.assertTrue(anc.strictly_ancestral(FULL, "b" * 40))  # cached
+        self.assertFalse(anc.strictly_ancestral("b" * 40, FULL))  # reversed
+        self.assertEqual(2, len(calls))
+
+    def test_invalid_hash_refused_before_git_call(self):
+        run, calls = recording_run(0, "")
+        anc = tri.AncestryChecker("R:/repo", run=run)
+        with self.assertRaises(SystemExit) as cm:
+            anc.strictly_ancestral(FULL, "abc")
+        self.assertEqual(2, cm.exception.code)
+        self.assertEqual([], calls)
+
+
+class _TempGitRepoTestCase(unittest.TestCase):
+    X_FILE = "mods/cameo/ContentPacks/X/yaml/weapons.yaml"
+    Y_FILE = "mods/cameo/ContentPacks/Y/yaml/weapons.yaml"
+    A_YAML = "A:\n\tInherits: ^Base\n"
+    B_YAML = "B:\n\tInherits: ^Base\n"
+    C_YAML = "C:\n\tInherits: ^Base\n"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self._git(["init"])
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _git(self, args):
+        subprocess.run(["git", "-C", str(self.repo)] + args,
+                       capture_output=True, text=True, check=True)
+
+    def _commit(self, files, msg, allow_empty=False):
+        for rel, content in files:
+            p = self.repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(content.encode("utf-8"))
+            self._git(["add", rel])
+        argv = ["-c", "user.email=t@example.com", "-c", "user.name=t",
+                "commit", "-m", msg]
+        if allow_empty and files:
+            argv.append("--allow-empty")
+        if not files:
+            argv.append("--allow-empty")
+        self._git(argv)
+        return tri.head_commit(self.repo)
+
+    def _pairs(self, commit):
+        return [{"commit": commit, **p}
+                for p in tri.extract_commit_pairs(commit, self.repo)]
+
+    def _chain_rows(self, evidences, ids=("A",), base=None, now=None,
+                    active=None):
+        edges, rejected = tri.resolve_evidence_strict(evidences)
+        ancestry = tri.AncestryChecker(self.repo)
+        return tri.classify(ids, base, now, active, edges, rejected,
+                            lambda n: object(), follow_chains=True,
+                            ancestry=ancestry)
+
+
+class AncestryRealGitTests(_TempGitRepoTestCase):
+    def test_proper_ancestor_asymmetry_and_cache(self):
+        c1 = self._commit([], "one")
+        c2 = self._commit([], "two")
+        calls = []
+
+        def counting(cmd):
+            calls.append(list(cmd))
+            return tri._git(cmd)
+
+        anc = tri.AncestryChecker(self.repo, run=counting)
+        self.assertTrue(anc.strictly_ancestral(c1, c2))
+        self.assertFalse(anc.strictly_ancestral(c2, c1))
+        self.assertTrue(anc.strictly_ancestral(c1, c2))  # cached
+        self.assertEqual(2, len(calls))
+
+    def test_incomparable_two_branches_both_false(self):
+        c0 = self._commit([], "root")
+        c_master = self._commit([], "master-only")
+        self._git(["checkout", "-q", "-b", "side", c0])
+        c_side = self._commit([], "side-only")
+        self._git(["checkout", "-q", "-"])
+        anc = tri.AncestryChecker(self.repo)
+        self.assertFalse(anc.strictly_ancestral(c_master, c_side))
+        self.assertFalse(anc.strictly_ancestral(c_side, c_master))
+
+
+class ChainRealGitTests(_TempGitRepoTestCase):
+    def setUp(self):
+        super().setUp()
+        self.c0 = self._commit([(self.X_FILE, self.A_YAML),
+                                (self.Y_FILE, self.B_YAML)], "base")
+
+    def test_ordered_two_hop_end_to_end(self):
+        c1 = self._commit([(self.X_FILE, self.B_YAML)], "A to B")
+        c2 = self._commit([(self.Y_FILE, self.C_YAML)], "B to C")
+        rows, counts = self._chain_rows(
+            self._pairs(c1) + self._pairs(c2),
+            base={"A": {"flat": 8000, "mains": 4}},
+            now={"C": {"flat": 8000, "mains": 4}}, active={"C"})
+        row = rows[0]
+        self.assertEqual(tri.STATUS_RENAMED, row["status"])
+        self.assertEqual("C", row["renamed_to"])
+        self.assertEqual([c1, c2], [h["commit"] for h in
+                                    row["evidence_chain"]])
+        self.assertEqual(1, counts[tri.STATUS_RENAMED])
+
+    def test_reverse_ref_input_order_same_result(self):
+        c1 = self._commit([(self.X_FILE, self.B_YAML)], "A to B")
+        c2 = self._commit([(self.Y_FILE, self.C_YAML)], "B to C")
+        rows, _ = self._chain_rows(
+            self._pairs(c2) + self._pairs(c1),
+            base={"A": {"flat": 8000, "mains": 4}},
+            now={"C": {"flat": 8000, "mains": 4}}, active={"C"})
+        self.assertEqual(tri.STATUS_RENAMED, rows[0]["status"])
+        self.assertEqual("C", rows[0]["renamed_to"])
+        self.assertEqual([c1, c2], [h["commit"] for h in
+                                    rows[0]["evidence_chain"]])
+
+    def test_reverse_chronology_rejected(self):
+        c1 = self._commit([(self.Y_FILE, self.C_YAML)], "B to C first")
+        c2 = self._commit([(self.X_FILE, self.B_YAML)], "A to B later")
+        rows, _ = self._chain_rows(
+            self._pairs(c2) + self._pairs(c1),
+            base={"A": {"flat": 8000, "mains": 4}}, now={}, active=set())
+        self.assertEqual(tri.STATUS_UNRESOLVED, rows[0]["status"])
+        self.assertEqual("chain_not_ancestrally_ordered", rows[0]["reason"])
+
+    def test_same_commit_two_hunks_rejected(self):
+        c = self._commit([(self.X_FILE, self.B_YAML),
+                          (self.Y_FILE, self.C_YAML)], "both in one")
+        rows, _ = self._chain_rows(
+            self._pairs(c), base={"A": {"flat": 8000, "mains": 4}},
+            now={}, active=set())
+        self.assertEqual("chain_same_commit", rows[0]["reason"])
+
+    def test_incomparable_branches_rejected(self):
+        c_master = self._commit([(self.X_FILE, self.B_YAML)], "A to B")
+        self._git(["checkout", "-q", "-b", "side", self.c0])
+        c_side = self._commit([(self.Y_FILE, self.C_YAML)], "B to C side")
+        self._git(["checkout", "-q", "-"])
+        rows, _ = self._chain_rows(
+            self._pairs(c_master) + self._pairs(c_side),
+            base={"A": {"flat": 8000, "mains": 4}}, now={}, active=set())
+        self.assertEqual("chain_not_ancestrally_ordered", rows[0]["reason"])
+
+    def test_non_ancestor_ref_still_refused_real_git(self):
+        c_master = self._commit([(self.X_FILE, self.B_YAML)], "A to B")
+        self._git(["checkout", "-q", "-b", "side", self.c0])
+        c_side = self._commit([(self.Y_FILE, self.C_YAML)], "side only")
+        self._git(["checkout", "-q", "-"])
+        # An ancestor-of-HEAD commit is accepted...
+        tri.require_ancestor(c_master, self.repo)
+        # ...an unmerged side-branch commit is refused with exit 2.
+        with self.assertRaises(SystemExit) as cm:
+            tri.require_ancestor(c_side, self.repo)
+        self.assertEqual(2, cm.exception.code)
+
+
+class BuildReportSchemaTests(unittest.TestCase):
+    BASE_KEYS = {"what", "measurement_basis", "worktree_dirty", "caveat",
+                 "gitHEAD", "releasecommit", "release_tag", "raw_unmatched",
+                 "classified", "classified_sum", "rename_commits", "rows"}
+
+    @staticmethod
+    def _run():
+        return fake_git({"rev-parse": completed(0, FULL + "\n"),
+                         "status": completed(0, "")})
+
+    def test_default_schema_unchanged_optin_adds_keys_only_when_opted(self):
+        meta = {"_release_commit": FULL, "_release_tag": "baseline"}
+        base = {"A": {"flat": 100, "mains": 1}}
+        now = {"B": {"flat": 100, "mains": 1}}
+        saved = (tri.load_baseline, tri.snapshot, tri.miniyaml)
+
+        class FakeRS:
+            weapons = {"B"}
+
+            def resolve_weapon(self, name):
+                return object()
+
+        tri.load_baseline = lambda repo: (meta, base)
+        tri.snapshot = lambda repo: now
+        tri.miniyaml = types.SimpleNamespace(Ruleset=lambda repo: FakeRS())
+        try:
+            default = tri.build_report("R:/repo", [], run=self._run())
+            opted = tri.build_report("R:/repo", [], run=self._run(),
+                                     follow_chains=True)
+        finally:
+            tri.load_baseline, tri.snapshot, tri.miniyaml = saved
+        self.assertEqual(self.BASE_KEYS, set(default))
+        self.assertNotIn("follow_rename_chains", default)
+        self.assertEqual(self.BASE_KEYS | {"follow_rename_chains",
+                                           "chain_collision_coverage"},
+                         set(opted))
+        self.assertTrue(opted["follow_rename_chains"])
+        self.assertEqual(default["rows"], opted["rows"])
+        self.assertEqual(default["raw_unmatched"], opted["raw_unmatched"])
+        self.assertEqual(1, opted["classified_sum"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Adds a read-only diagnostic for distinguishing weapon rename candidates from unresolved release IDs. Optional strict rename-chain following requires unique adjacent-header evidence and ordered Git ancestry, rejects ambiguity/cycles/collisions, and preserves the raw unmatched-ID inventory (335 IDs in the measured baseline, not a permanent expected count). Identity candidates are not proof of equivalent gameplay or accepted damage drift.

## Scope and recommendation

Draft for integration review. **Recommendation: merge after normal PR review/checks**, because this is a bounded correctness fix with independently challenged implementation and no live gameplay change. It does not authorize a balance import, anchor sign-off, or applying proposals. No YAML rules, engine/C#, prices, HP, weapons, reserved producer files, or generated audit reports are included.

Split from the reviewed non-AI batch to respect the repository's PR-size guidance; related dossier improvements stay in #335. Implemented with OpenCode GLM 5.3 Flash; coordinated and independently reviewed through Codex for Blackrobe.

## Validation

- 97 focused regression tests pass on the isolated publication branch. Published file contents match the independently reviewed batch; diff checks pass.
- The exact combined master-based batch was tested at base `5f170ba07a95620ce4324553600bce3ed7bfb723`: 1,148 tests, 44 skipped, 15 failing modules / 22 failure signatures, identical to the untouched-master baseline. All 169 added tests pass. **The full suite is not green.** This is combined-batch evidence, not a claim that each split branch reran the entire suite.
- 33 balance ledgers: zero drift. Percentage checks pass. Weapon structure/shape ratchets unchanged; raw exceptions remain visible. These gates were run on the combined batch.
- Independent source and test challenge found no remaining blocker in the owned changes. Static tests do not prove gameplay balance.
- Tools/data-for-tools only; no game launch. Existing full-suite debt is disclosed, not waived.
