### PR TITLE
Guard legacy balance imports against identity and row conflicts

### DIFF
--- a/docs/balance/name_map.yaml
+++ b/docs/balance/name_map.yaml
@@ -1,0 +1,90 @@
+# docs/balance/name_map.yaml — legacy workbook keys -> ledger actor id.
+#
+# ⚠ IDENTITY ALIASES ONLY. Each row tells seed_design.py WHICH actor a legacy
+# workbook row corresponds to. It is NOT approval to import legacy numbers
+# (hp/cost/dps still flow through the balance pipeline and maintainer rulings)
+# and NOT approval to retire docs/design/cameo_armor_system.xlsx.
+#
+# Two key kinds:
+#   - DISPLAY-NAME keys: match the legacy type tabs' column B (Infantry/
+#     Tanks/Vehicles/Aircraft/Defenses) against the ledger display names;
+#   - ACTOR-ID keys: match the legacy CABAL tab's column C, and are consulted
+#     ONLY when that exact actor id is MISSING from the ledger — an existing
+#     id is always kept and never redirected by this file.
+#
+# Parsed by seed_design.load_name_map:
+#   - full-line "#" comments and blank lines are skipped;
+#   - keys go through seed_design.norm() (parentheses stripped, lowercased,
+#     non-alphanumerics dropped), so key case/punctuation is irrelevant —
+#     normalized keys must stay unique across BOTH key kinds;
+#   - the value is taken VERBATIM after the first colon — an inline " #"
+#     comment on an entry line would corrupt the actor id, so citations sit
+#     on the full-line comment directly above each entry;
+#   - a value of "-" marks a TYPE-TAB DISPLAY-NAME row as deliberately
+#     ignored. On the CABAL actor-ID path "-" has NO ignore authority: a
+#     CABAL id mapped to "-" stays unresolved (missing actor ID).
+#
+# Display aliases — verified 2026-09-09: a read-only pass over the five legacy
+# type tabs (Infantry/Tanks/Vehicles/Aircraft/Defenses) using seed_design.norm
+# found exactly one row per key, no collisions. All targets exist in the
+# committed ledger and in the active rules.
+
+# Infantry!B62 — legacy "Terran Marine"; current ledger display is "Marine"
+# (starcraft_terran.json, section infantry), so the auto name-match misses.
+Terran Marine: terran_marine
+
+# Vehicles!B139 — legacy "Ordos Tank Destroyer"; current ledger display is
+# "Tank Destroyer" (d2k_ordos.json, section vehicles), so the auto match misses.
+Ordos Tank Destroyer: ordos_tankdestroyer
+
+# Defenses!B15 — legacy "Ixian Gun Turret"; current ledger display is
+# "Gun Turret" (d2k_ixian.json, section buildings), so the auto match misses.
+Ixian Gun Turret: ixian_gunturret
+
+# FutureTech display aliases — identity chain: the legacy ids
+# future_robot_cannon / future_robot_missiles / future_mech_plasma / futu_wheel
+# became robot_cannon.futu / robot_missiles.futu / mech_plasma.futu /
+# wheel.futu in migration 6dbba3eaa007fcd3d612a37f013fe4854f87de6b, then
+# literal header renames in db913a5abcb80cbf7489728ed3213e6cf18e96b7 landed the
+# current ids. The old names survive under the exact old ids in
+# fd58e3f93^:mods/cameo/rules/redalert2mod.yaml and still key the legacy
+# workbook rows below. ⚠ The migration did NOT rename tooltips — its parent
+# already used the new droid names; the dormant monolith's old names are
+# legacy-name association only. IDENTITY aliases, not approved current legacy
+# judgments: values flow only through the existing fill-only seed logic, and
+# code comments + a --dry-run review are required before any write run.
+
+# Tanks!B47 — legacy "Cannon Attack Robot"; current ledger display is
+# "Cannon Droid" (redalert2mod_futuretech.json, section vehicles), so the auto
+# name-match misses.
+Cannon Attack Robot: futuretech_cannondroid
+
+# Vehicles!B162 — legacy "Missile Attack Robot"; current ledger display is
+# "Missile Droid" (redalert2mod_futuretech.json, section vehicles), so the
+# auto name-match misses.
+Missile Attack Robot: futuretech_missiledroid
+
+# Tanks!B96 — legacy "Plasma Super Mech"; current ledger display is
+# "Plasma Strider" (redalert2mod_futuretech.json, section vehicles), so the
+# auto name-match misses.
+Plasma Super Mech: futuretech_plasmastrider
+
+# Vehicles!B35 — legacy "Scout Robot"; current ledger display is "Scout Droid"
+# (redalert2mod_futuretech.json, section vehicles), so the auto name-match
+# misses.
+Scout Robot: futuretech_scoutdroid
+
+# Actor-ID aliases — provenance: ancestor commit
+# 86eee6bcadb5cbe567ec1f470eb5617d5bb9c713 ("merge internal underscores") made
+# literal header renames in
+# mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/aircraft.yaml: the old
+# definition was removed and replaced under the underscore-free id. All six
+# targets are active and present in tiberiansun_cabal.json. The legacy CABAL
+# column C still carries the OLD id; seed_design consults these entries only
+# when the original id is absent from the ledger.
+cabal_overkill_gunship: cabal_overkillgunship
+cabal_hunter_drone_carrier: cabal_hunterdronecarrier
+cabal_hunter_drone: cabal_hunterdrone
+cabal_orb_drone: cabal_orbdrone
+cabal_cyborg_assassin: cabal_cyborgassassin
+cabal_repair_drone: cabal_repairdrone

--- a/tools/balance/seed_design.py
+++ b/tools/balance/seed_design.py
@@ -1,18 +1,58 @@
 #!/usr/bin/env python3
 """seed_design.py — Balance Pipeline Phase 3 (BALANCE_PIPELINE.md §6).
 
-Seeds the ledger's design.* judgment fields (unit_class, special,
+Seeds the ledger's design.* judgment fields (special, unit_class,
 tech_tier) from the LEGACY workbook (docs/design/cameo_armor_system.xlsx)
 and writes the discrepancy report docs/balance/discrepancies.md.
 
 Matching:
-- CABAL tab carries actor ids (column C) -> direct.
+- CABAL tab carries actor ids (column C) -> resolved, when the exact id
+  exists in the ledger (an existing id is ALWAYS kept, never redirected).
+  Historical actor-id reuse (LEGACY_ID_QUARANTINE) is withheld first.
+  A missing id consults docs/balance/name_map.yaml by norm(actor id)
+  (explicit actor-ID aliases only; the mapped target must exist). No
+  automatic normalized actor search — a missing key or a missing target
+  stays unresolved; the report says "missing actor ID / unresolved
+  identity", never that a unit is proven dead from an absent id.
 - Legacy type tabs (Infantry/Tanks/Vehicles/Aircraft/Defenses) carry
   display names only -> normalized-name match against ledger display
   names; ambiguous or unmatched rows are REPORTED, never guessed.
-- docs/balance/name_map.yaml (committed, hand-curated) overrides:
-      legacy display name: actor_id     # or "-" to ignore the row
+- docs/balance/name_map.yaml (committed, hand-curated) overrides, with
+  BOTH display-name keys and actor-ID keys:
+      legacy display name or actor id: target_actor_id
+  a "-" value ignores type-tab DISPLAY-NAME rows only; on the CABAL
+  actor-ID path "-" has no ignore authority — such a row stays unresolved.
 Respects the ~$ Excel lock (queues per the balance law).
+
+Quarantined target ids (LEGACY_ID_QUARANTINE) are authoritative for ALL
+resolved source rows — the original CABAL row, a type-tab display-name
+match, or an explicit alias all get withheld; only the section-derived
+fallback stays separate.
+
+Labels are precise: "matched legacy rows" counts rows collected into
+target groups (before conflict withholding); "applied design fields"
+counts real missing→value transitions; the design import diagnostics
+table mixes kept/withheld/fallback records and is NOT an apply count;
+direct/mapped are raw resolution counts, not import counts.
+
+Import order (two-phase collection/preflight, deliberately small):
+1. COLLECT every resolvable row into groups keyed by TARGET ACTOR,
+   across the CABAL tab and ALL type tabs (not per normalized name).
+2. PREFLIGHT: if any non-null imported judgment (special, unit_class,
+   tech_tier, category, subtype) conflicts inside a target's group, ALL
+   workbook-derived changes for that target are withheld and the source
+   cells/names/values are reported. Identical duplicates and
+   complementary nonconflicting partial rows stay accepted; 0 is a
+   populated value and None is missing; costs never conflict (they are
+   comparison-only). Existing ledger values do NOT erase a source
+   conflict — it is reported even when no field would have been filled.
+3. APPLY: fill-only per field (existing values win; conflicts were
+   already withheld whole-target).
+
+--dry-run runs the identical collect/preflight/apply logic in memory on
+a throwaway copy of the ledger docs, prints every proposal/discrepancy
+to stdout, and writes NOTHING — no ledger, no workbook, no
+discrepancies.md. Dry-run output never claims anything was seeded.
 """
 from __future__ import annotations
 
