### PR TITLE
CI: validate pull requests targeting master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
   pull_request:
-    branches: [ bleed, 'prep-*' ]
+    branches: [ master, bleed, 'prep-*' ]
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)


### PR DESCRIPTION
Adds master to the existing pull_request branch filter so governance and future contribution PRs receive the repository's Linux, Mono, and Windows checks. Scope: one workflow line only. Validation: YAML parsed successfully and git diff --check passed.