@@ -36,16 +76,61 @@ FALLBACK_CATEGORY = {"infantry": "Infantry", "vehicles": "Vehicles", "aircraft":
 # H weapon class, K special, L unit class, M tech tier
 # CABAL tab: A mod, B name, C actor, ... K special, L unit class, M tier, R cost
 
+# Historical CABAL actor-id reuse, quarantined from automatic LEGACY seeding.
+#
+# Provenance — commit 833f7123e9978918730bbcf8ce716dfed5d9dc2d (2026-07-15,
+# "Rename Legion to Widow (replace old Widow)"): the OLD cabal_widow definition
+# (^HighTechTankTemplate, HP 80000, Cost 3000, weapon CabalWidowPlasma) was
+# removed and the `cabal_widow` id was replaced/reused for the former
+# cabal_legion unit (renamed Widow, main-battle-tank body, Cost 3500);
+# `cabal_legion` itself ceased to exist under that id. This is an identity
+# replacement, not an alias.
+#
+# The retained CABAL identity rows in the LEGACY workbook still describe the
+# older lineup (the workbook has later updates, so this is NOT a claim about
+# the whole workbook): its CABAL row keyed `cabal_widow` (B29/C29) describes
+# the OLD HighTechTank definition, while today's `cabal_widow` actor is the
+# former Legion. Seeding that row's special/unit_class/tier into the
+# replacement actor would import another definition's judgment values, so the
+# row is WITHHELD from automatic seeding until a maintainer re-judges it.
+# Existing ledger values are fill-only and stay untouched — today's tier1 on
+# cabal_widow is NOT proven wrongly imported and is NOT repaired here. The
+# unresolved `cabal_legion` row (missing actor ID) stays unresolved: reported,
+# never auto-mapped, never substituted.
+#
+# Deliberately a tiny constant keyed by (sheet, actor id lowercased/stripped).
+LEGACY_ID_QUARANTINE = {
+    ("CABAL", "cabal_widow"): (
+        "commit 833f7123e9978918730bbcf8ce716dfed5d9dc2d removed and replaced "
+        "the old cabal_widow definition (HighTechTank/80kHP/3000-cost/"
+        "CabalWidowPlasma) under the id of the former cabal_legion; this "
+        "retained CABAL identity row still describes the older lineup, not "
+        "today's cabal_widow actor"
+    ),
+}
+
+JUDGMENT_FIELDS = ("special", "unit_class", "tech_tier")
+
+# Blocked TARGET ids derived from LEGACY_ID_QUARANTINE (same provenance, no
+# second registry): a historically replaced/reused id must not be filled by
+# ANY resolved source row — the original CABAL row, a type-tab display-name
+# match, or an explicit alias — independent of whether the original CABAL row
+# still exists. Section-derived fallback is not affected.
+QUARANTINED_TARGETS = {
+    orig_id: reason for (_sheet, orig_id), reason in LEGACY_ID_QUARANTINE.items()
+}
+
 
 def norm(s: str) -> str:
     s = re.sub(r"\(.*?\)", "", str(s)).lower()
     return re.sub(r"[^a-z0-9]", "", s)
 
 
-def load_name_map() -> dict[str, str]:
+def load_name_map(path=None) -> dict[str, str]:
+    base = pathlib.Path(path) if path is not None else NAME_MAP
     out = {}
-    if NAME_MAP.exists():
-        for line in NAME_MAP.read_text(encoding="utf-8").splitlines():
+    if base.exists():
+        for line in base.read_text(encoding="utf-8").splitlines():
             s = line.strip()
             if not s or s.startswith("#"):
                 continue
@@ -54,9 +139,10 @@ def load_name_map() -> dict[str, str]:
     return out
 
 
-def ledger_docs() -> dict[str, dict]:
+def ledger_docs(ledger_dir=None) -> dict[str, dict]:
+    base = pathlib.Path(ledger_dir) if ledger_dir is not None else LEDGER
     out = {}
-    for p in sorted(LEDGER.glob("*.json")):
+    for p in sorted(base.glob("*.json")):
         doc = json.loads(p.read_text(encoding="utf-8"))
         if "sections" in doc:  # skip registry files (class_anchors.json …)
             out[p.stem] = doc
@@ -80,125 +166,300 @@ def fnum(v):
         return None
 
 
-def main() -> int:
-    if (LEGACY.parent / ("~$" + LEGACY.name)).exists():
+def fmt_val(v):
+    return "<missing>" if v is None else v
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    unknown = [a for a in args if a != "--dry-run"]
+    if unknown:
+        print(f"unknown argument(s): {' '.join(unknown)}; supported: --dry-run")
+        return 2
+    return run(dry_run="--dry-run" in args)
+
+
+def run(dry_run: bool = False, ledger_dir=None, legacy_path=None,
+        name_map_path=None, report_path=None) -> int:
+    """Seed design fields from the legacy workbook.
+
+    Default paths are the module constants (real repository). Tests and
+    inspections MUST pass explicit temp paths — never the defaults.
+    dry_run=True mutates nothing on disk: the fill-only logic runs on the
+    in-memory docs (already private copies from json.loads) and every
+    proposed change is printed instead of written.
+    """
+    ledger_dir = pathlib.Path(ledger_dir) if ledger_dir is not None else LEDGER
+    legacy_path = pathlib.Path(legacy_path) if legacy_path is not None else LEGACY
+    name_map_path = pathlib.Path(name_map_path) if name_map_path is not None else NAME_MAP
+    report_path = pathlib.Path(report_path) if report_path is not None else REPORT
+
+    if (legacy_path.parent / ("~$" + legacy_path.name)).exists():
         print("legacy workbook is OPEN in Excel (~$ lock) — queueing per the balance law; rerun later.")
         return 2
-    docs = ledger_docs()
+    docs = ledger_docs(ledger_dir)
     units = all_units(docs)
     by_norm_name: dict[str, list[str]] = {}
     for actor, (_, _, u) in units.items():
         if u.get("name"):
             by_norm_name.setdefault(norm(u["name"]), []).append(actor)
-    nmap = load_name_map()
+    nmap = load_name_map(name_map_path)
 
-    wb = openpyxl.load_workbook(LEGACY, data_only=False)
-    seeded, direct, mapped, unmatched, ambiguous, dead = 0, 0, 0, [], [], []
-    mismatches = []
+    wb = openpyxl.load_workbook(legacy_path, data_only=False)
+    try:
+        direct, mapped = 0, 0
+        matched_rows, applied = 0, 0
+        unmatched, ambiguous, unresolved = [], [], []
+        withheld, alias_lines, conflicts, proposals, mismatches = [], [], [], [], []
+        conflict_targets: set[str] = set()
+        groups: dict[str, list[dict]] = {}
 
-    def seed(actor, special, unit_class, tier, legacy_cost, tab, rowname,
-             category=None, subtype=None):
-        nonlocal seeded
-        if actor not in units:
-            dead.append(f"{tab}: `{rowname}` -> `{actor}` (no such actor)")
-            return
-        _, _, u = units[actor]
-        d = u.setdefault("design", {})
-        for key, val in (("special", fnum(special)), ("unit_class", fnum(unit_class)),
-                         ("tech_tier", fnum(tier)), ("category", category),
-                         ("subtype", subtype)):
-            if val is not None and d.get(key) is None:
-                d[key] = val
-        seeded += 1
-        cost = fnum((u.get("cost") or {}).get("v"))
-        lcost = fnum(legacy_cost)
-        if cost is not None and lcost is not None and abs(cost - lcost) > 0.5:
-            mismatches.append(f"`{actor}`: yaml cost {cost:.0f} vs legacy sheet {lcost:.0f} ({tab})")
+        def design_of(actor):
+            entry = units.get(actor)
+            return (entry[2].get("design") or {}) if entry else {}
 
-    # --- CABAL tab: direct actor ids ---
-    ws = wb["CABAL"]
-    for r in range(2, ws.max_row + 1):
-        actor = ws.cell(row=r, column=3).value
-        if not actor:
-            continue
-        seed(str(actor).strip(), ws.cell(row=r, column=11).value,
-             ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
-             ws.cell(row=r, column=18).value, "CABAL", ws.cell(row=r, column=2).value)
-        direct += 1
+        def record(src, key, existing, val, disposition):
+            proposals.append((src, key, fmt_val(existing), val, disposition))
 
-    # --- legacy type tabs: name matching ---
-    for tab in ("Infantry", "Tanks", "Vehicles", "Aircraft", "Defenses"):
-        if tab not in wb.sheetnames:
-            continue
-        ws = wb[tab]
-        subtype = "Unclassified"
-        for r in range(3, ws.max_row + 1):
-            rowname = ws.cell(row=r, column=2).value
-            hp = ws.cell(row=r, column=4).value
-            if rowname and fnum(hp) is None:
-                subtype = str(rowname).strip()
-                continue
-            if not rowname or fnum(hp) is None:
-                continue
-            key = norm(rowname)
-            if key in nmap:
-                target = nmap[key]
-                if target == "-":
-                    continue
-                seed(target, ws.cell(row=r, column=11).value,
-                     ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
-                     ws.cell(row=r, column=19).value, tab, rowname, tab, subtype)
-                mapped += 1
-                continue
-            cands = by_norm_name.get(key, [])
-            if len(cands) == 1:
-                seed(cands[0], ws.cell(row=r, column=11).value,
-                     ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
-                     ws.cell(row=r, column=19).value, tab, rowname, tab, subtype)
-                mapped += 1
-            elif len(cands) > 1:
-                ambiguous.append(f"{tab}: `{rowname}` -> {cands}")
+        # --- phase 1: COLLECT resolved rows, grouped by target actor ---
+        def collect(target, orig, special, unit_class, tier, legacy_cost,
+                    sheet, row, rowname, alias=False, category=None, subtype=None):
+            """Collect one resolved row; returns False if the TARGET id is
+            quarantined (withheld for every source path, no group entry)."""
+            nonlocal matched_rows
+            u = units[target][2]
+            vals = {"special": fnum(special), "unit_class": fnum(unit_class),
+                    "tech_tier": fnum(tier), "category": category, "subtype": subtype}
+            if alias:
+                src = (f"{sheet} row {row}: name `{rowname}`, actor `{orig}` "
+                       f"-> target `{target}` (actor-ID alias)")
             else:
-                unmatched.append(f"{tab}: `{rowname}`")
+                src = f"{sheet} row {row}: name `{rowname}`, actor `{orig or target}`"
+            # quarantined target ids are authoritative for ALL resolved rows
+            blocked_reason = QUARANTINED_TARGETS.get(target.lower())
+            if blocked_reason is not None:
+                d = design_of(target)
+                for field in ("special", "unit_class", "tech_tier"):
+                    val = vals[field]
+                    if val is not None:
+                        record(src, field, d.get(field), val,
+                               "WITHHELD (historical actor-id reuse — see withheld section)")
+                withheld.append(f"{src} — special/unit_class/tier withheld from automatic "
+                                f"seeding (quarantined target id): {blocked_reason}")
+                return False
+            groups.setdefault(target, []).append(
+                {"src": src, "vals": vals, "sheet": sheet, "row": row,
+                 "name": rowname, "cost": legacy_cost})
+            matched_rows += 1
+            cost = fnum((u.get("cost") or {}).get("v"))
+            lcost = fnum(legacy_cost)
+            if cost is not None and lcost is not None and abs(cost - lcost) > 0.5:
+                mismatches.append(f"`{target}`: yaml cost {cost:.0f} vs legacy sheet {lcost:.0f} ({sheet})")
+            return True
 
-    for actor, (_, section, u) in units.items():
-        category = FALLBACK_CATEGORY.get(section)
-        if category:
-            d = u.setdefault("design", {})
-            if d.get("category") is None:
-                d["category"] = category
-            if d.get("subtype") is None:
-                d["subtype"] = "Unclassified"
+        # --- CABAL tab: direct actor ids, then explicit actor-ID aliases ---
+        ws = wb["CABAL"]
+        for r in range(2, ws.max_row + 1):
+            actor = ws.cell(row=r, column=3).value
+            if not actor:
+                continue
+            actor_id = str(actor).strip()
+            rowname = ws.cell(row=r, column=2).value
+            # 1. quarantine is authoritative and comes first
+            quarantine = LEGACY_ID_QUARANTINE.get(("CABAL", actor_id.lower()))
+            if quarantine is not None:
+                src = f"CABAL row {r}: name `{rowname}`, actor `{actor_id}`"
+                d = design_of(actor_id)
+                for col, key in ((11, "special"), (12, "unit_class"), (13, "tech_tier")):
+                    val = fnum(ws.cell(row=r, column=col).value)
+                    if val is None:
+                        continue
+                    record(src, key, d.get(key), val,
+                           "WITHHELD (historical actor-id reuse — see withheld section)")
+                withheld.append(f"CABAL row {r} (C{r}=`{actor_id}`, B{r}=`{rowname}`) — "
+                                f"special/unit_class/tier withheld from automatic seeding: "
+                                f"{quarantine}")
+                continue
+            direct += 1
+            # 2. an existing original id is ALWAYS kept — never redirected
+            if actor_id in units:
+                collect(actor_id, actor_id, ws.cell(row=r, column=11).value,
+                        ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
+                        ws.cell(row=r, column=18).value, "CABAL", r, rowname)
+                continue
+            # 3. only when the id is absent: explicit actor-ID alias from name_map
+            alias_target = nmap.get(norm(actor_id))
+            if alias_target and alias_target != "-" and alias_target in units:
+                alias_lines.append(f"CABAL row {r} (C{r}=`{actor_id}`) — actor-ID alias "
+                                   f"-> `{alias_target}`")
+                collect(alias_target, actor_id, ws.cell(row=r, column=11).value,
+                        ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
+                        ws.cell(row=r, column=18).value, "CABAL", r, rowname,
+                        alias=True)
+                continue
+            unresolved.append(f"CABAL: `{rowname}` -> `{actor_id}` "
+                              f"(missing actor ID — unresolved identity)")
+
+        # --- legacy type tabs: name matching (scan starts at row 2 so the
+        # first-group subtype header in B2 is honored by the same heuristic) ---
+        for tab in ("Infantry", "Tanks", "Vehicles", "Aircraft", "Defenses"):
+            if tab not in wb.sheetnames:
+                continue
+            ws = wb[tab]
+            subtype = "Unclassified"
+            for r in range(2, ws.max_row + 1):
+                rowname = ws.cell(row=r, column=2).value
+                hp = ws.cell(row=r, column=4).value
+                if rowname and fnum(hp) is None:
+                    subtype = str(rowname).strip()
+                    continue
+                if not rowname or fnum(hp) is None:
+                    continue
+                key = norm(rowname)
+                if key in nmap:
+                    target = nmap[key]
+                    if target == "-":
+                        continue
+                    if target in units:
+                        collect(target, None, ws.cell(row=r, column=11).value,
+                                ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
+                                ws.cell(row=r, column=19).value, tab, r, rowname,
+                                category=tab, subtype=subtype)
+                    else:
+                        unresolved.append(f"{tab}: `{rowname}` -> `{target}` "
+                                          f"(missing actor ID — unresolved identity)")
+                    mapped += 1
+                    continue
+                cands = by_norm_name.get(key, [])
+                if len(cands) == 1:
+                    collect(cands[0], None, ws.cell(row=r, column=11).value,
+                            ws.cell(row=r, column=12).value, ws.cell(row=r, column=13).value,
+                            ws.cell(row=r, column=19).value, tab, r, rowname,
+                            category=tab, subtype=subtype)
+                    mapped += 1
+                elif len(cands) > 1:
+                    ambiguous.append(f"{tab}: `{rowname}` -> {cands}")
+                else:
+                    unmatched.append(f"{tab}: `{rowname}`")
+
+        # --- phase 2: PREFLIGHT target-level conflicts ---
+        for target, rows in groups.items():
+            for field in ("special", "unit_class", "tech_tier", "category", "subtype"):
+                by_val: dict = {}
+                for rowrec in rows:
+                    v = rowrec["vals"][field]
+                    if v is None:
+                        continue
+                    by_val.setdefault(v, []).append(rowrec)
+                if len(by_val) > 1:
+                    conflict_targets.add(target)
+                    detail = " vs ".join(
+                        f"{vrows[0]['sheet']} row {vrows[0]['row']} `{vrows[0]['name']}`={v}"
+                        for v, vrows in by_val.items())
+                    conflicts.append(f"`{target}` design.{field}: {detail}")
+
+        # --- phase 3: APPLY fill-only per field (conflicts already withheld) ---
+        for target, rows in groups.items():
+            if target in conflict_targets:
+                continue
+            _, _, u = units[target]
+            for rowrec in rows:
+                d = u.setdefault("design", {})
+                for field, kind in (("special", "legacy sheet"), ("unit_class", "legacy sheet"),
+                                    ("tech_tier", "legacy sheet"), ("category", "row context"),
+                                    ("subtype", "row context")):
+                    val = rowrec["vals"][field]
+                    if val is None:
+                        continue
+                    existing = d.get(field)
+                    if existing is None:
+                        if dry_run:
+                            record(rowrec["src"], field, None, val, f"propose fill ({kind})")
+                        d[field] = val
+                        applied += 1  # a real missing->value transition
+                    elif dry_run:
+                        record(rowrec["src"], field, existing, val, "existing value kept (fill-only)")
+
+        for actor, (_, section, u) in units.items():
+            category = FALLBACK_CATEGORY.get(section)
+            if category:
+                d = u.setdefault("design", {})
+                for key, val in (("category", category), ("subtype", "Unclassified")):
+                    if d.get(key) is None:
+                        if dry_run:
+                            record(f"ledger section `{section}`: actor `{actor}`", key, None, val,
+                                   "propose fallback (section-derived — NOT a legacy numeric import)")
+                        d[key] = val
+                        applied += 1  # a real missing->value transition (section-derived)
+    finally:
+        wb.close()
+
+    # ledger units whose design JUDGMENTS were never populated (special,
+    # unit_class, tech_tier all missing — 0 counts as populated; category/
+    # subtype fallback metadata does not hide them)
+    no_judgments = [a for a, (_, sec, u) in sorted(units.items())
+                    if sec in ("infantry", "vehicles", "aircraft", "naval", "defenses")
+                    and all((u.get("design") or {}).get(k) is None for k in JUDGMENT_FIELDS)]
+
+    fill_action = "would fill" if dry_run else "applied"
+    lines = ["# Balance ledger — legacy-sheet discrepancy report",
+             "", f"_generated by seed_design.py; matched {matched_rows} legacy rows "
+             f"across {len(groups)} unique targets; {fill_action} {applied} design fields_"
+             + (" — DRY-RUN: nothing seeded, nothing written" if dry_run else ""),
+             "",
+             "## Unresolved legacy rows (missing actor ID or unmatched display name — extend name_map.yaml)", ""]
+    lines += [f"- {x}" for x in unmatched + unresolved] or ["- none"]
+    lines += ["", "## Ambiguous name matches (resolve in name_map.yaml)", ""]
+    lines += [f"- {x}" for x in ambiguous] or ["- none"]
+    lines += ["", f"## CABAL actor-ID aliases resolved via name_map ({len(alias_lines)})", ""]
+    lines += [f"- {x}" for x in alias_lines] or ["- none"]
+    lines += ["", "## Withheld legacy rows (historical actor-id reuse — needs a maintainer decision, NOT auto-seeded)", ""]
+    lines += [f"- {x}" for x in withheld] or ["- none"]
+    lines += ["", "## Conflicting source rows (ALL workbook-derived values withheld for the target)", ""]
+    lines += [f"- {x}" for x in conflicts] or ["- none"]
+    lines += ["", "## Cost mismatches (yaml vs legacy sheet — maintainer picks the law)", ""]
+    lines += [f"- {x}" for x in mismatches] or ["- none"]
+    if dry_run:
+        lines += ["", f"## Design import diagnostics ({len(proposals)} records — includes kept/withheld "
+                      f"records and section fallback; the record count is NOT an apply count)", ""]
+        lines += [f"- {src} — design.{key}: {existing} -> {proposed} [{disposition}]"
+                  for src, key, existing, proposed, disposition in proposals]
+    lines += ["", f"## Ledger units with no design judgments populated ({len(no_judgments)})", ""]
+    lines += [f"- `{a}`" for a in no_judgments[:200]]
+    if len(no_judgments) > 200:
+        lines.append(f"- … and {len(no_judgments) - 200} more")
+
+    if dry_run:
+        print("\n".join(lines))
+        print(f"DRY-RUN complete: {len(proposals)} diagnostic records (not an apply count), "
+              f"would fill {applied} design fields, "
+              f"{len(alias_lines)} alias-resolved, {len(conflict_targets)} conflict targets, "
+              f"unmatched {len(unmatched)}, ambiguous {len(ambiguous)}, "
+              f"unresolved {len(unresolved)}, withheld {len(withheld)}, "
+              f"cost mismatches {len(mismatches)}, no design judgments {len(no_judgments)}; "
+              f"NO ledger, workbook or report was written.")
+        return 0
 
     # write ledgers back (design fields only changed)
     for name, doc in docs.items():
-        p = LEDGER / f"{name}.json"
+        p = ledger_dir / f"{name}.json"
         p.write_text(json.dumps(doc, sort_keys=True, indent=1, ensure_ascii=False) + "\n",
                      encoding="utf-8", newline="\n")
 
-    # unseeded units (in yaml, never in legacy sheet)
-    unseeded = [a for a, (_, sec, u) in sorted(units.items())
-                if sec in ("infantry", "vehicles", "aircraft", "naval", "defenses")
-                and all(v is None for v in (u.get("design") or {}).values())]
-
-    lines = ["# Balance ledger — legacy-sheet discrepancy report",
-             "", f"_generated by seed_design.py; seeded {seeded} units "
-             f"({direct} by actor id, {mapped} by name)_", "",
-             "## Legacy rows with NO matching actor (dead or unmatched — extend name_map.yaml)", ""]
-    lines += [f"- {x}" for x in unmatched + dead] or ["- none"]
-    lines += ["", "## Ambiguous name matches (resolve in name_map.yaml)", ""]
-    lines += [f"- {x}" for x in ambiguous] or ["- none"]
-    lines += ["", "## Cost mismatches (yaml vs legacy sheet — maintainer picks the law)", ""]
-    lines += [f"- {x}" for x in mismatches] or ["- none"]
-    lines += ["", f"## Combat units never priced in the legacy sheet ({len(unseeded)})", ""]
-    lines += [f"- `{a}`" for a in unseeded[:200]]
-    if len(unseeded) > 200:
-        lines.append(f"- … and {len(unseeded) - 200} more")
-    REPORT.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
-    print(f"seeded {seeded} (direct {direct}, name-matched {mapped}); "
-          f"unmatched {len(unmatched)}, ambiguous {len(ambiguous)}, dead {len(dead)}, "
-          f"cost mismatches {len(mismatches)}, unseeded combat units {len(unseeded)}")
-    print(f"report -> {REPORT.relative_to(ROOT)}")
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    print(f"matched {matched_rows} legacy rows across {len(groups)} unique targets "
+          f"(resolution: {direct} by CABAL actor id, {mapped} by display name — "
+          f"resolution counts, not import counts); aliases {len(alias_lines)}; "
+          f"applied {applied} design fields; "
+          f"unmatched {len(unmatched)}, ambiguous {len(ambiguous)}, "
+          f"unresolved {len(unresolved)}, conflicts {len(conflict_targets)}, "
+          f"withheld {len(withheld)}, cost mismatches {len(mismatches)}, "
+          f"no design judgments {len(no_judgments)}")
+    try:
+        where = report_path.relative_to(ROOT)
+    except ValueError:
+        where = report_path
+    print(f"report -> {where}")
     return 0
 
 

--- a/tools/tests/test_legacy_name_aliases.py
+++ b/tools/tests/test_legacy_name_aliases.py
@@ -1,0 +1,234 @@
+"""C21 — the verified legacy identity aliases in docs/balance/name_map.yaml.
+
+Two key kinds:
+- SEVEN display aliases pin legacy workbook rows (Infantry!B62, Vehicles!B139,
+  Defenses!B15, Tanks!B47, Vehicles!B162, Tanks!B96, Vehicles!B35) to ledger
+  actors whose CURRENT display name no longer matches the legacy row, so
+  seed_design's normalized-name auto-match can never find them. A read-only
+  norm() pass over the five legacy type tabs found exactly one row per key, no
+  collisions. The four FutureTech aliases trace through migration
+  6dbba3eaa007fcd3d612a37f013fe4854f87de6b (future_robot_* / futu_wheel ->
+  *.futu) and header renames db913a5abcb80cbf7489728ed3213e6cf18e96b7; the
+  migration did NOT rename tooltips (its parent already used the new droid
+  names) — the dormant monolith's old names are legacy-name association only.
+- SIX actor-ID aliases pin legacy CABAL column-C ids that commit
+  86eee6bcadb5cbe567ec1f470eb5617d5bb9c713 merged (internal underscores
+  removed) in mods/cameo/ContentPacks/TiberianSun/CABAL/yaml/aircraft.yaml.
+  They are consulted ONLY when the original id is absent from the ledger —
+  an existing id is always kept, never redirected.
+
+The aliases are IDENTITY aliases only — not approval to import legacy numbers
+and not approval to retire the workbook — so the tests also pin that no
+speculative aliases leaked in for still-untriaged rows (Minigunner / AP /
+Laser / Freezer Turret / Advanced Soviet Mammoth Tank).
+
+PRIOR ART: seed_design.load_name_map / ledger_docs / all_units are the consumer
+side (seed_design.main); docs/balance/discrepancies.md is the triage report the
+entries resolve rows in (historical until a full authorized reseed/triage).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+LEDGER = ROOT / "docs" / "balance"
+
+try:
+    import openpyxl  # noqa: F401
+    _HAVE_OPENPYXL = True
+except ImportError:
+    _HAVE_OPENPYXL = False
+
+if _HAVE_OPENPYXL:
+    sys.path.insert(0, str(ROOT / "tools" / "balance"))
+    import seed_design as sd  # noqa: E402
+else:
+    sd = None
+
+# legacy workbook row -> (ledger file, actor id, current display name, content pack)
+ALIASES = {
+    "Terran Marine": ("starcraft_terran.json", "terran_marine", "Marine", "StarCraft/Terran"),
+    "Ordos Tank Destroyer": ("d2k_ordos.json", "ordos_tankdestroyer", "Tank Destroyer", "D2k/Ordos"),
+    "Ixian Gun Turret": ("d2k_ixian.json", "ixian_gunturret", "Gun Turret", "D2k/Ixian"),
+    # FutureTech identity chain: 6dbba3eaa007fcd3d612a37f013fe4854f87de6b then
+    # db913a5abcb80cbf7489728ed3213e6cf18e96b7; no tooltip rename in the migration
+    "Cannon Attack Robot": ("redalert2mod_futuretech.json", "futuretech_cannondroid",
+                            "Cannon Droid", "RedAlert2Mod/FutureTech"),
+    "Missile Attack Robot": ("redalert2mod_futuretech.json", "futuretech_missiledroid",
+                             "Missile Droid", "RedAlert2Mod/FutureTech"),
+    "Plasma Super Mech": ("redalert2mod_futuretech.json", "futuretech_plasmastrider",
+                          "Plasma Strider", "RedAlert2Mod/FutureTech"),
+    "Scout Robot": ("redalert2mod_futuretech.json", "futuretech_scoutdroid",
+                    "Scout Droid", "RedAlert2Mod/FutureTech"),
+}
+
+# legacy CABAL column-C id (underscored) -> active CABAL actor id (merged);
+# provenance: 86eee6bcadb5cbe567ec1f470eb5617d5bb9c713, aircraft.yaml headers
+ACTOR_ID_ALIASES = {
+    "cabal_overkill_gunship": "cabal_overkillgunship",
+    "cabal_hunter_drone_carrier": "cabal_hunterdronecarrier",
+    "cabal_hunter_drone": "cabal_hunterdrone",
+    "cabal_orb_drone": "cabal_orbdrone",
+    "cabal_cyborg_assassin": "cabal_cyborgassassin",
+    "cabal_repair_drone": "cabal_repairdrone",
+}
+
+
+@unittest.skipUnless(sd is not None, "openpyxl unavailable (seed_design dependency)")
+class LegacyNameAliasTest(unittest.TestCase):
+    def test_loader_returns_exactly_the_authorized_aliases(self):
+        """The committed file must load to exactly the seven display aliases
+        plus the six actor-ID aliases — nothing more.
+        load_name_map normalizes keys through norm() and takes values verbatim."""
+        self.assertTrue(sd.NAME_MAP.exists(), f"missing: {sd.NAME_MAP}")
+        expected = {sd.norm(legacy): actor for legacy, (_, actor, _, _) in ALIASES.items()}
+        expected.update({sd.norm(old): new for old, new in ACTOR_ID_ALIASES.items()})
+        self.assertEqual(sd.load_name_map(), expected)
+
+    def test_normalized_keys_stay_unique_across_both_key_kinds(self):
+        """The registry matches through norm(), not exact strings — a collision
+        between a display-name key and an actor-ID key would silently redirect
+        one of the two families."""
+        keys = list(ALIASES) + list(ACTOR_ID_ALIASES)
+        normalized = [sd.norm(k) for k in keys]
+        self.assertEqual(len(normalized), len(set(normalized)),
+                         "a display alias and an actor-ID alias collide after norm()")
+        self.assertEqual(len(keys), 13, "expected exactly 3+6+4 authorized aliases")
+
+    def test_cabal_actor_id_alias_targets_exist_and_originals_are_gone(self):
+        """Every actor-ID alias must point at an ACTIVE ledger actor, and the
+        old underscored id must be GONE from the ledger — otherwise the alias
+        would be dead weight or, worse, never fire (an existing id is kept)."""
+        units = sd.all_units(sd.ledger_docs())
+        for old, new in ACTOR_ID_ALIASES.items():
+            with self.subTest(alias=old):
+                self.assertNotIn(old, units,
+                                 f"{old} still exists in the ledger — the alias must "
+                                 f"be removed (an existing id is never redirected)")
+                self.assertIn(new, units,
+                              f"{new} missing from the committed ledger")
+                self.assertNotEqual(old, new,
+                                    f"{old}: alias redirects to the same raw id — dead entry")
+
+    def test_targets_exist_in_the_real_ledger_with_aligned_display_and_faction(self):
+        """Every target must exist in seed_design's own ledger view (the exact
+        lookup seed_design.main seeds through), under the named faction ledger,
+        with the display name the alias rationale cites."""
+        units = sd.all_units(sd.ledger_docs())
+        for legacy, (fn, actor, display, pack) in ALIASES.items():
+            with self.subTest(alias=legacy):
+                self.assertIn(actor, units, f"{actor} vanished from the committed ledger")
+                ledger_name, _section, u = units[actor]
+                self.assertEqual(ledger_name, pathlib.Path(fn).stem,
+                                 f"{actor} moved to a different faction ledger")
+                self.assertEqual(u.get("name"), display,
+                                 f"{actor}: ledger display drifted from the alias rationale")
+                doc = json.loads((LEDGER / fn).read_text(encoding="utf-8"))
+                self.assertTrue(str(doc.get("pack", "")).endswith(pack),
+                                f"{actor}: pack {doc.get('pack')!r} is not the {pack} faction")
+                self.assertNotEqual(sd.norm(display), sd.norm(legacy),
+                                    f"{actor}: display now matches the legacy row — the "
+                                    f"{legacy!r} alias is redundant, drop it")
+
+    def test_no_speculative_aliases_for_still_untriaged_rows(self):
+        """Minigunner / AP / Laser legacy rows have NOT been triaged, and
+        Freezer Turret / Advanced Soviet Mammoth Tank are deliberately left
+        unmapped (conflicting Freezer rows / unproven Mammoth identity) — an inferred alias there would
+        silently seed design fields for an unverified match."""
+        nmap = sd.load_name_map()
+        for legacy in ("Minigunner", "AP", "Laser",
+                       "Freezer Turret", "Advanced Soviet Mammoth Tank"):
+            self.assertNotIn(sd.norm(legacy), nmap,
+                             f"unauthorized alias for still-untriaged row {legacy!r}")
+
+    def test_loader_skips_comments_and_blank_lines(self):
+        """Temporary-file fixture (NAME_MAP restored via addCleanup, normalization
+        untouched): header/blank/comment lines are ignored and the key is
+        normalized — which is exactly why the yaml keeps citations on their own
+        comment line above each entry instead of inline after the value."""
+        original = sd.NAME_MAP
+        self.addCleanup(setattr, sd, "NAME_MAP", original)
+        with tempfile.TemporaryDirectory() as td:
+            sd.NAME_MAP = pathlib.Path(td) / "name_map.yaml"
+            sd.NAME_MAP.write_text(
+                "# header comment — ignored\n"
+                "\n"
+                "# Infantry!B62\n"
+                "Terran Marine: terran_marine\n"
+                "\n"
+                "# trailing comment — ignored\n",
+                encoding="utf-8")
+            self.assertEqual(sd.load_name_map(), {"terranmarine": "terran_marine"})
+
+
+@unittest.skipUnless(sd is not None, "openpyxl unavailable (seed_design dependency)")
+class FutureTechDisplayAliasResolutionTest(unittest.TestCase):
+    """The four FutureTech display aliases must work through the REAL chain:
+    seed_design.load_name_map -> active Ruleset actor resolution -> ledger
+    target with the cited display — not a string-only key-existence check.
+    One shared Ruleset for the whole class (cached fixture, no re-parse)."""
+
+    # legacy key -> (tab, B-cell row)
+    WORKBOOK_CELLS = {
+        "Cannon Attack Robot": ("Tanks", 47),
+        "Missile Attack Robot": ("Vehicles", 162),
+        "Plasma Super Mech": ("Tanks", 96),
+        "Scout Robot": ("Vehicles", 35),
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(ROOT / "tools" / "audit"))
+        from miniyaml import Ruleset
+        cls.rules = Ruleset(ROOT)
+        cls.units = sd.all_units(sd.ledger_docs())
+        cls.nmap = sd.load_name_map()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.rules = None
+        cls.units = None
+        cls.nmap = None
+
+    def test_aliases_resolve_through_loader_ruleset_and_ledger(self):
+        for legacy, (fn, actor, display, _pack) in ALIASES.items():
+            if legacy not in self.WORKBOOK_CELLS:
+                continue  # the three pre-existing aliases are covered elsewhere
+            with self.subTest(alias=legacy):
+                # real loader (normalized key -> target), not a dict literal
+                self.assertEqual(self.nmap[sd.norm(legacy)], actor)
+                # ACTIVE ruleset resolution: the target actor exists in the
+                # live mod yaml, not only in the balance ledger
+                self.assertIsNotNone(self.rules.resolve(actor),
+                                     f"{actor} does not resolve in the active rules")
+                # ledger target with the cited current display
+                ledger_name, _section, u = self.units[actor]
+                self.assertEqual(pathlib.Path(fn).stem, ledger_name)
+                self.assertEqual(u.get("name"), display)
+                # the legacy workbook row still exists at the cited cell
+                import openpyxl
+                wb = openpyxl.load_workbook(sd.LEGACY, read_only=True, data_only=False)
+                try:
+                    tab, row = self.WORKBOOK_CELLS[legacy]
+                    self.assertEqual(wb[tab].cell(row=row, column=2).value, legacy)
+                finally:
+                    wb.close()
+
+    def test_old_ids_are_migration_history_not_current_actors(self):
+        """The chain's intermediate and old ids must NOT be active — the alias
+        must point at the current id only."""
+        for old in ("future_robot_cannon", "future_robot_missiles",
+                    "future_mech_plasma", "futu_wheel",
+                    "robot_cannon.futu", "robot_missiles.futu",
+                    "mech_plasma.futu", "wheel.futu"):
+            self.assertIsNone(self.rules.resolve(old), f"{old} unexpectedly active")
+            self.assertNotIn(old, self.units)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_seed_design_identity.py
+++ b/tools/tests/test_seed_design_identity.py
@@ -1,0 +1,794 @@
+"""Regression tests for seed_design.py — CABAL historical actor-id reuse,
+two-phase target-conflict preflight, --dry-run zero-write guarantee, header
+scan, and actor-ID alias wiring.
+
+Identity provenance: commit 833f7123e9978918730bbcf8ce716dfed5d9dc2d (the old
+cabal_widow definition was removed and the id replaced under the former
+cabal_legion) and commit 86eee6bcadb5cbe567ec1f470eb5617d5bb9c713 (six CABAL
+aircraft actor ids merged their internal underscores).
+
+EVERY behavioral test runs seed_design.run() against TEMP fixtures with
+explicit paths. The default main() (real repository paths) is NEVER invoked
+here; main() is only exercised with a mocked run() to prove argument wiring.
+The single real-file test is read-only (name_map.yaml contents).
+"""
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import openpyxl
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools/balance"))
+import seed_design as sd
+
+COMMIT = "833f7123e9978918730bbcf8ce716dfed5d9dc2d"
+WITHHELD_SECTION = "## Withheld legacy rows (historical actor-id reuse — needs a maintainer decision, NOT auto-seeded)"
+CONFLICT_SECTION = "## Conflicting source rows (ALL workbook-derived values withheld for the target)"
+UNRESOLVED_SECTION = "## Unresolved legacy rows (missing actor ID or unmatched display name — extend name_map.yaml)"
+NO_JUDGMENT_SECTION = "## Ledger units with no design judgments populated"
+UNRESOLVED_MSG = "(missing actor ID — unresolved identity)"
+
+SIX_ALIASES = [
+    ("cabal_overkill_gunship", "cabal_overkillgunship"),
+    ("cabal_hunter_drone_carrier", "cabal_hunterdronecarrier"),
+    ("cabal_hunter_drone", "cabal_hunterdrone"),
+    ("cabal_orb_drone", "cabal_orbdrone"),
+    ("cabal_cyborg_assassin", "cabal_cyborgassassin"),
+    ("cabal_repair_drone", "cabal_repairdrone"),
+]
+
+
+def cabal_row(name, actor, special, unit_class, tier, cost):
+    # CABAL columns: A mod, B name, C actor, K special, L unit class, M tier, R cost
+    return ["TS", name, actor, None, None, None, None, None, None, None,
+            special, unit_class, tier, None, None, None, None, cost]
+
+
+def type_row(name, hp, special, unit_class, tier, cost):
+    # type tabs: B name, D hp, K special, L unit class, M tier, S cost
+    return [None, name, None, hp, None, None, None, None, None, None,
+            special, unit_class, tier, None, None, None, None, None, cost]
+
+
+DUMMY = [None, None, None, None]  # verbatim sheet row 1 (scanner starts at 2)
+
+
+def build_workbook(path, cabal_rows, extra_sheets=None):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "CABAL"
+    ws.append(["mod", "name", "actor"] + [f"col{i}" for i in range(4, 19)])
+    for row in cabal_rows:
+        ws.append(row)
+    for title, rows in (extra_sheets or {}).items():
+        sheet = wb.create_sheet(title)
+        for row in rows:  # verbatim; index 0 lands on sheet row 1
+            sheet.append(row)
+    wb.save(path)
+    wb.close()
+
+
+def snapshot(root: pathlib.Path):
+    out = {}
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            out[str(p.relative_to(root))] = p.read_bytes()
+    return out
+
+
+class SeedDesignIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = pathlib.Path(self.temp.name)
+        self.ledger = self.root / "docs/balance"
+        self.ledger.mkdir(parents=True)
+        self.legacy = self.root / "cameo_armor_system.xlsx"
+        self.report = self.ledger / "discrepancies.md"
+        self.namemap = self.ledger / "name_map.yaml"
+
+    # --- fixtures -------------------------------------------------------
+
+    def write_ledger(self, doc, name="test"):
+        (self.ledger / f"{name}.json").write_text(
+            json.dumps(doc, sort_keys=True, indent=1, ensure_ascii=False) + "\n",
+            encoding="utf-8", newline="\n")
+
+    def read_ledger(self, name="test"):
+        return json.loads((self.ledger / f"{name}.json").read_text(encoding="utf-8"))
+
+    def write_namemap(self, text):
+        self.namemap.write_text(text, encoding="utf-8", newline="\n")
+
+    def unit(self, name, cost, design=None):
+        u = {"name": name, "cost": {"v": cost}}
+        if design:
+            u["design"] = dict(design)
+        return u
+
+    def cabal_ledger(self, widow_design=None, avatar_design=None):
+        vehicles = {
+            "cabal_widow": self.unit("Widow", 3500, widow_design),
+            "cabal_avatar": self.unit("Avatar", 500, avatar_design),
+        }
+        return {"schema": 2, "ledger": "test", "sections": {"vehicles": vehicles}}
+
+    def standard_cabal_rows(self):
+        # row 2 = unrelated valid row, row 3 = obsolete Widow (old HighTechTank
+        # values), row 4 = dead Legion row (today's sheet B16/C16/M16 analog).
+        return [
+            cabal_row("Avatar", "cabal_avatar", 1.0, 3.0, 2.0, 500),
+            cabal_row("Widow", "cabal_widow", 4.0, 2.0, 1.0, 3000),
+            cabal_row("Legion", "cabal_legion", 3.0, 2.0, 0.5, 3500),
+        ]
+
+    def make_workbook(self, cabal_rows=None, extra_sheets=None):
+        build_workbook(self.legacy, self.standard_cabal_rows()
+                       if cabal_rows is None else cabal_rows, extra_sheets)
+
+    def run_seed(self, dry_run=False):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = sd.run(dry_run=dry_run, ledger_dir=self.ledger,
+                        legacy_path=self.legacy, name_map_path=self.namemap,
+                        report_path=self.report)
+        return rc, out.getvalue()
+
+    def design_of(self, actor, section=None):
+        sections = self.read_ledger()["sections"]
+        if section:
+            return sections.get(section, {}).get(actor, {}).get("design")
+        for sec in sections.values():
+            if actor in sec:
+                return sec[actor].get("design")
+        return {}
+
+    # --- 1. Widow special/unit_class/tier withheld, fallback distinct ----
+
+    def test_widow_legacy_values_withheld_and_reported(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        self.assertIsNone(d.get("special"))
+        self.assertIsNone(d.get("unit_class"))
+        self.assertIsNone(d.get("tech_tier"))
+        # ordinary section fallback is NOT withheld (not a legacy numeric import)
+        self.assertEqual(d.get("category"), "Vehicles")
+        self.assertEqual(d.get("subtype"), "Unclassified")
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(WITHHELD_SECTION, report)
+        self.assertIn(COMMIT, report)
+        self.assertIn("CABAL row 3 (C3=`cabal_widow`, B3=`Widow`)", report)
+        self.assertIn(f"CABAL: `Legion` -> `cabal_legion` {UNRESOLVED_MSG}", report)
+        # the obsolete row must not even produce a cost mismatch (other definition)
+        self.assertNotIn("yaml cost 3500 vs legacy sheet 3000", report)
+        self.assertIn("withheld 1", out)
+
+    # --- 2. existing tier1 untouched -------------------------------------
+
+    def test_existing_tier1_unchanged(self):
+        self.write_ledger(self.cabal_ledger(widow_design={"tech_tier": 1.0}))
+        self.make_workbook()
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        self.assertEqual(d.get("tech_tier"), 1.0)
+        self.assertIsNone(d.get("special"))
+        self.assertIsNone(d.get("unit_class"))
+
+    # --- 3. Legion stays unresolved --------------------------------------
+
+    def test_legion_row_stays_unresolved(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(UNRESOLVED_SECTION, report)
+        self.assertIn(f"CABAL: `Legion` -> `cabal_legion` {UNRESOLVED_MSG}", report)
+        for p in self.ledger.glob("*.json"):
+            self.assertNotIn("cabal_legion", p.read_text(encoding="utf-8"))
+            self.assertNotIn("0.5", p.read_text(encoding="utf-8"))
+
+    # --- 4. unrelated valid CABAL row still fills (negative counterpart) -
+
+    def test_unrelated_cabal_row_fills_in_write_mode(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_avatar")
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("unit_class"), 3.0)
+        self.assertEqual(d.get("tech_tier"), 2.0)
+        # direct/mapped are raw resolution counts (unresolved rows included),
+        # never presented as imports
+        self.assertIn("matched 1 legacy rows across 1 unique targets", out)
+        self.assertIn("applied 7 design fields", out)
+        self.assertIn("resolution: 2 by CABAL actor id", out)
+        self.assertIn("withheld 1", out)
+
+    # --- 5. dry-run writes nothing, shows real proposals ------------------
+
+    def test_dry_run_zero_writes_with_existing_report(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        self.report.write_text("SENTINEL-REPORT\n", encoding="utf-8", newline="\n")
+        before = snapshot(self.root)
+        rc, out = self.run_seed(dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(snapshot(self.root), before)
+        # honest labelling — no seeded/written claim
+        self.assertNotIn("seeded 1 units", out)
+        self.assertIn("DRY-RUN: nothing seeded, nothing written", out)
+        self.assertIn("NO ledger, workbook or report was written", out)
+        self.assertIn("would fill 7 design fields", out)
+        self.assertIn("## Design import diagnostics (10 records", out)
+        # actual proposals with coordinates, source, field, values, disposition
+        self.assertIn("- CABAL row 2: name `Avatar`, actor `cabal_avatar` — "
+                      "design.tech_tier: <missing> -> 2.0 [propose fill (legacy sheet)]", out)
+        self.assertIn("- CABAL row 3: name `Widow`, actor `cabal_widow` — "
+                      "design.tech_tier: <missing> -> 1.0 "
+                      "[WITHHELD (historical actor-id reuse — see withheld section)]", out)
+        self.assertIn(COMMIT, out)
+        self.assertIn("- ledger section `vehicles`: actor `cabal_widow` — "
+                      "design.category: <missing> -> Vehicles "
+                      "[propose fallback (section-derived — NOT a legacy numeric import)]", out)
+        self.assertIn(f"CABAL: `Legion` -> `cabal_legion` {UNRESOLVED_MSG}", out)
+        self.assertEqual(self.report.read_text(encoding="utf-8"), "SENTINEL-REPORT\n")
+
+    def test_dry_run_creates_no_report_when_absent(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        before = snapshot(self.root)
+        rc, out = self.run_seed(dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(snapshot(self.root), before)
+        self.assertFalse(self.report.exists())
+        self.assertIn("propose fill (legacy sheet)", out)
+
+    # --- 6. name_map display-alias behaviors unchanged ---------------------
+
+    def test_name_map_behaviors_unchanged(self):
+        doc = {"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "cabal_ghost": self.unit("Ghost", 300),
+            "cabal_commando": self.unit("Commando", 400),
+            "cabal_ranger": self.unit("Ranger", 500),
+        }}}
+        self.write_ledger(doc)
+        self.write_namemap("Legacy Ghost: cabal_ghost\n"
+                           "Legacy Commando: cabal_commando\n"
+                           "Legacy Ranger: cabal_ranger\n"
+                           "Phantom: -\n")
+        infantry = [DUMMY,
+                    type_row("Legacy Ghost", 100, 1.0, 1.0, 1.0, 300),
+                    type_row("Legacy Commando", 120, 2.0, 1.0, 2.0, 400),
+                    type_row("Legacy Ranger", 140, 2.0, 2.0, 2.0, 500),
+                    type_row("Phantom", 160, 3.0, 1.0, 3.0, 600),
+                    type_row("Unheard Unit", 180, 1.0, 2.0, 3.0, 700)]
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": infantry})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        sections = self.read_ledger()["sections"]["infantry"]
+        self.assertEqual(sections["cabal_ghost"]["design"]["special"], 1.0)
+        self.assertEqual(sections["cabal_commando"]["design"]["tech_tier"], 2.0)
+        self.assertEqual(sections["cabal_ranger"]["design"]["unit_class"], 2.0)
+        self.assertEqual(sections["cabal_ghost"]["design"]["category"], "Infantry")
+        self.assertIn("matched 3 legacy rows across 3 unique targets", out)
+        self.assertIn("applied 15 design fields", out)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("Infantry: `Unheard Unit`", report)
+        self.assertNotIn("Phantom", report)
+
+    # --- 7. Excel lock refuses before writes (both modes) ------------------
+
+    def test_lock_refuses_before_writes(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook()
+        (self.root / "~$cameo_armor_system.xlsx").write_text("lock", encoding="utf-8")
+        before = snapshot(self.root)
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 2)
+        self.assertIn("~$ lock", out)
+        rc, out = self.run_seed(dry_run=True)
+        self.assertEqual(rc, 2)
+        self.assertIn("~$ lock", out)
+        self.assertEqual(snapshot(self.root), before)
+        self.assertFalse(self.report.exists())
+
+    # --- 8. main() argument wiring (run mocked — repo never touched) -------
+
+    def test_main_arg_wiring(self):
+        with patch.object(sd, "run") as runmock:
+            self.assertEqual(sd.main(["--dry-run"]), runmock.return_value)
+            runmock.assert_called_once_with(dry_run=True)
+        with patch.object(sd, "run") as runmock:
+            self.assertEqual(sd.main([]), runmock.return_value)
+            runmock.assert_called_once_with(dry_run=False)
+        with patch.object(sd, "run") as runmock:
+            self.assertEqual(sd.main(["--bogus"]), 2)
+            runmock.assert_not_called()
+
+    # === revision 2: two-phase target-conflict preflight ===================
+
+    def gi_fixture(self, design=None):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "ra2_allies_gi": self.unit("G.I.", 300, design)}}})
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY,
+            [None, "Scout Infantry", None, "HP"],                      # row 2 first-group header
+            type_row("G.I.", 300, 1.25, 1.0, 1.0, 300),                # row 18 analog
+            type_row("G.I.(deployed)", 400, 1.0, 1.0, 1.0, 300),       # row 19 analog
+        ]})
+
+    def test_gi_conflict_withholds_all_legacy_fields(self):
+        self.gi_fixture()
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("ra2_allies_gi")
+        for field in ("special", "unit_class", "tech_tier"):
+            self.assertIsNone(d.get(field), f"{field} must stay unfilled on conflict")
+        # section fallback is ordinary and distinct from the withheld rows
+        self.assertEqual(d.get("category"), "Infantry")
+        self.assertEqual(d.get("subtype"), "Unclassified")
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(CONFLICT_SECTION, report)
+        self.assertIn("`ra2_allies_gi` design.special: Infantry row 3 `G.I.`=1.25 "
+                      "vs Infantry row 4 `G.I.(deployed)`=1.0", report)
+        self.assertIn("conflicts 1", out)
+        # B2 header honored but never counted as a unit
+        self.assertIn("matched 2 legacy rows across 1 unique targets", out)
+        self.assertIn("applied 2 design fields", out)  # fallback only — conflict withheld
+        self.assertNotIn("Scout Infantry", report)
+
+    def test_conflict_still_reported_with_existing_ledger_values(self):
+        self.gi_fixture(design={"special": 1.25, "unit_class": 1.0, "tech_tier": 1.0})
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(CONFLICT_SECTION, report)
+        self.assertIn("`ra2_allies_gi` design.special: Infantry row 3 `G.I.`=1.25 "
+                      "vs Infantry row 4 `G.I.(deployed)`=1.0", report)
+        d = self.design_of("ra2_allies_gi")
+        self.assertEqual(d.get("special"), 1.25)  # existing values untouched
+        self.assertEqual(d.get("tech_tier"), 1.0)
+
+    def test_cross_cabal_and_type_tab_conflict(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Exunit", 500)}}})
+        self.make_workbook(
+            cabal_rows=[cabal_row("Exunit", "cabal_x", 1.0, 1.0, 1.0, 500)],
+            extra_sheets={"Infantry": [DUMMY, type_row("Exunit", 100, 2.0, 1.0, 1.0, 500)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("`cabal_x` design.special: CABAL row 2 `Exunit`=1.0 "
+                      "vs Infantry row 2 `Exunit`=2.0", report)
+        d = self.design_of("cabal_x")
+        self.assertIsNone(d.get("special"))
+        self.assertEqual(d.get("category"), "Vehicles")  # fallback still ordinary
+        self.assertIn("conflicts 1", out)
+
+    def test_two_aliases_to_same_target_conflict(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Xunit", 300)}}})
+        self.write_namemap("Legacy Alpha: cabal_x\nLegacy Beta: cabal_x\n")
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY,
+            type_row("Legacy Alpha", 100, 1.0, 1.0, 1.0, 100),
+            type_row("Legacy Beta", 200, 2.0, 1.0, 1.0, 200)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("`cabal_x` design.special: Infantry row 2 `Legacy Alpha`=1.0 "
+                      "vs Infantry row 3 `Legacy Beta`=2.0", report)
+        self.assertIsNone(self.design_of("cabal_x").get("special"))
+        self.assertIn("conflicts 1", out)
+
+    def test_identical_duplicates_accepted(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Dup", 500)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Dup", "cabal_x", 1.0, 2.0, 3.0, 500),
+            cabal_row("Dup", "cabal_x", 1.0, 2.0, 3.0, 500)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_x")
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("unit_class"), 2.0)
+        self.assertEqual(d.get("tech_tier"), 3.0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("## Conflicting source rows", report)
+        self.assertIn("- none", report)
+        self.assertIn("conflicts 0", out)
+
+    def test_complementary_partials_accepted(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Part", 500)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Part", "cabal_x", 1.0, None, None, 500),
+            cabal_row("Part", "cabal_x", None, 2.0, 3.0, 500)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_x")
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("unit_class"), 2.0)
+        self.assertEqual(d.get("tech_tier"), 3.0)
+        self.assertIn("conflicts 0", out)
+
+    def test_zero_vs_none_accepted_and_zero_vs_one_conflict(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_zero": self.unit("Zero", 100),
+            "cabal_conf": self.unit("Conf", 200)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Zero", "cabal_zero", 0, 1.0, 1.0, 100),
+            cabal_row("Zero", "cabal_zero", None, 1.0, 1.0, 100),
+            cabal_row("Conf", "cabal_conf", 0, 1.0, 1.0, 200),
+            cabal_row("Conf", "cabal_conf", 1, 1.0, 1.0, 200)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.design_of("cabal_zero").get("special"), 0.0)  # 0 is populated
+        self.assertIsNone(self.design_of("cabal_conf").get("special"))      # 0 vs 1 conflicts
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("`cabal_conf` design.special: CABAL row 4 `Conf`=0.0 "
+                      "vs CABAL row 5 `Conf`=1.0", report)
+        self.assertIn("conflicts 1", out)
+
+    def test_reversed_source_row_order_same_result(self):
+        rows = [cabal_row("Part", "cabal_x", 1.0, None, None, 500),
+                cabal_row("Part", "cabal_x", None, 2.0, 3.0, 500)]
+        doc = {"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Part", 500)}}}
+        results = []
+        for variant in (rows, list(reversed(rows))):
+            self.write_ledger(doc)
+            self.make_workbook(cabal_rows=variant)
+            rc, _ = self.run_seed()
+            self.assertEqual(rc, 0)
+            results.append(self.design_of("cabal_x"))
+        self.assertEqual(results[0], results[1])
+        self.assertEqual(results[0].get("special"), 1.0)
+        self.assertEqual(results[0].get("tech_tier"), 3.0)
+
+    def test_conflict_target_does_not_block_unrelated_target(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_x": self.unit("Bad", 100),
+            "cabal_ok": self.unit("Good", 200)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Bad", "cabal_x", 1.0, 1.0, 1.0, 100),
+            cabal_row("Bad", "cabal_x", 2.0, 1.0, 1.0, 100),
+            cabal_row("Good", "cabal_ok", 1.0, 2.0, 3.0, 200)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        self.assertIsNone(self.design_of("cabal_x").get("special"))
+        d = self.design_of("cabal_ok")
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("tech_tier"), 3.0)
+        self.assertIn("conflicts 1", out)
+
+    def test_differing_costs_alone_accepted(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_y": self.unit("Costly", 500)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Costly", "cabal_y", 1.0, 2.0, 3.0, 500),
+            cabal_row("Costly", "cabal_y", 1.0, 2.0, 3.0, 600)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_y")
+        self.assertEqual(d.get("special"), 1.0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("`cabal_y`: yaml cost 500 vs legacy sheet 600 (CABAL)", report)
+        self.assertIn("- none", report.split("## Conflicting source rows")[1].split("##")[0])
+        self.assertIn("conflicts 0", out)
+
+    def test_conflicting_category_subtype_withheld(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_dual": self.unit("Dualunit", 100)}}})
+        self.write_namemap("Dual Role: cabal_dual\n")
+        self.make_workbook(cabal_rows=[], extra_sheets={
+            "Infantry": [DUMMY, type_row("Dual Role", 100, 1.0, 1.0, 1.0, 100)],
+            "Vehicles": [DUMMY, type_row("Dual Role", 200, 1.0, 1.0, 1.0, 200)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("`cabal_dual` design.category: Infantry row 2 `Dual Role`=Infantry "
+                      "vs Vehicles row 2 `Dual Role`=Vehicles", report)
+        d = self.design_of("cabal_dual")
+        self.assertIsNone(d.get("special"))  # whole target withheld
+        self.assertEqual(d.get("category"), "Vehicles")  # section fallback only
+
+    def test_dry_run_shows_conflict_and_writes_nothing(self):
+        self.gi_fixture()
+        before = snapshot(self.root)
+        rc, out = self.run_seed(dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(snapshot(self.root), before)
+        self.assertFalse(self.report.exists())
+        self.assertIn("`ra2_allies_gi` design.special: Infantry row 3 `G.I.`=1.25 "
+                      "vs Infantry row 4 `G.I.(deployed)`=1.0", out)
+        self.assertIn("1 conflict targets", out)
+        self.assertIn("NO ledger, workbook or report was written", out)
+
+    # === revision 2: first-group header scan ===============================
+
+    def test_header_row2_recognized_not_counted(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "scout1": self.unit("Scout", 50)}}})
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY,
+            [None, "Scout Infantry", None, "HP"],                 # row 2 header (D2='HP')
+            type_row("Scout", 50, 1.0, 1.0, 1.0, 50)]})           # row 3 data
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.read_ledger()["sections"]["infantry"]["scout1"]["design"]
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("subtype"), "Scout Infantry")
+        self.assertEqual(d.get("category"), "Infantry")
+        self.assertIn("matched 1 legacy rows", out)
+        self.assertIn("applied 5 design fields", out)
+        self.assertIn("conflicts 0", out)
+
+    def test_later_header_switches_subtype(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "t1": self.unit("Early", 100), "t2": self.unit("Late", 200)}}})
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY,
+            type_row("Early", 100, 1.0, 1.0, 1.0, 100),
+            [None, "Elite", None, "HP"],
+            type_row("Late", 200, 2.0, 2.0, 2.0, 200)]})
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        sections = self.read_ledger()["sections"]["infantry"]
+        self.assertEqual(sections["t1"]["design"]["subtype"], "Unclassified")
+        self.assertEqual(sections["t2"]["design"]["subtype"], "Elite")
+
+    def test_blank_row2_skipped(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "solo": self.unit("Solo", 100)}}})
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY, [None, None, None, None], type_row("Solo", 100, 1.0, 1.0, 1.0, 100)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.read_ledger()["sections"]["infantry"]["solo"]["design"]
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("subtype"), "Unclassified")
+        self.assertIn("matched 1 legacy rows", out)
+        self.assertIn("applied 5 design fields", out)
+
+    def test_defense_header3_recognized(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"defenses": {
+            "tower": self.unit("Tower", 500)}}})
+        self.make_workbook(cabal_rows=[], extra_sheets={"Defenses": [
+            DUMMY, [None, None, None, None],
+            [None, "Basic Defense", None, "HP"],                  # row 3 header (Defenses layout)
+            type_row("Tower", 500, 1.0, 1.0, 1.0, 500)]})         # row 4 data
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.read_ledger()["sections"]["defenses"]["tower"]["design"]
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("subtype"), "Basic Defense")
+
+    # === revision 2: no-design-judgment predicate ==========================
+
+    def test_no_design_judgments_label_and_predicate(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"infantry": {
+            "u_none": self.unit("NoJudg", 500),
+            "u_tier0": self.unit("Tier0", 10, design={"tech_tier": 0.0})}}})
+        self.make_workbook(cabal_rows=[])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(f"{NO_JUDGMENT_SECTION} (1)", report)
+        self.assertIn("- `u_none`", report)          # real cost 500 + fallback metadata, 3 missing
+        self.assertNotIn("`u_tier0`", report)        # tech_tier 0.0 counts as populated
+        self.assertNotIn("never priced in the legacy sheet", report)
+        self.assertNotIn("Combat units", report)
+        self.assertIn("no design judgments 1", out)
+
+    # === revision 2: CABAL actor-ID alias wiring ===========================
+
+    def test_direct_id_wins_over_explicit_mapping(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_avatar": self.unit("Avatar", 500),
+            "cabal_other": self.unit("Other", 999)}}})
+        self.write_namemap("cabal_avatar: cabal_other\n")
+        self.make_workbook(cabal_rows=[cabal_row("Avatar", "cabal_avatar", 1.0, 2.0, 3.0, 500)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_avatar")  # original id kept, filled from its own row
+        self.assertEqual(d.get("special"), 1.0)
+        self.assertEqual(d.get("unit_class"), 2.0)
+        self.assertEqual(d.get("tech_tier"), 3.0)
+        other = self.design_of("cabal_other")
+        for field in ("special", "unit_class", "tech_tier"):
+            self.assertIsNone(other.get(field))
+        self.assertIn("aliases 0", out)
+
+    def test_unknown_id_without_alias_stays_unresolved(self):
+        self.write_ledger(self.cabal_ledger())
+        self.make_workbook(cabal_rows=[cabal_row("Ghost", "cabal_nope", 1.0, 1.0, 1.0, 100)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(f"CABAL: `Ghost` -> `cabal_nope` {UNRESOLVED_MSG}", report)
+        self.assertIn("aliases 0", out)
+        self.assertNotIn("cabal_nope", self.read_ledger_text())
+
+    def test_missing_alias_target_stays_unresolved(self):
+        self.write_ledger(self.cabal_ledger())
+        self.write_namemap("cabal_ghostid: cabal_absent\n")
+        self.make_workbook(cabal_rows=[cabal_row("Ghostid", "cabal_ghostid", 1.0, 1.0, 1.0, 100)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(f"CABAL: `Ghostid` -> `cabal_ghostid` {UNRESOLVED_MSG}", report)
+        self.assertIn("aliases 0", out)
+        self.assertNotIn("cabal_ghostid", self.read_ledger_text())
+
+    def test_alias_plus_direct_conflict_withholds_target(self):
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_new": self.unit("Newname", 300)}}})
+        self.write_namemap("cabal_old: cabal_new\n")
+        self.make_workbook(cabal_rows=[
+            cabal_row("Newname", "cabal_new", 1.0, 1.0, 1.0, 300),
+            cabal_row("Oldname", "cabal_old", 2.0, 1.0, 1.0, 300)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("CABAL row 3 (C3=`cabal_old`) — actor-ID alias -> `cabal_new`", report)
+        self.assertIn("`cabal_new` design.special: CABAL row 2 `Newname`=1.0 "
+                      "vs CABAL row 3 `Oldname`=2.0", report)
+        self.assertIsNone(self.design_of("cabal_new").get("special"))
+        self.assertIn("aliases 1", out)
+        self.assertIn("conflicts 1", out)
+
+    def test_six_real_registry_alias_targets(self):
+        ledger = {"schema": 2, "ledger": "test", "sections": {"aircraft": {
+            new: self.unit(f"Unit{i}", 100 + i)
+            for i, (_, new) in enumerate(SIX_ALIASES)}}}
+        self.write_ledger(ledger)
+        self.write_namemap("".join(f"{old}: {new}\n" for old, new in SIX_ALIASES))
+        rows = [cabal_row(old, old, 1.0, 2.0, 3.0, 100 + i)
+                for i, (old, _) in enumerate(SIX_ALIASES)]
+        rows.append(cabal_row("Legion", "cabal_legion", 3.0, 2.0, 0.5, 3500))
+        self.make_workbook(cabal_rows=rows)
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        # 7 raw missing legacy ids -> 6 alias matches + 1 unresolved Legion
+        self.assertIn("aliases 6", out)
+        self.assertIn("unresolved 1", out)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn(f"CABAL: `Legion` -> `cabal_legion` {UNRESOLVED_MSG}", report)
+        for i, (old, new) in enumerate(SIX_ALIASES):
+            self.assertIn(f"CABAL row {i + 2} (C{i + 2}=`{old}`) — actor-ID alias -> `{new}`", report)
+            d = self.read_ledger()["sections"]["aircraft"][new]["design"]
+            self.assertEqual(d.get("special"), 1.0)
+            self.assertEqual(d.get("unit_class"), 2.0)
+            self.assertEqual(d.get("tech_tier"), 3.0)
+        self.assertNotIn("cabal_legion", self.read_ledger_text())
+
+    def test_real_name_map_unique_normalized_keys_and_nine_entries(self):
+        # read-only check against the real committed name_map.yaml
+        keys = sd.load_name_map(ROOT / "docs/balance/name_map.yaml")
+        self.assertEqual(len(keys), len(set(keys)), "normalized keys must stay unique")
+        for k in ("terranmarine", "ordostankdestroyer", "ixiangunturret"):
+            self.assertIn(k, keys)
+        for old, _new in SIX_ALIASES:
+            self.assertIn(sd.norm(old), keys)
+
+    # === revision 3: quarantined TARGET ids authoritative on every path ===
+
+    def widowed_ledger(self, widow_design=None):
+        return {"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_widow": self.unit("Widow", 3500, widow_design),
+            "cabal_ok": self.unit("OKunit", 200)}},
+            # keep the ledger small: only these two combat units
+        }
+
+    def test_type_tab_unique_name_to_widow_blocked(self):
+        self.write_ledger(self.widowed_ledger())
+        # NO original CABAL Widow row at all — the blocked TARGET must still hold
+        self.make_workbook(cabal_rows=[cabal_row("OKunit", "cabal_ok", 1.0, 2.0, 3.0, 200)],
+                           extra_sheets={"Infantry": [
+                               DUMMY, type_row("Widow", 3000, 4.0, 2.0, 1.0, 3000)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        for field in ("special", "unit_class", "tech_tier"):
+            self.assertIsNone(d.get(field))
+        self.assertEqual(d.get("category"), "Vehicles")     # section fallback stays separate
+        self.assertEqual(d.get("subtype"), "Unclassified")
+        ok = self.design_of("cabal_ok")                      # unrelated valid target works
+        self.assertEqual(ok.get("special"), 1.0)
+        self.assertEqual(ok.get("tech_tier"), 3.0)
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("Infantry row 2: name `Widow`, actor `cabal_widow` — "
+                      "special/unit_class/tier withheld from automatic seeding "
+                      "(quarantined target id): commit " + COMMIT, report)
+        self.assertIn("withheld 1", out)
+
+    def test_explicit_alias_to_widow_blocked(self):
+        self.write_ledger(self.widowed_ledger())
+        self.write_namemap("Old Widow: cabal_widow\n")
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY, type_row("Old Widow", 3000, 4.0, 2.0, 1.0, 3000)]})
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        for field in ("special", "unit_class", "tech_tier"):
+            self.assertIsNone(d.get(field))
+        self.assertEqual(d.get("category"), "Vehicles")
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("Infantry row 2: name `Old Widow`, actor `cabal_widow` — "
+                      "special/unit_class/tier withheld from automatic seeding "
+                      "(quarantined target id): commit " + COMMIT, report)
+
+    def test_cabal_actor_alias_to_widow_blocked(self):
+        self.write_ledger(self.widowed_ledger())
+        self.write_namemap("cabal_oldwidow: cabal_widow\n")
+        self.make_workbook(cabal_rows=[cabal_row("OldWidow", "cabal_oldwidow",
+                                                 4.0, 2.0, 1.0, 3000)])
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        for field in ("special", "unit_class", "tech_tier"):
+            self.assertIsNone(d.get(field))
+        report = self.report.read_text(encoding="utf-8")
+        self.assertIn("CABAL row 2: name `OldWidow`, actor `cabal_oldwidow` -> target "
+                      "`cabal_widow` (actor-ID alias) — special/unit_class/tier withheld "
+                      "from automatic seeding (quarantined target id): commit " + COMMIT, report)
+        self.assertIn("CABAL row 2 (C2=`cabal_oldwidow`) — actor-ID alias -> `cabal_widow`", report)
+
+    def test_blocked_target_keeps_existing_judgments(self):
+        self.write_ledger(self.widowed_ledger(widow_design={"tech_tier": 1.0}))
+        self.write_namemap("Old Widow: cabal_widow\n")
+        self.make_workbook(cabal_rows=[], extra_sheets={"Infantry": [
+            DUMMY, type_row("Old Widow", 3000, 4.0, 2.0, 1.0, 3000)]})
+        rc, _ = self.run_seed()
+        self.assertEqual(rc, 0)
+        d = self.design_of("cabal_widow")
+        self.assertEqual(d.get("tech_tier"), 1.0)   # existing judgments untouched
+        self.assertIsNone(d.get("special"))
+        self.assertIsNone(d.get("unit_class"))
+
+    # === revision 3: truthful apply counts =================================
+
+    def test_no_positive_apply_count_for_kept_or_withheld_records(self):
+        full = {"special": 1.0, "unit_class": 1.0, "tech_tier": 1.0,
+                "category": "Vehicles", "subtype": "Unclassified"}
+        self.write_ledger({"schema": 2, "ledger": "test", "sections": {"vehicles": {
+            "cabal_keep": self.unit("Keeper", 100, design=full),
+            "cabal_hold": self.unit("Holder", 200, design=full)}}})
+        self.make_workbook(cabal_rows=[
+            cabal_row("Keeper", "cabal_keep", 1.0, 1.0, 1.0, 100),   # all kept
+            cabal_row("Holder", "cabal_hold", 1.0, 1.0, 1.0, 200),   # conflicting pair:
+            cabal_row("Holder", "cabal_hold", 2.0, 1.0, 1.0, 200)])  # withheld only
+        before = snapshot(self.root)
+        rc, out = self.run_seed(dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(snapshot(self.root), before)
+        self.assertFalse(self.report.exists())
+        self.assertIn("matched 3 legacy rows across 2 unique targets", out)
+        self.assertIn("would fill 0 design fields", out)   # no real transitions exist
+        self.assertNotIn("would fill 1 design fields", out)
+        self.assertIn("1 conflict targets", out)
+        self.assertIn("NO ledger, workbook or report was written", out)
+        rc, out = self.run_seed()
+        self.assertEqual(rc, 0)
+        self.assertIn("applied 0 design fields", out)
+        self.assertIn("conflicts 1", out)
+
+    def read_ledger_text(self):
+        return (self.ledger / "test.json").read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Quarantines the reused CABAL Widow identity, withholds conflicting workbook-derived actor updates, preserves existing values, and makes dry runs non-mutating with truthful diagnostics. Adds 13 evidence-backed aliases. No workbook import or ledger write was performed; this changes future importer behavior, not live unit stats.

## Scope and recommendation

Draft for integration review. **Recommendation: merge after normal PR review/checks**, because this is a bounded correctness fix with independently challenged implementation and no live gameplay change. It does not authorize a balance import, anchor sign-off, or applying proposals. No YAML rules, engine/C#, prices, HP, weapons, reserved producer files, or generated audit reports are included.

Split from the reviewed non-AI batch to respect the repository's PR-size guidance; related dossier improvements stay in #335. Implemented with OpenCode GLM 5.3 Flash; coordinated and independently reviewed through Codex for Blackrobe.

## Validation

- 45 focused regression tests pass on the isolated publication branch. Published file contents match the independently reviewed batch; diff checks pass.
- The exact combined master-based batch was tested at base `5f170ba07a95620ce4324553600bce3ed7bfb723`: 1,148 tests, 44 skipped, 15 failing modules / 22 failure signatures, identical to the untouched-master baseline. All 169 added tests pass. **The full suite is not green.** This is combined-batch evidence, not a claim that each split branch reran the entire suite.
- 33 balance ledgers: zero drift. Percentage checks pass. Weapon structure/shape ratchets unchanged; raw exceptions remain visible. These gates were run on the combined batch.
- Independent source and test challenge found no remaining blocker in the owned changes. Static tests do not prove gameplay balance.
- Tools/data-for-tools only; no game launch. Existing full-suite debt is disclosed, not waived.
