### PR TITLE
Prepare shared developer and agent coordination pilot

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,158 @@
+name: Agent task
+description: Propose a scoped task for human approval in the shared agent pilot.
+title: "[Agent task] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This record coordinates ownership; it is not an atomic lock. Follow AGENTS.md and docs/AGENT_WORKSPACE.md, including the pilot activation gate. Human integrators approve claims; agents may record existing approval.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Intended outcome
+      description: Describe one independently mergeable result and why it matters.
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Human owner
+      description: GitHub username of the person responsible for the agent and final handoff.
+      placeholder: "@username"
+    validations:
+      required: true
+
+  - type: input
+    id: integrator
+    attributes:
+      label: Human integrator
+      description: GitHub username of the person authorized to approve the claim and decide merge readiness.
+      placeholder: "@username"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Agent provider
+      options:
+        - Codex
+        - Claude
+        - Devin
+        - AionUI-hosted agent
+        - OpenCode
+        - Other or human-only
+    validations:
+      required: true
+
+  - type: input
+    id: session
+    attributes:
+      label: Agent session identity
+      description: Opaque session ID and model, or pending if the session has not started. Human-only tasks may say none. Do not publish private session links or conversation text.
+    validations:
+      required: true
+
+  - type: input
+    id: base
+    attributes:
+      label: Repository and base commit
+      description: Repository plus the exact branch/ref and commit from which work will start.
+      placeholder: "cameo-mod/Cameo-mod master @ 40-character SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: writable_scope
+    attributes:
+      label: Writable paths
+      description: One repository-relative path or glob per line. Read-only exploration may be broader.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: checkout
+    attributes:
+      label: Branch and worktree label
+      description: Branch/ref plus a portable label for the isolated checkout. Use pending before creation; never publish an absolute personal path.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reading_route
+    attributes:
+      label: Read first and existing implementation
+      description: Exact TASK_INDEX route, document sections and existing tools/branches to inspect before editing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: excluded_scope
+    attributes:
+      label: Explicitly excluded paths or work
+      description: Record nearby files, generated outputs, gameplay changes, publishing, or other work that this task must not touch.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and overlapping work checked
+      description: Link related tasks/PRs and state how active claims were checked for overlap.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime_impact
+    attributes:
+      label: Expected runtime impact
+      options:
+        - None - documentation or tooling only
+        - Generated analysis or ledger only
+        - YAML or asset behavior
+        - Cameo C# behavior
+        - OpenRA engine behavior or pin
+        - Unknown - requires investigation
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance evidence
+      description: Exact checks, review evidence, and any required human gameplay or visual decision.
+    validations:
+      required: true
+
+  - type: input
+    id: expiry
+    attributes:
+      label: Claim expires
+      description: Explicit date, time, and timezone. The Project DATE field is a reminder only. Stop writes on expiry until renewed; keep the reservation until a human explicitly releases it.
+      placeholder: "YYYY-MM-DD HH:MM UTC"
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Required decision and next action
+      description: Name any human policy/visual/merge decision still needed, or none. Record the next concrete step and any existing approval source.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Claim acknowledgement
+      options:
+        - label: The agent will remain read-only until the human integrator approves this claim.
+          required: true
+        - label: Each writer will use its own branch and isolated worktree; research-only work may remain read-only.
+          required: true
+        - label: No token, SSH detail, credential, or private conversation content is included here.
+          required: true

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -77,7 +77,7 @@ body:
     id: checkout
     attributes:
       label: Branch and worktree label
-      description: Branch/ref plus a portable label for the isolated checkout. Use pending before creation; never publish an absolute personal path.
+      description: Branch/ref plus the pushed remote ref and a portable checkout label. Use pending before creation; never publish an absolute personal path. The claim is not valid until its approved empty claim commit is pushed.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,11 +1,11 @@
 name: Agent task
-description: Propose a scoped task for human approval in the shared agent pilot.
+description: Propose a scoped task for the designated approver in the shared agent pilot.
 title: "[Agent task] "
 body:
   - type: markdown
     attributes:
       value: |
-        This record coordinates ownership; it is not an atomic lock. Follow AGENTS.md and docs/AGENT_WORKSPACE.md, including the pilot activation gate. Human integrators approve claims; agents may record existing approval.
+        This record coordinates ownership; it is not an atomic lock. Follow AGENTS.md and docs/AGENT_WORKSPACE.md, including activation. Aedis's designated agent is the primary approver; Blackrobe takes over when it exhausts quota. Record the active approver and approval receipt.
 
   - type: textarea
     id: outcome
@@ -27,9 +27,9 @@ body:
   - type: input
     id: integrator
     attributes:
-      label: Human integrator
-      description: GitHub username of the person authorized to approve the claim and decide merge readiness.
-      placeholder: "@username"
+      label: Current approver
+      description: Aedis's designated coordinator agent (provider/session ID), or Blackrobe during quota fallback. Link the approval or takeover record; do not assume quota recovery transfers control back.
+      placeholder: "Aedis coordinator - provider/session ID, or @Blackrobe - takeover receipt"
     validations:
       required: true
 
@@ -132,7 +132,7 @@ body:
     id: expiry
     attributes:
       label: Claim expires
-      description: Explicit date, time, and timezone. The Project DATE field is a reminder only. Stop writes on expiry until renewed; keep the reservation until a human explicitly releases it.
+      description: Explicit date, time, and timezone. The Project DATE field is a reminder only. Stop writes on expiry until renewed; keep the reservation until the current approver explicitly releases it.
       placeholder: "YYYY-MM-DD HH:MM UTC"
     validations:
       required: true
@@ -150,7 +150,7 @@ body:
     attributes:
       label: Claim acknowledgement
       options:
-        - label: The agent will remain read-only until the human integrator approves this claim.
+        - label: The worker will remain read-only until the recorded current approver approves this claim.
           required: true
         - label: Each writer will use its own branch and isolated worktree; research-only work may remain read-only.
           required: true

--- a/.github/agents/openra-cameo.agent.md
+++ b/.github/agents/openra-cameo.agent.md
@@ -4,6 +4,12 @@ description: Senior developer agent for the OpenRA Cameo mod. Use when implement
 argument-hint: Describe the feature to implement or bug to fix. E.g. "Add a new Zerg unit to the larva queue" or "Fix the production timer for harvester units".
 ---
 
+## Shared workflow
+
+Read `AGENTS.md`, then `docs/AGENT_WORKSPACE.md` and the relevant `docs/TASK_INDEX.md` route.
+This profile supplies specialist context. Human task instructions and the shared workflow govern
+claims, validation and publication. Verify the technical examples below against current source.
+
 ## Repository Layout
 
 ```
@@ -20,11 +26,9 @@ Cameo-mod/
     hotkeys.yaml             # Cameo-specific hotkey bindings
 ```
 
-**Build command** (run from repo root):
-```powershell
-dotnet build --configuration Release --verbosity minimal
-```
-Close the game before building — the game locks `bin/*.dll`.
+**Build and validation:** follow the current task route in `docs/TASK_INDEX.md` and the canonical
+procedure in `docs/LESSONS_LEARNED.md`. A bare `dotnet build` is not release or boot evidence.
+Report static, build/boot, and in-game evidence separately.
 
 ---
 
@@ -90,12 +94,10 @@ Current `Adjacent: 5` on `SCHATCHERY` (updated from 4). Palette uses `TileSet.Te
 
 ---
 
-## engine ↔ OpenRA Synchronisation
-The `Cameo-mod/engine/` directory is fetched by `fetch-engine.sh` from the `cameo-mod/OpenRA` fork, pinned to the commit hash in `mod.config` (`ENGINE_VERSION`). It is `.gitignored` — NOT a git submodule. Engine-side C# changes follow the canonical engine update pipeline (see `docs/LESSONS_LEARNED.md` § "The canonical engine update pipeline"):
+## Engine and OpenRA boundary
 
-1. Edit engine C# only in the `cameo-engine` dev clone (branch `cameo-engine`).
-2. Commit + push to `origin/cameo-engine`.
-3. `git rev-parse cameo-engine` for the full 40-char hash.
-4. Set `ENGINE_VERSION` in `mod.config` (NOT `mod.yaml`).
-5. `make.cmd all` to re-fetch + rebuild; verify `engine/VERSION` matches.
-6. Boot-gate with `launch-game.cmd`, then commit `mod.config` with updated docs.
+`engine/` is fetched build input, not the authoritative engine repository. Engine source changes
+belong in the separate `cameo-mod/OpenRA` repository under their own approved task and pull
+request. Never change `mod.config`, `ENGINE_VERSION`, or `engine/VERSION` until a human maintainer
+authorizes the pin update to a verified upstream engine commit. Follow `AGENTS.md` and the current
+canonical procedure in `docs/LESSONS_LEARNED.md`; do not reproduce the pipeline in this profile.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 
 - Task/issue:
 - Human owner:
-- Human integrator:
+- Current approver (Aedis's coordinator agent, or Blackrobe during quota fallback):
+- Approval or takeover receipt:
 - Agent provider and opaque session ID (no private session links):
 - Base commit:
 
@@ -38,7 +39,8 @@ Explain the selected impact:
 - [ ] The branch contains one independently mergeable outcome.
 - [ ] The changed files stay inside the approved task scope.
 - [ ] Generated files and their source changes are in the same commit where required.
-- [ ] This PR is ready for human-integrator review.
+- [ ] This PR is ready for review by the current approver.
 
-Humans decide merge readiness. An agent may execute a merge only under explicit human
+The current approver reviews technical readiness within the human-authorized scope.
+An agent may execute a merge only under explicit human
 authorization; green checks do not grant authority. Preserve all explicit holds.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Linked task
+
+- Task/issue:
+- Human owner:
+- Human integrator:
+- Agent provider and opaque session ID (no private session links):
+- Base commit:
+
+## Scope
+
+- Intended outcome:
+- Writable paths claimed:
+- Explicit exclusions respected:
+- Related or overlapping work checked:
+
+## Runtime impact
+
+- [ ] Documentation or tooling only; no live runtime change
+- [ ] Generated analysis or ledger only
+- [ ] YAML or asset behavior
+- [ ] Cameo C# behavior
+- [ ] OpenRA engine behavior or engine pin
+
+Explain the selected impact:
+
+## Evidence
+
+- Focused validation:
+- Broader validation:
+- Baseline failures, if any:
+- New regressions:
+- Build/boot evidence:
+- In-game or visual evidence:
+
+## Handoff
+
+- Remaining decisions or risks:
+- [ ] The branch contains one independently mergeable outcome.
+- [ ] The changed files stay inside the approved task scope.
+- [ ] Generated files and their source changes are in the same commit where required.
+- [ ] This PR is ready for human-integrator review.
+
+Humans decide merge readiness. An agent may execute a merge only under explicit human
+authorization; green checks do not grant authority. Preserve all explicit holds.

--- a/.windsurf/rules/start-protocol.md
+++ b/.windsurf/rules/start-protocol.md
@@ -14,8 +14,9 @@ continue; do not assume that a new Project activates the pilot or cancels reserv
 During the active pilot, follow the manual claim/recovery process in AGENT_WORKSPACE.
 
 Each writer uses an isolated checkout. Agent names and file mtimes do not establish ownership.
-Stage named paths and preserve others' work. Humans decide merges; agents may execute only
-explicitly authorized publication steps. Keep explicit holds.
+Stage named paths and preserve others' work. Aedis's designated coordinator agent approves claims
+and work reviews; Blackrobe takes over on quota exhaustion. Use the documented handover process.
+Agents execute only explicitly authorized publication steps. Keep explicit holds.
 
 Use AGENT_WORKSPACE for validation appropriate to the change, including build preflight and
 engine source/pin boundaries. Do not run --check-yaml or make test. Launch the game only when authorized.

--- a/.windsurf/rules/start-protocol.md
+++ b/.windsurf/rules/start-protocol.md
@@ -1,50 +1,25 @@
 ---
 trigger: always_on
-description: Mandatory start protocol, boot-gate, and engine update pipeline for all tasks
+description: Shared Cameo task and validation entry point
 ---
 
-# Mandatory start protocol (read before EVERY task)
+# Start protocol
 
-Before starting ANY task, load these documents into context IN THIS ORDER. Never skip this, even for "small" tasks:
+Read `AGENTS.md`, then `docs/AGENT_WORKSPACE.md` for coordination and activation status.
+Use `docs/TASK_INDEX.md` to find the relevant technical sections and existing tools.
+`docs/README.md` maps technical documentation; `CLAUDE.md` is optional provider context.
 
-1. `CLAUDE.md` (repo root) — project instructions, loaded every session.
-2. `docs/LESSONS_LEARNED.md` — safe defaults, pitfalls, latest incident findings.
-3. `docs/AGENT_WORKSPACE.md` — source-of-truth map, operating sequence, git/commit rules.
-4. `docs/HANDOFF.md` — **the entry point**: verified current state and the priority-ordered
-   queue. It supersedes every dated handoff; those live in `docs/history/handoffs/` and must
-   NOT be resumed from.
-5. `docs/DESIGN.md` — binding rules (relevant sections) before touching YAML/assets/naming/balance.
-6. `docs/design/ROADMAP.md` — the granular work queue; P0 crashes jump it.
-7. `docs/audit/SUMMARY.md` — known issue classes and current counts.
-8. `docs/Cameo_Knowledge_Base_Manual.md` — engine/trait reference as needed.
+Human task instructions remain controlling. During preparation, existing explicit assignments
+continue; do not assume that a new Project activates the pilot or cancels reservations.
+During the active pilot, follow the manual claim/recovery process in AGENT_WORKSPACE.
 
-`docs/README.md` is the CANONICAL definition of this order; if this copy disagrees with it,
-README wins and this copy gets fixed.
+Each writer uses an isolated checkout. Agent names and file mtimes do not establish ownership.
+Stage named paths and preserve others' work. Humans decide merges; agents may execute only
+explicitly authorized publication steps. Keep explicit holds.
 
-If any document conflicts with chat memory or old notes, the repository documents win — and if
-the ARTIFACT (the tree, an audit, the boot) disagrees with a document, the artifact wins and the
-document gets fixed in the same commit.
+Use AGENT_WORKSPACE for validation appropriate to the change, including build preflight and
+engine source/pin boundaries. Do not run --check-yaml or make test. Launch the game only when authorized.
+Never bypass OS security settings for validation. Report pending runtime evidence honestly.
 
-# Boot-gate rule (never forget)
-
-**ALWAYS test the game with `launch-game.cmd` BEFORE committing anything.** Wait for the main menu (perf.log ends with `MenuPostProcessEffect.PostWorldLoaded`), kill the process, check for NEW `exception-*.log` in `%APPDATA%/OpenRA/Logs`. A commit without a passing boot-gate is not acceptable.
-
-- Known blocker: Windows Smart App Control (SAC) in Enforcement mode blocks all locally built engine binaries (see `docs/LESSONS_LEARNED.md` § Smart App Control 2026-07-30). Four options exist to enable boot-gating: (1) EA cache workaround — turn SAC off, launch game once (ISG writes trust EAs), re-enable SAC; (2) SAC Evaluation mode via WinRE — SAC stays active but does not block (recommended for development); (3) VM / SAC-free machine; (4) code signing with a trusted CA. If the boot-gate cannot run for any SAC reason, say so explicitly, record the SAC state in the commit/PR description, and do NOT silently skip or claim it passed.
-- `utility.cmd cameo --check-yaml` is a lint tool, NOT a boot-gate substitute.
-
-# Engine update pipeline (uniform, binding)
-
-Engine changes follow the pipeline in `docs/LESSONS_LEARNED.md` § "The canonical engine update pipeline". Summary:
-
-1. Edit engine C# only in the `cameo-engine` dev clone (branch `cameo-engine`).
-2. Commit + push to `origin/cameo-engine` (check `git status` for stray gitlinks first).
-3. `git rev-parse cameo-engine` for the full 40-char hash — never hand-type or pad a hash.
-4. Set `ENGINE_VERSION` in `mod.config` (NOT `mod.yaml`).
-5. `make.cmd all` to re-fetch + rebuild; verify `engine/VERSION` matches.
-6. Boot-gate with `launch-game.cmd`, then commit `mod.config` with updated docs.
-
-# Documentation discipline
-
-- Update ALL affected docs (`docs/LESSONS_LEARNED.md`, `docs/design/ROADMAP.md`, `docs/DESIGN.md`, `docs/audit/SUMMARY.md`) BEFORE committing.
-- Write down every significant finding in the appropriate doc immediately — do not leave knowledge only in chat.
-- Never use absolute local file paths in repository documents; use repo-relative paths.
+Update the one canonical document affected by an accepted decision. Task state belongs in the
+active task record; old logs and rosters are historical. Use repository-relative paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,15 +20,16 @@ Provider files add technical context and should point here for collaboration pro
 - The organization GitHub Project and its linked issue or draft item are the live task ledger once
   the workflow is activated. `docs/HANDOFF.md` and `docs/design/ROADMAP.md` retain project context
   and priorities; they do not grant a write claim.
-- A Project item is a manual coordination record, not an atomic lock. The designated human
-  integrator approves claims after checking overlap. An agent may record that existing approval.
-- Each outcome has one task record, human owner and integrator. Each independent writer has its
+- A Project item is a coordination record, not an atomic lock. Aedis's designated coordinator
+  agent approves task claims and reviews work. Blackrobe takes over when that agent runs out of
+  quota. Record the active approver and explicit takeover/handback per `docs/AGENT_WORKSPACE.md`.
+- Each outcome has one task record, human owner and current approver. Each independent writer has its
   own branch and isolated worktree; research-only tasks need no branch or pull request.
 - Record the provider/session identity, base commit, exact writable paths, excluded paths,
   dependencies, acceptance evidence, runtime impact, and an explicit claim-expiry timestamp.
-- Expiry never transfers ownership automatically. The integrator must release or reassign a stale
+- Expiry never transfers ownership automatically. The current approver must release or reassign a stale
   claim after inspecting its branch, commits, worktree, and handoff evidence.
-- Read-only investigation may overlap. Write scopes may not. Stop and contact the integrator when
+- Read-only investigation may overlap. Write scopes may not. Stop and contact the current approver when
   scopes overlap or the task record is missing, stale, or ambiguous.
 
 Do not infer activation from the existence of a Project or issue form. The team must record its
@@ -37,7 +38,7 @@ go-live decision in `docs/AGENT_WORKSPACE.md` and the Project README.
 ## Git and worktree isolation
 
 - Never perform agent work in another person's dirty checkout or another task's worktree.
-- Create an isolated worktree from the human-approved base ref. Re-check the base and active claims
+- Create an isolated worktree from the approved base ref. Re-check the base and active claims
   immediately before the first edit.
 - Use a provider-prefixed branch containing the task number and subject, such as
   `codex/123-fix-description` or `claude/123-fix-description`.
@@ -45,8 +46,9 @@ go-live decision in `docs/AGENT_WORKSPACE.md` and the Project README.
   that may belong to another person or agent.
 - Keep each branch to one sentence-worth of purpose. Before an overnight handoff, publish a draft
   pull request or provide a recoverable commit/patch reference as authorized by the human owner.
-- Humans decide merge readiness and publication. An agent may execute an explicitly authorized
-  merge, but cannot grant itself that authority or infer it from green checks. Preserve explicit
+- Aedis's designated agent (or Blackrobe during quota fallback) approves technical readiness
+  within the human-authorized scope. An agent may execute an explicitly authorized merge, but
+  cannot expand that authority or infer it from green checks. Preserve explicit
   HOLD, no-merge, and review-only instructions.
 
 ## Engine and validation boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ go-live decision in `docs/AGENT_WORKSPACE.md` and the Project README.
   immediately before the first edit.
 - Use a provider-prefixed branch containing the task number and subject, such as
   `codex/123-fix-description` or `claude/123-fix-description`.
+- After the current approver approves a write claim, create an empty claim commit and push the
+  branch ref to the agreed remote. A local branch name alone is not a verifiable claim. If push
+  authorization or connectivity is missing, remain read-only and record the blocker.
 - Stage named paths only. Never broadly stage, reset, clean, restore, rebase, delete, or move work
   that may belong to another person or agent.
 - Keep each branch to one sentence-worth of purpose. Before an overnight handoff, publish a draft

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Cameo shared agent entry point
+
+Read `docs/AGENT_WORKSPACE.md` for the canonical coordination design and its activation status.
+The Project is preparatory until the three developers agree to activate the pilot. Current human
+task instructions remain controlling; this proposal does not revoke existing assignments.
+Provider files add technical context and should point here for collaboration procedure.
+
+## Start every task
+
+1. Read `docs/TASK_INDEX.md`, then the exact sections and existing tools it routes for the task.
+2. Inspect the current checkout, branch, remotes, worktrees, open task record, and related pull
+   requests before deciding that work is missing.
+3. Treat repository source and current generated evidence as stronger than chat, agent memory,
+   dated orders, or old handoffs. Correct stale summaries instead of following them.
+4. Verify the human-authorized outcome and scope before editing. During the active pilot, record
+   the approved claim as described in `docs/AGENT_WORKSPACE.md`.
+
+## Live task and claim state
+
+- The organization GitHub Project and its linked issue or draft item are the live task ledger once
+  the workflow is activated. `docs/HANDOFF.md` and `docs/design/ROADMAP.md` retain project context
+  and priorities; they do not grant a write claim.
+- A Project item is a manual coordination record, not an atomic lock. The designated human
+  integrator approves claims after checking overlap. An agent may record that existing approval.
+- Each outcome has one task record, human owner and integrator. Each independent writer has its
+  own branch and isolated worktree; research-only tasks need no branch or pull request.
+- Record the provider/session identity, base commit, exact writable paths, excluded paths,
+  dependencies, acceptance evidence, runtime impact, and an explicit claim-expiry timestamp.
+- Expiry never transfers ownership automatically. The integrator must release or reassign a stale
+  claim after inspecting its branch, commits, worktree, and handoff evidence.
+- Read-only investigation may overlap. Write scopes may not. Stop and contact the integrator when
+  scopes overlap or the task record is missing, stale, or ambiguous.
+
+Do not infer activation from the existence of a Project or issue form. The team must record its
+go-live decision in `docs/AGENT_WORKSPACE.md` and the Project README.
+
+## Git and worktree isolation
+
+- Never perform agent work in another person's dirty checkout or another task's worktree.
+- Create an isolated worktree from the human-approved base ref. Re-check the base and active claims
+  immediately before the first edit.
+- Use a provider-prefixed branch containing the task number and subject, such as
+  `codex/123-fix-description` or `claude/123-fix-description`.
+- Stage named paths only. Never broadly stage, reset, clean, restore, rebase, delete, or move work
+  that may belong to another person or agent.
+- Keep each branch to one sentence-worth of purpose. Before an overnight handoff, publish a draft
+  pull request or provide a recoverable commit/patch reference as authorized by the human owner.
+- Humans decide merge readiness and publication. An agent may execute an explicitly authorized
+  merge, but cannot grant itself that authority or infer it from green checks. Preserve explicit
+  HOLD, no-merge, and review-only instructions.
+
+## Engine and validation boundaries
+
+- Treat `engine/` as a fetched build input, not the authoritative engine repository. Engine source
+  changes belong in the separate `cameo-mod/OpenRA` repository and require their own task and pull
+  request before a Cameo engine-pin update.
+- Never change `mod.config`, `ENGINE_VERSION`, or `engine/VERSION` without explicit maintainer
+  authorization and a verified upstream engine commit.
+- Follow the validation and engine procedure in `docs/AGENT_WORKSPACE.md`, using technical checks
+  routed by `docs/TASK_INDEX.md`. State what was proven statically, by build/boot, and in game.
+- Do not claim gameplay or visual approval from static checks. The human maintainer makes the final
+  gameplay and visual call.
+- Do not run `--check-yaml` or `make test` (which invokes it). Continuous Integration is disabled
+  in GitHub; use relevant local validation and human review. Do not enable or replace CI unless
+  a human explicitly requests it. CI is not a coordination-pilot activation prerequisite.
+
+## Handoff and communication
+
+- Put binding decisions in their canonical repository document and implementation evidence in the
+  linked pull request. Use the task item for ownership and status only.
+- Report milestones, blockers, decisions needed, and completion receipts. Do not stream internal
+  reasoning or duplicate the same status across documents and chat systems.
+- Discord, MCP, ACP, AionUI, and provider-native agent teams are optional interfaces. They do not
+  override the GitHub task record, grant write scope, or authorize a merge.
+- Never place tokens, SSH details, private conversation text, or other credentials in public task
+  records, pull requests, logs, or repository files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ go-live decision in `docs/AGENT_WORKSPACE.md` and the Project README.
   immediately before the first edit.
 - Use a provider-prefixed branch containing the task number and subject, such as
   `codex/123-fix-description` or `claude/123-fix-description`.
-- After the current approver approves a write claim, create an empty claim commit and push the
+- After activation, for tasks migrated into the Project, and after the current approver approves a
+  write claim, create an empty claim commit and push the
   branch ref to the agreed remote. A local branch name alone is not a verifiable claim. If push
   authorization or connectivity is missing, remain read-only and record the blocker.
 - Stage named paths only. Never broadly stage, reset, clean, restore, rebase, delete, or move work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
 # Cameo-mod
 
-## ⚡ START HERE — read before acting (the rest of this file is the full contract)
+> **Shared workflow:** Read `AGENTS.md` first, then `docs/AGENT_WORKSPACE.md` for the coordination
+> design and activation status. Human task instructions remain controlling. This file adds
+> technical context; its dated rosters and operational recipes do not grant claims or publication.
+
+## ⚡ START HERE — technical context after the shared workflow
 
 **Don't trust, verify.** Before asserting anything is done / pending / blocked / missing,
 check the artifact itself — grep the data, `ls` the file (incl. `~/Downloads`), run the tool,
@@ -40,20 +44,13 @@ never for status.
 5. **Weapon 3-way split:** preserve resolved behaviour (`Damage` verbatim, projectile fields — the
    Frankenstein merge), `find_empty_warhead.py = 0`, boot-gate per batch. Verify a conversion with
    `tools/audit/review_resolve_diff.py` (before/after resolve).
-6. **Multi-agent tree** (maintainer, co-maintainer, other agents, you): **one owner per file-set.**
-   Check a file's mtime and `git log -3 <file>` for a live agent before editing; re-verify others'
-   commits before building on them; never `git checkout -- .` or wide-add someone else's WIP.
-   The file-set boundaries are defined in `docs/design/BALANCE_PROGRAM_PLAN.md` §2.
-7. **Rebuild C# before boot** if `OpenRA.Mods.Cameo/` or `engine/` changed
-   (`DOTNET_ROLL_FORWARD=LatestMajor dotnet build -c Release --nologo -p:TargetPlatform=win-x64` → `engine/bin`).
-   ⚠ **`engine/` IS NOT PART OF THIS REPO** — it is `.gitignore`d, has no `.git`/`.gitmodules`,
-   and `git ls-files engine` returns **zero** files (`git` run from inside it silently targets
-   the PARENT repo). Editing `engine/**` produces work that **cannot be committed here** and is
-   **deleted by the next `make all`**. To change the engine, follow
-   **`docs/LESSONS_LEARNED.md` → "The canonical engine update pipeline"**: edit the SEPARATE
-   `cameo-engine` clone of `github.com/cameo-mod/OpenRA` → push → `git rev-parse cameo-engine`
-   for the full 40-char hash → set `ENGINE_VERSION` in **`mod.config`** → `make.cmd all` →
-   verify `engine/VERSION` + recreate `engine/glsl/` shaders → boot-gate → commit `mod.config`.
+6. **Use the shared claim and checkout procedure** in `docs/AGENT_WORKSPACE.md`.
+   File mtimes, Git authors and agent nicknames cannot establish live ownership. Inspect existing
+   reservations and have the designated human integrator resolve overlap. Preserve others' work.
+7. **Rebuild affected C# before runtime validation.** Follow the current engine and validation
+   procedure in `docs/AGENT_WORKSPACE.md`, including preflight before `make all`. `engine/` is
+   ignored build input; retain engine source in the separate OpenRA repository. Pin changes and
+   publication require explicit human authorization. Never infer permission from an old recipe.
    **First check whether a mod-side SHADOW avoids all of that:** `ObjectCreator.FindType` takes
    the first assembly in `mod.yaml`'s `Assemblies` list (AS, CA, **Cameo**, Cnc, D2k, Common),
    so an `OpenRA.Mods.Cameo` type of the same name wins with zero yaml changes (precedent:
@@ -207,18 +204,13 @@ Then, as the task needs them:
 - Recurring code-health audits and freshness policy: `docs/audit/PERIODIC.md`
   and `docs/audit/periodic.json`.
 
-## Commit gate (absolute — no exceptions)
+## Validation and publication
 
-**Never commit without booting the game first.** Run `launch-game.cmd`
-and confirm it reaches the main menu with NO new `exception-*.log` in
-`%APPDATA%/OpenRA/Logs` (snapshot the log list BEFORE launching; menu
-proof: perf.log ends with `MenuPostProcessEffect.PostWorldLoaded`).
-The Python resolver does not catch junk trait nodes — only the engine
-does, and it parses every faction at boot. If C# sources changed or
-were pulled, rebuild first (`dotnet build -c Release --nologo
--p:TargetPlatform=win-x64`); stale DLLs crash the boot with
-`Cannot locate type: …Info`. Commit with scoped `git add <files>`,
-never `git add -A` — the maintainer usually has live uncommitted edits.
+Use `docs/AGENT_WORKSPACE.md` for validation appropriate to the change. Documentation/templates
+need syntax and link checks; runtime changes need build/boot and relevant behavior evidence.
+Launch the game only when authorized and report pending runtime checks explicitly. A boot proves
+loading, not gameplay correctness. Stage named files and preserve the human owner's publication
+and merge boundaries.
 
 ## Balance changes: the pipeline, never by hand
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ never for status.
    `tools/audit/review_resolve_diff.py` (before/after resolve).
 6. **Use the shared claim and checkout procedure** in `docs/AGENT_WORKSPACE.md`.
    File mtimes, Git authors and agent nicknames cannot establish live ownership. Inspect existing
-   reservations and have the designated human integrator resolve overlap. Preserve others' work.
+   reservations and have the current approver resolve overlap: Aedis's coordinator agent,
+   or Blackrobe during quota fallback. Follow AGENT_WORKSPACE for the handover record.
 7. **Rebuild affected C# before runtime validation.** Follow the current engine and validation
    procedure in `docs/AGENT_WORKSPACE.md`, including preflight before `make all`. `engine/` is
    ignored build input; retain engine source in the separate OpenRA repository. Pin changes and

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -132,6 +132,10 @@ Co-Authored-By: Devin AI <devin@cognition.ai>
 
 # Development Log
 
+> This is append-only implementation history, not a live task ledger or file claim. After the
+> shared workflow is activated, current ownership and status live in the organization GitHub
+> Project and linked task; implementation evidence lives in the linked pull request.
+
 ## Codex - Complete runtime graph validation (2026-09-07)
 
 A 21-minute scripted match completed normally with all 80 kills, exact reciprocal

--- a/docs/AGENT_WORKSPACE.md
+++ b/docs/AGENT_WORKSPACE.md
@@ -20,8 +20,25 @@ does not change that repository's rules; confirm the approved `cameo-engine` bas
 
 Blackrobe uses Codex with GPT-5.6 Sol at High effort. Aedis and Kmoney keep their preferred agent
 tools, including Claude, Devin and AionUI where available. Each human remains responsible for
-their agents' scope and outputs. One named human integrator per task checks overlap and decides
-integration. This design does not appoint a permanent team-wide merger or transfer anyone's rights.
+their agents' scope and outputs. Blackrobe has designated Aedis's coordinator agent as the primary
+approver for task claims, overlap resolution, work reviews and technical integration readiness.
+Blackrobe takes over that approval role when Aedis's agent exhausts its usage quota.
+
+### Approver identity and quota handover
+
+Aedis identifies the coordinator by provider and persistent session ID in the Project README;
+an arbitrary agent nickname or another Aedis worker does not inherit the role. Until that identity
+is confirmed, existing explicit human assignments continue. Each task records its current approver
+and links the approval receipt. This is delegated approval within human-authorized project scope;
+task-specific HOLDs and decisions explicitly reserved for humans remain binding.
+
+On a quota-limit report from Aedis, his designated agent, or Blackrobe, Blackrobe records the
+takeover in the Project and any affected task: previous approver, new approver, time, reason and
+last approval/remaining review. Silence alone is not evidence of quota exhaustion. Only the
+recorded current approver issues new approvals. Quota recovery does not transfer control back
+automatically: Blackrobe records handback after Aedis's agent reads the intervening decisions.
+Existing claims and accepted evidence survive both transfers. GitHub does not enforce this
+handover or monitor provider quotas; it is an explicit coordination procedure.
 
 ```text
 Human owner + preferred agents
@@ -31,7 +48,7 @@ GitHub task record -> approved scope -> isolated writer checkout
           |                                  |
           +------------- evidence / draft PR-+
                                              |
-                                   human integration decision
+                                   designated approver review
 ```
 
 Discord carries scoped discussions, handoffs and review requests. When Codex communicates using
@@ -43,7 +60,7 @@ or task ownership by themselves.
 
 | Need | Canonical location | Rule |
 |---|---|---|
-| **Live task ownership and claim state** | Organization GitHub Project plus linked issue or draft item | Sole live assignment ledger for migrated pilot tasks after activation. Human approval and overlap checks are manual. |
+| **Live task ownership and claim state** | Organization GitHub Project plus linked issue or draft item | Sole live assignment ledger for migrated pilot tasks after activation. The designated approver records approvals and overlap checks; no atomic lock is implemented. |
 | Lessons learned / start protocol | `docs/LESSONS_LEARNED.md` | Read before every new task: accumulated pitfalls and safe defaults. (It carries a convenience copy of the reading order; `docs/README.md` is the canonical one.) |
 | **Project state and priority rationale** | `docs/HANDOFF.md` | The single project handoff. It supersedes dated handoffs but does not grant an agent write claim. |
 | Short project orientation | `docs/README.md` | One page for a first-time reader; every document above is authoritative over it. |
@@ -70,13 +87,14 @@ its human owner confirms the current branch, scope and status; an old roster ent
 silently treated as free space.
 
 1. Create one task record for one independently mergeable outcome. Record the human owner,
-   integrator, provider/session ID, base commit, writable and excluded paths, dependencies,
+   current approver, provider/session ID, base commit, writable and excluded paths, dependencies,
    acceptance evidence, runtime impact, and claim review time. Include the branch, a portable
    worktree label and the exact reading route from `TASK_INDEX.md`. Use `repository#issue` as the
    ID, or the permanent Project draft-item URL while Issues are unavailable.
-2. The designated human integrator checks active claims, existing reservations and PRs for
-   overlapping paths and shared technical dependencies, then approves `Claimed`. An agent may
-   record that approval, including its source, but may not approve its own claim. For the pilot,
+2. The current approver (Aedis's designated agent, or Blackrobe during quota fallback) checks
+   active claims, existing reservations and PRs for overlapping paths and shared technical
+   dependencies, then approves `Claimed` with a linked receipt. Workers cannot self-approve.
+   Work implemented by the approving agent needs a separate reviewer before integration. For the pilot,
    explicitly enumerate paths and directory prefixes; review globs conservatively. Different
    files can still conflict through shared templates, schemas or generators.
 3. Start each writer in an isolated worktree or clone with its own branch and approved base.
@@ -86,7 +104,7 @@ silently treated as free space.
 4. Record outcome, changed paths, base and head commit, evidence, remaining risks and next action.
    Code changes use a linked draft PR; research tasks may finish with an accepted review artifact.
    Source YAML and derived ledgers belong together where required by the balance pipeline.
-5. The human integrator decides readiness. Agents may execute a merge only under explicit human
+5. The current approver decides technical readiness. Agents may execute a merge only under explicit human
    authorization; green checks or a `Review` status do not grant it. Mark code tasks `Done` only
    when the accepted change has a merge receipt. Keep an explicit HOLD until its human owner
    releases it.
@@ -94,21 +112,21 @@ silently treated as free space.
 ### States, recovery and claim expiry
 
 Use `Intake`, `Ready`, `Claimed`, `In progress`, `Review`, `Blocked`, `Done`, and `Abandoned`.
-`Ready` means scoped but unclaimed. `Claimed` and `In progress` require recorded human approval.
-`Review` and `Blocked` retain the reservation until the integrator releases it. `Abandoned` means
+`Ready` means scoped but unclaimed. `Claimed` and `In progress` require recorded approver approval.
+`Review` and `Blocked` retain the reservation until the current approver releases it. `Abandoned` means
 the owner stopped the task and left recoverable evidence; it never means delete the branch.
 
 Keep Project fields small: Status, Priority, Claim expires and Work class; use built-in Assignees
 and Repository fields where available. `Claim expires` is a DATE reminder. Put the precise
-timestamp with timezone in the task body. It schedules human reassessment, not an expiring lock.
+timestamp with timezone in the task body. It schedules approver reassessment, not an expiring lock.
 On expiry, stop further writes until renewed; preserve the files and reservation. A replacement
-cannot take over until the integrator has confirmed the previous writer stopped, inspected its
+cannot take over until the current approver has confirmed the previous writer stopped, inspected its
 branch/diff, and explicitly released or reassigned the scope.
 
 After a crash or restart, recover from the task ID, provider session ID, base/head commit and
 worktree label. Inspect the actual checkout and current task record before resuming. A friendly
 agent name is not an identity. If the board is unavailable or state is uncertain, preserve work,
-continue read-only investigation and contact the integrator instead of self-assigning.
+continue read-only investigation and contact the current approver instead of self-assigning.
 
 ### What is enforced and what is a convention
 
@@ -116,12 +134,12 @@ continue read-only investigation and contact the integrator instead of self-assi
 |---|---|
 | Git worktree or separate clone | Separate working files when writers stay inside their checkout; not a security sandbox |
 | Issue form and PR template | Prompts for scope and evidence; cannot prevent unauthorized edits or enforce correctness |
-| Project states, timestamps and human overlap review | Manual coordination; no atomic claims, lease service, automatic expiry or filesystem lock |
+| Project states, timestamps and designated approver review | Explicit coordination; no atomic claims, lease service, automatic expiry, quota monitor or filesystem lock |
 | Local validation and human review | Record actual checks on the relevant commit and their limits; CI is disabled and is not an activation prerequisite |
 | Repository protection | Only the rules configured by an administrator; this preparation does not add review or required-check enforcement |
 
 The initial pilot must exercise two simultaneous requests for one scope, a restart, and an
-expired claim with unfinished work. In each case the integrator must preserve one writer and a
+expired claim with unfinished work, plus quota takeover and handback. In each case the approver must preserve one writer and a
 recoverable handoff. These are acceptance scenarios to run before expanding the pilot, not tests
 already performed by this documentation PR.
 
@@ -167,7 +185,8 @@ for upstream integration. Never force-push, delete or reassign others' branches 
 Use clear commit titles describing behavior. Record actual agent/provider provenance in the task
 and PR; do not infer ownership from shared Git authors or copy another agent's attribution.
 Update the canonical document affected by the change, not every status file. An agent may execute
-explicitly authorized publication/merge steps, but only humans decide the authority and scope.
+explicitly authorized publication/merge steps. Humans set the authority and scope; Aedis's
+designated agent reviews within that delegation, with Blackrobe as the quota fallback.
 Pending reviews, explicit holds and failing checks must be reported before any integration decision.
 
 ## Documentation rules
@@ -195,8 +214,9 @@ For an engine crash or player-visible visual regression:
 
 ## Pilot activation and deferred work
 
-Before activation, the three developers agree on the claim integrator, status meanings, recovery
-procedure and access to the task records. A repository administrator decides whether to enable
+Before activation, record Aedis's designated coordinator identity and the team's acceptance of
+the status meanings, quota handover, recovery procedure and task access. The primary/fallback
+approval roles are decided; the governance design still awaits team review. A repository administrator decides whether to enable
 Issues in both repositories. Review/status-check branch protections are a separate team decision,
 not an activation prerequisite. Report any required check that blocks merging before changing
 protections. No Project field or template changes repository permissions.

--- a/docs/AGENT_WORKSPACE.md
+++ b/docs/AGENT_WORKSPACE.md
@@ -18,8 +18,9 @@ does not change that repository's rules; confirm the approved `cameo-engine` bas
 
 ## Design and responsibilities
 
-Blackrobe uses Codex with GPT-5.6 Sol at High effort. Aedis and Kmoney keep their preferred agent
-tools, including Claude, Devin and AionUI where available. Each human remains responsible for
+Blackrobe uses the task-selected Codex model and reasoning effort; that selection remains
+configuration, not a coordination identity. Aedis and Kmoney keep their preferred agent tools,
+including Claude, Devin and AionUI where available. Each human remains responsible for
 their agents' scope and outputs. Blackrobe has designated Aedis's coordinator agent as the primary
 approver for task claims, overlap resolution, work reviews and technical integration readiness.
 Blackrobe takes over that approval role when Aedis's agent exhausts its usage quota.

--- a/docs/AGENT_WORKSPACE.md
+++ b/docs/AGENT_WORKSPACE.md
@@ -26,10 +26,12 @@ Blackrobe takes over that approval role when Aedis's agent exhausts its usage qu
 
 ### Approver identity and quota handover
 
-Aedis identifies the coordinator by provider and persistent session ID in the Project README;
-an arbitrary agent nickname or another Aedis worker does not inherit the role. Until that identity
-is confirmed, existing explicit human assignments continue. Each task records its current approver
-and links the approval receipt. This is delegated approval within human-authorized project scope;
+Aedis identifies the coordinator by human plus provider/tool (for example, Aedis's Claude Code
+coordinator). The session ID is provenance, not the role identity, because a new session may have
+a new ID after restart. An arbitrary agent nickname or another Aedis worker does not inherit the
+role. Until the coordinator identity is confirmed, existing explicit human assignments continue.
+Each task records its current approver and links the approval receipt. This is delegated approval
+within human-authorized project scope;
 task-specific HOLDs and decisions explicitly reserved for humans remain binding.
 
 On a quota-limit report from Aedis, his designated agent, or Blackrobe, Blackrobe records the
@@ -91,13 +93,18 @@ silently treated as free space.
    acceptance evidence, runtime impact, and claim review time. Include the branch, a portable
    worktree label and the exact reading route from `TASK_INDEX.md`. Use `repository#issue` as the
    ID, or the permanent Project draft-item URL while Issues are unavailable.
-2. The current approver (Aedis's designated agent, or Blackrobe during quota fallback) checks
+2. After approval, the writer creates the provider-prefixed branch, an empty claim commit, and
+   pushes that ref to the agreed remote. The remote branch ref is the verifiable claim receipt;
+   a local branch name alone is not a claim. If pushing is not authorized or fails, remain
+   read-only and record the blocker. The current approver (Aedis's designated agent, or Blackrobe
+   during quota fallback) then checks
    active claims, existing reservations and PRs for overlapping paths and shared technical
    dependencies, then approves `Claimed` with a linked receipt. Workers cannot self-approve.
    Work implemented by the approving agent needs a separate reviewer before integration. For the pilot,
    explicitly enumerate paths and directory prefixes; review globs conservatively. Different
    files can still conflict through shared templates, schemas or generators.
-3. Start each writer in an isolated worktree or clone with its own branch and approved base.
+3. Start each writer in an isolated worktree or clone from the pushed branch/base with its own
+   branch and approved base.
    Read-only reviewers may overlap. Start the pilot with at most one write task per human; expand
    only after the handoff process works. A local supervisor may use workers, but must isolate each
    independent writer and partition the parent's approved scope.
@@ -143,6 +150,10 @@ expired claim with unfinished work, plus quota takeover and handback. In each ca
 recoverable handoff. These are acceptance scenarios to run before expanding the pilot, not tests
 already performed by this documentation PR.
 
+With two agents, review can be mutual rather than independent: each side may review the other's
+work while the current approver also integrates it. Record that limitation on consequential tasks
+and escalate to a third reviewer when the pilot's humans decide it is needed.
+
 ## Required operating sequence
 
 Read `AGENTS.md`, use `TASK_INDEX.md` to locate existing tools and technical decisions, then read
@@ -169,7 +180,9 @@ Keep packaging, deployment and other workflows unchanged. Use relevant local che
 review; do not enable CI, add replacement CI, or make CI a pilot activation condition without a
 new explicit human request. PR #343 added a branch filter only; it did not enable that workflow.
 
-For runtime-affecting changes, keep build, menu-load and in-game proof distinct. A menu-load test
+For engine-content changes, a merge requires the applicable boot evidence. If launch authorization
+or the runtime environment is unavailable, hold the engine change for a human rather than merging
+it without proof. For other runtime-affecting changes, keep build, menu-load and in-game proof distinct. A menu-load test
 must identify the tested commit/build and new logs; it cannot establish gameplay correctness.
 Launch the game only when authorized. If runtime review is pending, say so in the PR instead of
 claiming complete validation. Never change OS security settings or bypass a blocked launch as

--- a/docs/AGENT_WORKSPACE.md
+++ b/docs/AGENT_WORKSPACE.md
@@ -1,16 +1,54 @@
 # Shared Agent Workspace
 
-This repository is the shared source of truth for maintainers and every AI agent. Do not create a second roadmap, audit tree, or design contract outside this repository.
+This document is the canonical coordination design for Cameo's developers and their agents.
+`AGENTS.md` is its entry point. Technical design and evidence remain versioned in the repository;
+GitHub tracks who owns each active task.
+
+**Status: preparation for team review, 2026-09-11.** The private
+[Cameo Development Coordination Project](https://github.com/orgs/cameo-mod/projects/1) covers
+`cameo-mod/Cameo-mod` and `cameo-mod/OpenRA`. Creating it does not activate this pilot or release
+any existing assignments. Aedis and Kmoney are asked to review this design with their agents before
+the governance PR is merged. After agreement, record the activation decision here and in the
+Project README. Repository Issues are currently disabled; Project draft items support the initial
+review, while enabling Issues requires a repository administrator.
+
+The OpenRA repository also needs a reviewed adapter for its own `AGENTS.md` before the pilot is
+activated for engine tasks. Its existing instructions name a different base branch. This Project
+does not change that repository's rules; confirm the approved `cameo-engine` base in each task.
+
+## Design and responsibilities
+
+Blackrobe uses Codex with GPT-5.6 Sol at High effort. Aedis and Kmoney keep their preferred agent
+tools, including Claude, Devin and AionUI where available. Each human remains responsible for
+their agents' scope and outputs. One named human integrator per task checks overlap and decides
+integration. This design does not appoint a permanent team-wide merger or transfer anyone's rights.
+
+```text
+Human owner + preferred agents
+          |
+          v
+GitHub task record -> approved scope -> isolated writer checkout
+          |                                  |
+          +------------- evidence / draft PR-+
+                                             |
+                                   human integration decision
+```
+
+Discord carries scoped discussions, handoffs and review requests. When Codex communicates using
+Blackrobe's account, messages start with `[Codex]`. No Discord bot or shared server execution is
+part of this preparation. ACP and MCP can connect clients and tools, but provide no file locks
+or task ownership by themselves.
 
 ## Source-of-truth map
 
 | Need | Canonical location | Rule |
 |---|---|---|
+| **Live task ownership and claim state** | Organization GitHub Project plus linked issue or draft item | Sole live assignment ledger for migrated pilot tasks after activation. Human approval and overlap checks are manual. |
 | Lessons learned / start protocol | `docs/LESSONS_LEARNED.md` | Read before every new task: accumulated pitfalls and safe defaults. (It carries a convenience copy of the reading order; `docs/README.md` is the canonical one.) |
-| **Entry point: current state + priority queue** | `docs/HANDOFF.md` | The single handoff. Supersedes every dated one in `docs/history/handoffs/`; never resume from those. |
+| **Project state and priority rationale** | `docs/HANDOFF.md` | The single project handoff. It supersedes dated handoffs but does not grant an agent write claim. |
 | Short project orientation | `docs/README.md` | One page for a first-time reader; every document above is authoritative over it. |
-| Current work queue | `docs/design/ROADMAP.md` | Crashes and player-visible bugs are P0 and always jump the queue. Add new issues here before implementation. Closed July items live in `docs/history/ROADMAP_ARCHIVE_2026-07.md`. |
-| Balance board, ownership, acceptance criteria | `docs/design/BALANCE_PROGRAM_PLAN.md` | W1–W26, file-set ownership (§2), and the binding order of operations (§0a). |
+| Program backlog | `docs/design/ROADMAP.md` | Crashes and player-visible bugs are P0 and always jump the queue. It records program priority, while the linked GitHub task record carries live ownership. Closed July items live in `docs/history/ROADMAP_ARCHIVE_2026-07.md`. |
+| Balance program and acceptance criteria | `docs/design/BALANCE_PROGRAM_PLAN.md` | W1–W26 and the technical order of operations (§0a). Dated ownership tables are context; confirm reservations before changing them. |
 | Numeric claims that must not rot | `docs/audit/doc_claims.yaml` | Every number a DECISION rests on, with its re-measure command. Update `value` AND every doc under `docs:` in the same commit. |
 | Binding rules and conventions | `docs/DESIGN.md` | Read before modifying YAML, assets, naming, weapons, balance, or descriptions. |
 | Engine and custom-trait reference | `docs/Cameo_Knowledge_Base_Manual.md` | Consult before changing unfamiliar traits or C#-backed behavior. |
@@ -24,31 +62,113 @@ This repository is the shared source of truth for maintainers and every AI agent
 | External-agent historical evidence | `docs/history/LEGACY_DEVIN_CABAL.md` | Historical register only. No external output is current until rerun in this repository. |
 | Archived handoffs | `docs/history/handoffs/` | Dated session records. Provenance only — **never** resume work from one. |
 
+## Cross-provider coordination
+
+During preparation, work continues under explicit human assignments. After activation, use the
+following procedure for tasks the team has moved into the Project. Move existing work only after
+its human owner confirms the current branch, scope and status; an old roster entry cannot be
+silently treated as free space.
+
+1. Create one task record for one independently mergeable outcome. Record the human owner,
+   integrator, provider/session ID, base commit, writable and excluded paths, dependencies,
+   acceptance evidence, runtime impact, and claim review time. Include the branch, a portable
+   worktree label and the exact reading route from `TASK_INDEX.md`. Use `repository#issue` as the
+   ID, or the permanent Project draft-item URL while Issues are unavailable.
+2. The designated human integrator checks active claims, existing reservations and PRs for
+   overlapping paths and shared technical dependencies, then approves `Claimed`. An agent may
+   record that approval, including its source, but may not approve its own claim. For the pilot,
+   explicitly enumerate paths and directory prefixes; review globs conservatively. Different
+   files can still conflict through shared templates, schemas or generators.
+3. Start each writer in an isolated worktree or clone with its own branch and approved base.
+   Read-only reviewers may overlap. Start the pilot with at most one write task per human; expand
+   only after the handoff process works. A local supervisor may use workers, but must isolate each
+   independent writer and partition the parent's approved scope.
+4. Record outcome, changed paths, base and head commit, evidence, remaining risks and next action.
+   Code changes use a linked draft PR; research tasks may finish with an accepted review artifact.
+   Source YAML and derived ledgers belong together where required by the balance pipeline.
+5. The human integrator decides readiness. Agents may execute a merge only under explicit human
+   authorization; green checks or a `Review` status do not grant it. Mark code tasks `Done` only
+   when the accepted change has a merge receipt. Keep an explicit HOLD until its human owner
+   releases it.
+
+### States, recovery and claim expiry
+
+Use `Intake`, `Ready`, `Claimed`, `In progress`, `Review`, `Blocked`, `Done`, and `Abandoned`.
+`Ready` means scoped but unclaimed. `Claimed` and `In progress` require recorded human approval.
+`Review` and `Blocked` retain the reservation until the integrator releases it. `Abandoned` means
+the owner stopped the task and left recoverable evidence; it never means delete the branch.
+
+Keep Project fields small: Status, Priority, Claim expires and Work class; use built-in Assignees
+and Repository fields where available. `Claim expires` is a DATE reminder. Put the precise
+timestamp with timezone in the task body. It schedules human reassessment, not an expiring lock.
+On expiry, stop further writes until renewed; preserve the files and reservation. A replacement
+cannot take over until the integrator has confirmed the previous writer stopped, inspected its
+branch/diff, and explicitly released or reassigned the scope.
+
+After a crash or restart, recover from the task ID, provider session ID, base/head commit and
+worktree label. Inspect the actual checkout and current task record before resuming. A friendly
+agent name is not an identity. If the board is unavailable or state is uncertain, preserve work,
+continue read-only investigation and contact the integrator instead of self-assigning.
+
+### What is enforced and what is a convention
+
+| Mechanism | Actual guarantee |
+|---|---|
+| Git worktree or separate clone | Separate working files when writers stay inside their checkout; not a security sandbox |
+| Issue form and PR template | Prompts for scope and evidence; cannot prevent unauthorized edits or enforce correctness |
+| Project states, timestamps and human overlap review | Manual coordination; no atomic claims, lease service, automatic expiry or filesystem lock |
+| Local validation and human review | Record actual checks on the relevant commit and their limits; CI is disabled and is not an activation prerequisite |
+| Repository protection | Only the rules configured by an administrator; this preparation does not add review or required-check enforcement |
+
+The initial pilot must exercise two simultaneous requests for one scope, a restart, and an
+expired claim with unfinished work. In each case the integrator must preserve one writer and a
+recoverable handoff. These are acceptance scenarios to run before expanding the pilot, not tests
+already performed by this documentation PR.
+
 ## Required operating sequence
 
-1. Read in this order before touching rules or assets: `docs/LESSONS_LEARNED.md` → this file → `docs/HANDOFF.md` → `docs/DESIGN.md` (the sections your change touches) → `docs/design/ROADMAP.md` → `docs/audit/SUMMARY.md`, then the relevant section of `docs/Cameo_Knowledge_Base_Manual.md`. **`docs/README.md` defines that order and wins over any copy of it, including this one.**
-2. Record a newly discovered crash, regression, or suspected discrepancy in `docs/design/ROADMAP.md` before proposing a fix.
-3. Treat release builds, engine logs, resolved-ruleset diffs, and current audit output as evidence. Do not promote an old raw `.txt` result to a live finding without rerunning its audit.
-4. For refactors, compare `tools/audit/dump_resolved.py` output before and after (for a single weapon conversion, `tools/audit/review_resolve_diff.py`). For content changes, run the targeted audit first and the full suite when practical.
-5. Before every commit, boot-gate with `launch-game.cmd` — launch the game, wait for the main menu (perf.log ends with `MenuPostProcessEffect.PostWorldLoaded`), kill the process, then check for NEW `exception-*.log` files in `%APPDATA%/OpenRA/Logs`. Fix any crashes before committing. Stage only the files belonging to the change. **SAC note**: If Windows Smart App Control (Enforcement mode) blocks the boot-gate, see `docs/LESSONS_LEARNED.md` § Smart App Control for four options to enable testing (EA cache workaround, Evaluation mode via WinRE, VM, or code signing). Never silently skip the boot-gate — record the SAC state in the commit/PR description.
-6. `utility.cmd cameo --check-yaml` is a **linting/YAML validation tool**, NOT a boot-gate substitute. Use it for: verifying cosmetic refactors (actor/template renames), checking broken prerequisites, and detecting gameplay-relevant YAML issues. **Goal: 0 errors AND 0 warnings.** The utility takes a VERY LONG TIME (10+ minutes) — only run it when you have completed ALL connected tasks from the last report and expect 0 errors/warnings to confirm. Do NOT run it repeatedly. Keep findings from the last report in ROADMAP and docs so they can be fixed without re-running. It is ABSOLUTELY NECESSARY — just choose wisely WHEN to run it.
-7. After any bulk YAML lint cleanup, run `python tools/audit/audit_nuclear_flash_bindings.py`. It resolves the active `mod.yaml` graph and blocks removal of the RA1, Ixian, or CABAL directional flash warhead. The full audit suite includes the same check.
+Read `AGENTS.md`, use `TASK_INDEX.md` to locate existing tools and technical decisions, then read
+the relevant current source and evidence. `docs/README.md` maps the technical documentation.
+Record a task before implementation during the active pilot; prioritize reproduced crashes and
+player-visible regressions. Current evidence wins over dated state claims, but a measurement does
+not authorize a gameplay-policy change.
 
-## Git workflow and commit rules (binding, 2026-07-24)
+Inspect `mods/cameo/mod.yaml` before auditing YAML/data and follow active include lists. Use the
+existing MiniYAML resolver for inheritance. Refactors require an appropriate before/after resolved
+comparison. Run focused checks for affected behavior, then broaden only when the risk or result
+requires it. Report baseline failures, new regressions and environment limits separately.
 
-**Multiple developers and agents work on this repository.** Committing identities seen in the
-log: **AedisToru** (maintainer — also lands most agent work under the shared repo identity),
-**Blackrobe** (co-maintainer), **Elpollo315**, **Zan Yewang**, **Devin AI**. Because the git
-author is often the shared identity, the `Co-Authored-By:` **trailer** is the only reliable
-record of which agent wrote a change — see CLAUDE.md rule 10.
+Documentation and template-only changes need syntax, links and diff validation. C# or engine
+shader changes need the current build procedure. YAML/assets need a restart, not a C# rebuild.
+Before `make all`, run `tools/preflight-build.ps1` from the configured Cameo checkout and stop if
+it fails; do not overwrite merged local engine work or alter a pin to bypass it. Preserve engine
+source in the separate OpenRA clone and mirror approved engine edits into the intended Cameo
+engine copy for validation. A pin update requires a verified merged upstream engine commit and
+explicit human authorization. Do not run `--check-yaml` or `make test`, which invokes it.
 
-1. **Always fetch, pull, and merge before any commit.** The remote may have changes from other developers. If the engine pin (`mod.config` `ENGINE_VERSION`) changed, always run `make all` to fetch and build the new engine before boot-gating. Never skip the boot-gate.
-2. **Always boot-gate before committing.** Launch the game with `launch-game.cmd`, wait for the main menu (perf.log ends with `MenuPostProcessEffect.PostWorldLoaded`), kill the process, then check for NEW `exception-*.log` files in `%APPDATA%/OpenRA/Logs`. A commit that breaks the boot is not acceptable. (`utility.cmd cameo --check-yaml` is a separate linting tool — see step 6 above.) **If SAC blocks the boot-gate**, see `docs/LESSONS_LEARNED.md` § Smart App Control for options; record the SAC state in the commit/PR description.
-3. **Always update ALL relevant documentation files BEFORE committing.** This includes `docs/design/ROADMAP.md`, `docs/DESIGN.md`, `docs/audit/SUMMARY.md`, `docs/LESSONS_LEARNED.md`, and any other docs affected by the change. Check old docs for outdated information, inconsistencies, and contradictions — fix them. A commit without updated docs is an incomplete commit.
-4. **Do not spam commits on upstream master.** Use a pull request (PR) for cleaner commit history. Create a feature branch, push it, open a PR, and merge only after verification.
-5. **Only merge a PR if either:** (a) you no longer detect regression caused by the changes, or (b) launching the game no longer results in a crash. Commits that do not break the master branch are a naturally acceptable outcome.
-6. **Commit titles must be self-explanatory to all developers.** Terms like "Phase 5", "A2 audit", "Fix B5", or "X/Y law" are only understood internally by Aedis and their agent. If such internal pointers are necessary, elaborate where to find the definition (e.g. "see docs/audit/SUMMARY.md bug class B5") and what kind of project it links to.
-7. **When a task is completely done, merge the feature branch to master.** Do not leave completed work stranded on a feature branch. Ensure boot-gate passes and docs are updated before merging.
+`Continuous Integration` (`.github/workflows/ci.yml`) is disabled in GitHub, verified on 2026-09-11.
+Keep packaging, deployment and other workflows unchanged. Use relevant local checks and human
+review; do not enable CI, add replacement CI, or make CI a pilot activation condition without a
+new explicit human request. PR #343 added a branch filter only; it did not enable that workflow.
+
+For runtime-affecting changes, keep build, menu-load and in-game proof distinct. A menu-load test
+must identify the tested commit/build and new logs; it cannot establish gameplay correctness.
+Launch the game only when authorized. If runtime review is pending, say so in the PR instead of
+claiming complete validation. Never change OS security settings or bypass a blocked launch as
+part of validation. Human gameplay and visual sign-off remains a separate acceptance decision.
+
+## Git workflow and commit rules
+
+Inspect remotes, base and dirty state before making changes. Fetching does not authorize merging
+into a shared checkout. Keep agent writes in isolated checkouts, stage named files, and preserve
+others' work. Publish to the human owner's fork or another explicitly authorized remote; use PRs
+for upstream integration. Never force-push, delete or reassign others' branches without authority.
+
+Use clear commit titles describing behavior. Record actual agent/provider provenance in the task
+and PR; do not infer ownership from shared Git authors or copy another agent's attribution.
+Update the canonical document affected by the change, not every status file. An agent may execute
+explicitly authorized publication/merge steps, but only humans decide the authority and scope.
+Pending reviews, explicit holds and failing checks must be reported before any integration decision.
 
 ## Documentation rules
 
@@ -69,6 +189,22 @@ For an engine crash or player-visible visual regression:
 
 1. Preserve the exact exception and failing asset/actor/sequence.
 2. Compare the affected actor, sequence key, asset filename, and tooltip/display references against the last known-good release.
-3. Add an evidence-backed P0 item to `docs/design/ROADMAP.md`.
+3. Add an evidence-backed P0 task to the active intake, linked to the program backlog when relevant.
 4. Do not modify unrelated palette, template, or naming data while root cause is unproven.
-5. Verify with a boot test before considering the incident resolved.
+5. Verify the affected behavior at the appropriate runtime boundary before marking the incident resolved.
+
+## Pilot activation and deferred work
+
+Before activation, the three developers agree on the claim integrator, status meanings, recovery
+procedure and access to the task records. A repository administrator decides whether to enable
+Issues in both repositories. Review/status-check branch protections are a separate team decision,
+not an activation prerequisite. Report any required check that blocks merging before changing
+protections. No Project field or template changes repository permissions.
+
+Start with three small independent tasks and one handoff/restart exercise. Review accepted
+outcomes, duplicated effort, abandoned work and time spent coordinating before increasing writers.
+Keep old worktrees and branches intact; inventory only work the owners identify as active.
+
+This preparation does not deploy a Discord bot, host an agent service on the game server, add an
+automatic lease/lock service, configure AionUI for teammates, or choose CODEOWNERS. Any future
+automation should justify its cost against the manual pilot and be reviewed separately.

--- a/docs/BLACKROBE_ASTRA_ORDERS_2026-09-07.md
+++ b/docs/BLACKROBE_ASTRA_ORDERS_2026-09-07.md
@@ -1,5 +1,10 @@
 # ORDERS — Codex / GPT-6 Astra · 2026-09-07
 
+> **Dated assignment record.** Preserve the technical requirements and evidence here. Revalidate
+> task status and reservations with the human owner before acting. `AGENTS.md` and
+> `docs/AGENT_WORKSPACE.md` describe the shared coordination pilot; this document does not activate
+> it or supply current publication/merge authority.
+
 **From Claude-Local (Opus 5), fleet coordinator, at the maintainer's order.**
 **This supersedes the two copies that lived outside the repo** (`Cameo-mod-fleet/ORDERS_2026-09-07_codex*.md`).
 It lives in the repository on purpose: it must be readable by you from a cold start, with no one
@@ -814,7 +819,8 @@ exception is a crash: crashes always jump the queue.
 * **Worktree, never `git checkout -b` in the shared checkout.**
   `git worktree add C:/tmp/astra-<lane> -b astra/<lane> origin/master`. A checkout in the main tree
   moves every other agent's working directory; it has happened twice.
-* **Branch, gate, push, post. Only Claude-Local merges to master.**
+* **Historical merge arrangement:** Claude-Local integrated the dated fleet. Current human
+  authorization and `docs/AGENT_WORKSPACE.md` govern publication and merge decisions.
 * **Scoped `git add <paths>` only** — never `-A` / `.` / `--all`. `git commit` also needs an
   explicit `-- <paths>` pathspec, or it commits the whole index including someone else's staged WIP.
 * **Sign your own trailer** with your own identity. Never the Claude one — the git author is a

--- a/docs/FLEET_ORDERS_2026-09-08.md
+++ b/docs/FLEET_ORDERS_2026-09-08.md
@@ -1,5 +1,12 @@
 # FLEET ORDERS — 2026-09-08 · land what you have built
 
+> **Historical coordination snapshot.** Preserve this document as evidence of the 2026-09-08
+> recovery, but do not treat its agent names, file claims, queue, or merge hierarchy as current.
+> After activation, live ownership is recorded in the organization GitHub Project and linked task;
+> the shared rules are in `AGENTS.md` and `docs/AGENT_WORKSPACE.md`.
+> This banner does not cancel assignments: retain existing reservations until their human owners
+> confirm transfer or release. Technical design rulings are unchanged.
+
 Issued by Claude-Local (Opus 5), coordinator, at the maintainer's order. **These supersede
 `Cameo-mod-fleet/ORDERS_2026-09-07_reference_reset.md` for every lane named below.** Codex/Astra
 has its own document: `docs/BLACKROBE_ASTRA_ORDERS_2026-09-07.md` — read §3 of it for the ownership
@@ -24,9 +31,9 @@ So the default changes. **Small branch, one subject, land it, delete it.** A bra
 described in one sentence is too big. If a branch has been open more than two days, it is now your
 top priority to finish or abandon it — say which, do not leave it.
 
-⛔ Only Claude-Local merges to master. That has not changed. What changed is that I am now
-actively landing, in order, and **a branch that conflicts goes to the back of the queue.** Rebase
-onto `origin/master` before you tell me a branch is ready.
+Historical integration arrangement: Claude-Local landed that fleet's branches and queued
+conflicting work for reconciliation. Current human assignments govern publication; use
+`AGENTS.md` and `docs/AGENT_WORKSPACE.md` before preparing or integrating new work.
 
 ### What I landed today, so you can rebase on it
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -40,6 +40,10 @@ Earlier dated snapshots below remain historical, and the only-UP rule remains.
 
 > **Numeric evidence refresh — 2026-09-10, combined `839cdced4` plus reopened tooling.** `multi_main_fired_weapons` = **120**; `unconverted_template_inheritors` = **1590**. Measured on this combined tree; predicates and tolerances are unchanged. The flat-health denominator correction changes diagnostics, not live weapons or prices. Earlier branch-specific snapshots remain historical.
 
+> **Coordination transition:** `AGENTS.md` and `AGENT_WORKSPACE.md` describe the proposed shared
+> pilot and its activation gate. This handoff retains technical decisions and historical evidence.
+> Dated rosters and claim tables below cannot establish current ownership on their own. Existing
+> assignments remain reserved until their human owners confirm a migration or release.
 
 ## ⛔⛔ 2026-09-07 — READ THIS FIRST: the reference map, and one absolute rule
 
@@ -368,7 +372,7 @@ shipped that many, so RV expands the roster like CA and DTA do. `OpenRA RA2 offi
 
 ⚠ **No balance number has been written to yaml.** Nothing is applied until the map is right.
 
-## ⭐ AGENT ASSIGNMENTS — who is doing what (2026-09-06)
+## ⭐ Historical agent assignments (2026-09-06)
 
 | agent | lane |
 |---|---|
@@ -381,10 +385,9 @@ shipped that many, so RV expands the roster like CA and DTA do. `OpenRA RA2 offi
 | **Blaze** | `atreides` + `corrino` + `harkonnen` + `futuretech` + `yuri` — **32 items**, incl. **14 of the 15 actor-id renames left in the whole mod** → `TASK_2026-09-06_blaze.md` |
 | **Claude-Local (Opus 5)** | rulings, review, squash-merges to master, and the gates |
 
-⚠ **Nobody merges to master except Claude-Local.** Agents commit freely on their own branch
-and report a completed work item; Claude reviews and squash-merges one meaningful commit. The
-maintainer must be able to read master — 107 commits in one day, 49 of them touching only
-`DEVELOPMENT_LOG.md`, is not reviewable.
+The 2026-09-06 arrangement had Claude-Local review and squash the fleet's branches. Its purpose
+was readable integration after a day of 107 commits, including 49 log-only updates. This is
+historical context; current human task authorization governs merges.
 
 ### ⛔ 2026-09-07 — four bugs shipped past every gate; three new audits + one hook rule
 
@@ -714,9 +717,8 @@ Rules 1–2 are enforced by hooks in `.claude/settings.json`.
 5. **Weapon 3-way split:** preserve resolved behaviour (`Damage` verbatim, projectile fields),
    `find_empty_warhead.py` = 0, boot-gate per batch. Verify with
    `tools/audit/review_resolve_diff.py` (resolve before and after).
-6. **One owner per file-set.** Check a file's mtime and `git log -3 <file>` for a live agent
-   before editing. Re-verify others' commits before building on them. Never
-   `git checkout -- .` or wide-add someone else's work.
+6. **One owner per file-set.** Follow the claim/recovery procedure in `AGENT_WORKSPACE.md`.
+   Mtimes and Git authors do not prove ownership. Re-verify commits and preserve others' work.
 7. **Rebuild C# before booting** if `OpenRA.Mods.Cameo/` or `engine/` changed. Stale DLLs crash
    the boot with `Cannot locate type: …Info`. See §5 for the engine pipeline.
 8. **Audit reports regenerate via `bash tools/audit/run_all.sh` only** — a PowerShell `>`
@@ -731,7 +733,10 @@ Rules 1–2 are enforced by hooks in `.claude/settings.json`.
     model misreport itself as an older one. A non-Claude agent signs as itself
     (`Co-Authored-By: Devin AI <devin@cognition.ai>`) and never appends the Claude trailer.
 
-### The gate before every commit
+### Historical gate snapshot (2026-08-23)
+
+Use `AGENT_WORKSPACE.md` for current scoped validation. The following commands and counts record
+the old gate; they are not a requirement to run every check for every change.
 
 ```sh
 python -m unittest discover -s tools/tests -t tools/tests   # all green (227 as of 2026-08-23)
@@ -742,13 +747,9 @@ bash tools/audit/run_all.sh                                 # bash ONLY
 python tools/balance/extract_stats.py --check               # 0 drifted
 ```
 
-…then the boot gate (rule 1). If Windows Smart App Control blocks the launch, use one of the
-four documented options in `LESSONS_LEARNED.md` § Smart App Control and **record the SAC state
-in the commit message**. Never silently skip the gate, and never claim it passed when it did not.
-
-`utility.cmd cameo --check-yaml` is a **separate lint tool**, not a boot-gate substitute. It
-takes 10+ minutes; run it once you have finished a batch and expect 0 errors and 0 warnings —
-not repeatedly.
+The old gate also required a launch and a separate YAML lint pass. Current validation is defined
+in `AGENT_WORKSPACE.md`: do not run `--check-yaml`, do not change OS security settings, and report
+any pending runtime check instead of claiming it passed.
 
 ---
 
@@ -758,28 +759,23 @@ Crashes and player-visible regressions jump everything below.
 
 ### 3.A — MULTI-AGENT COORDINATION (read this FIRST if you are an AI agent)
 
-**As of 2026-08-25, there are 5 Devin AI agents running locally.** Each agent MUST:
-1. Pick a unique name from the list below (or claim a new one in `DEVELOPMENT_LOG.md`).
-2. Read `DEVELOPMENT_LOG.md` §"Active claims" BEFORE editing any file.
-3. Claim a file-set by adding an entry to `DEVELOPMENT_LOG.md` §"Active claims" BEFORE editing.
-4. NEVER edit a file that another agent has claimed or that is in the locked list.
-5. After every step: update `DEVELOPMENT_LOG.md` with what you did, why, and what's next.
-6. Before committing: run verification (find_empty_warhead, audit_warhead_split,
-   review_resolve_diff, audit_doc_claims) and boot-gate (`launch-game.cmd`).
-7. Use scoped `git add <files>` only — never `git add -A` or `git add .`.
+Read `AGENT_WORKSPACE.md` for the current coordination proposal and activation status. The following
+roster and dated standing orders are historical evidence, not fresh claim or merge authorization.
+Do not pick an identity from them or overwrite their owners' work without confirmation.
 
-#### Agent roster and current assignments
+The 2026-08-25 workflow recorded five local Devin agents and used chosen names plus
+`DEVELOPMENT_LOG.md` entries for claims. It required frequent log updates and broad checks.
+That mechanism is retained here as history. New tasks use the current human assignment and,
+after pilot activation, the Project record and recovery procedure in `AGENT_WORKSPACE.md`.
 
-> ⭐ **THIS IS THE ONLY AUTHORITATIVE ROSTER.** Three other ownership tables exist
-> lower in this file (D2k faction completion, §3.C, §3.6); all three are marked
-> SUPERSEDED and contradict this one. Claim file-sets from HERE and nowhere else.
+#### Historical roster and assignments
 
-> **⚠ FLEET HIERARCHY (maintainer order 2026-09-05):** *"Claude AI is now your big
-> boss and controls all other AI Agents so you must always listen to him and do
-> EXACTLY as he says!"* — **Claude (Opus 5, local) is the fleet coordinator.** All
-> agents take direction from Claude. Aurora remains D2k coordinator **under Claude's
-> authority.** Claude has not yet issued consolidated fleet-wide orders in his
-> coordinator capacity; until he does, agents continue their established roles below.
+> This roster formerly superseded three conflicting tables lower in this file. It is now a
+> dated reservation record: contact the human owner before release or reassignment.
+
+> Historical hierarchy, 2026-09-05: Claude-Local coordinated that fleet, with Aurora handling
+> D2k. This records the former arrangement; it does not appoint a current coordinator or grant
+> any new write or merge authority.
 
 | Agent name | Status | Current task | Files claimed |
 |---|---|---|---|
@@ -796,10 +792,11 @@ Crashes and player-visible regressions jump everything below.
 
 ---
 
-## ⭐ STANDING ORDERS — issued by Claude-Local, 2026-09-05 (maintainer put me in coordination)
+## ⭐ Historical standing orders — Claude-Local, 2026-09-05
 
-The maintainer has asked me to coordinate this team and to review work as it completes.
-These orders supersede any conflicting instruction in a SUPERSEDED table lower in this file.
+The following dated orders record a previous fleet recovery. Their first-person instructions
+are historical quotations, not current task grants. Preserve unresolved reservations and check
+them with the human owner under `AGENT_WORKSPACE.md` before acting.
 
 ### How we work (read once, then follow it)
 
@@ -823,7 +820,7 @@ These orders supersede any conflicting instruction in a SUPERSEDED table lower i
    back short. For any presence/absence check use `git show <rev>:<file> | grep -a`.
    This nearly cost 30 live weapon nodes during the master merge.
 
-### Ownership, de-conflicted (this replaces the overlapping claims)
+### Historical ownership reconciliation
 
 Three stale tables in this file assigned D2k/Harkonnen to **two** agents and named **two**
 different coordinators. Resolved against §3.A and against who has actually been committing:
@@ -959,10 +956,9 @@ Prerequisites: ~d2k_barracks` etc.
 #### Agent assignments for D2k faction completion
 
 
-> ⛔ **SUPERSEDED — this ownership table is STALE. The single authoritative roster is
-> §3.A "Agent roster and current assignments".** It is kept only as provenance; it
-> contradicts §3.A on who owns D2k/Harkonnen and on who the coordinator is. Do NOT
-> claim a file-set from this table.
+> **Historical ownership table.** Retained as provenance only. For current assignments,
+> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> until their human owners confirm release or reassignment.
 
 | agent | faction | file-set | scope of work |
 |---|---|---|---|
@@ -1093,20 +1089,11 @@ Prerequisites: ~d2k_barracks` etc.
 5. **Do not flip `Selectable: true` prematurely.** A faction is only selectable when it has a full minimum viable tech tree: con yard, wind trap, refinery, harvester, barracks, light vehicle factory, MCV, one anti-ground unit, and `StartingUnits`.
 6. **Boot-gate and scoped commits.** `launch-game.cmd` before every commit; `git add <files>` only; never `-A`.
 
-#### How to coordinate after every step
+#### How to coordinate current work
 
-1. **Before editing**: check `DEVELOPMENT_LOG.md` §"Active claims" for file ownership.
-2. **After editing**: add an entry to `DEVELOPMENT_LOG.md` with:
-   - Your agent name
-   - What file(s) you edited
-   - What weapons you converted
-   - Why you made each decision (which rule, which pattern, which precedent)
-   - Verification results (find_empty_warhead, audit_warhead_split, review_resolve_diff)
-   - What's next
-3. **Before committing**: verify no other agent has uncommitted work in your file set
-   (`git status --short` + `git diff --name-only`).
-4. **After committing**: update your claim in `DEVELOPMENT_LOG.md` to say "COMMITTED"
-   with the commit hash.
+Follow `AGENT_WORKSPACE.md`. Record scope, evidence and commit/PR receipts in the approved task
+record. The former per-step DEVELOPMENT_LOG updates are historical; do not create a second live
+claim or status table.
 
 #### Devin-Prime handoff message (2026-08-25)
 
@@ -1148,10 +1135,9 @@ When a weapon has `Bullet_Light` + `Bullet_Medium` as two damage mains:
 **Coordinating agent:** Devin-Echo. See full plan and per-agent instructions in `DEVELOPMENT_LOG.md` §"D2k faction rollout plan — Atreides / Harkonnen / Corrino".
 
 
-> ⛔ **SUPERSEDED — this ownership table is STALE. The single authoritative roster is
-> §3.A "Agent roster and current assignments".** It is kept only as provenance; it
-> contradicts §3.A on who owns D2k/Harkonnen and on who the coordinator is. Do NOT
-> claim a file-set from this table.
+> **Historical ownership table.** Retained as provenance only. For current assignments,
+> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> until their human owners confirm release or reassignment.
 
 | Agent | Pack | Key deliverable | Verification before commit |
 |---|---|---|---|
@@ -1552,10 +1538,9 @@ another agent claimed it in the last 30 minutes, do not touch it.
 **Agent registry** (maintained in `DEVELOPMENT_LOG.md` → "Agent registry", mirrored here):
 
 
-> ⛔ **SUPERSEDED — this ownership table is STALE. The single authoritative roster is
-> §3.A "Agent roster and current assignments".** It is kept only as provenance; it
-> contradicts §3.A on who owns D2k/Harkonnen and on who the coordinator is. Do NOT
-> claim a file-set from this table.
+> **Historical ownership table.** Retained as provenance only. For current assignments,
+> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> until their human owners confirm release or reassignment.
 
 | name | identity | current file-set | current task |
 |---|---|---|---|
@@ -1574,8 +1559,8 @@ another agent claimed it in the last 30 minutes, do not touch it.
    your own batch commit, and re-read them before editing (they change every few minutes).
 4. After every commit, post a summary to `DEVELOPMENT_LOG.md` with your agent name,
    what you changed, and why.
-5. Before starting a new batch, re-read `DEVELOPMENT_LOG.md` → "Active claims" and
-   verify no other agent claimed your target files.
+5. Before starting a new batch, verify ownership using the active task record and the human
+   integrator; historical `DEVELOPMENT_LOG.md` entries are context only.
 6. **Never `git add -A` or `git add .`** — scoped adds only. Another agent's WIP is
    always in the tree.
 7. Boot-gate before every weapon commit. If another agent's uncommitted WIP is in the
@@ -1624,7 +1609,7 @@ index — read the entry before working in that area.
 | A missing `Versus` row | is not "no opinion" — an empty match returns 100, so a plated unit LOSES its armor. Every plating gets a row in EVERY template. |
 | An armor upgrade must never increase incoming damage | DESIGN §12.0e law 4. Guard: `audit_armor_upgrade_harm.py`. |
 | Bulk renames | never do a bare-identifier substitution: the same literal is a weapon, an actor, a condition and a sprite in this tree. Match the exact YAML field with a full-token comparison. |
-| Loose `*_extracted/` map folders | `.oramap` is a zip; the packaged file is what ships and silently shadows loose edits. Repack in the same session, then validate with `--check-yaml`. |
+| Loose `*_extracted/` map folders | `.oramap` is a zip; the packaged file is what ships and silently shadows loose edits. Repack, then validate the affected map using the current AGENT_WORKSPACE procedure. |
 | UTF-16 audit reports | a PowerShell `>` redirect corrupts them. `run_all.sh` only. |
 
 ---

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -957,7 +957,7 @@ Prerequisites: ~d2k_barracks` etc.
 
 
 > **Historical ownership table.** Retained as provenance only. For current assignments,
-> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> use `AGENT_WORKSPACE.md` and the approved task record. Preserve existing reservations
 > until their human owners confirm release or reassignment.
 
 | agent | faction | file-set | scope of work |
@@ -1136,7 +1136,7 @@ When a weapon has `Bullet_Light` + `Bullet_Medium` as two damage mains:
 
 
 > **Historical ownership table.** Retained as provenance only. For current assignments,
-> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> use `AGENT_WORKSPACE.md` and the approved task record. Preserve existing reservations
 > until their human owners confirm release or reassignment.
 
 | Agent | Pack | Key deliverable | Verification before commit |
@@ -1539,7 +1539,7 @@ another agent claimed it in the last 30 minutes, do not touch it.
 
 
 > **Historical ownership table.** Retained as provenance only. For current assignments,
-> use `AGENT_WORKSPACE.md` and the human-approved task record. Preserve existing reservations
+> use `AGENT_WORKSPACE.md` and the approved task record. Preserve existing reservations
 > until their human owners confirm release or reassignment.
 
 | name | identity | current file-set | current task |
@@ -1560,7 +1560,7 @@ another agent claimed it in the last 30 minutes, do not touch it.
 4. After every commit, post a summary to `DEVELOPMENT_LOG.md` with your agent name,
    what you changed, and why.
 5. Before starting a new batch, verify ownership using the active task record and the human
-   integrator; historical `DEVELOPMENT_LOG.md` entries are context only.
+   current approver; historical `DEVELOPMENT_LOG.md` entries are context only.
 6. **Never `git add -A` or `git add .`** — scoped adds only. Another agent's WIP is
    always in the tree.
 7. Boot-gate before every weapon commit. If another agent's uncommitted WIP is in the

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -1,5 +1,10 @@
 # Lessons Learned — read before every task
 
+> Current human task instructions and the shared workflow in `AGENTS.md` / `AGENT_WORKSPACE.md`
+> govern execution. Older operational examples below are historical evidence: they do not grant
+> automatic pull/merge, publication, pin changes, OS security changes, `--check-yaml`, or a game
+> launch for documentation-only work. Follow the shared procedure and its activation boundary.
+
 **Read this file, `AGENT_WORKSPACE.md`, `HANDOFF.md` and the relevant sections of `DESIGN.md`
 before touching any code, YAML, asset or balance value.**
 
@@ -15,7 +20,7 @@ add it to the Contents below: `audit_doc_health` D7 fails if the index misses on
 **`docs/README.md` is the canonical definition of the reading order.** The list below is a
 convenience copy; if they disagree, README wins and this copy gets fixed.
 
-1. `CLAUDE.md` (repo root) — the hard rules, loaded every session.
+1. `AGENTS.md` (repo root) — shared entry point; `CLAUDE.md` adds provider technical context.
 2. `docs/LESSONS_LEARNED.md` (this file) — safe defaults and pitfalls.
 3. `docs/AGENT_WORKSPACE.md` — source-of-truth map, operating sequence, incident protocol, commit gate.
 4. `docs/HANDOFF.md` — verified current state and the priority-ordered queue.
@@ -30,6 +35,8 @@ win — **unless the artifact says otherwise, and then the artifact wins and you
 ---
 
 ## Contents
+
+- [The canonical engine update pipeline (binding, uniform process)](#the-canonical-engine-update-pipeline-binding-uniform-process)
 
 **Crash classes — these end a boot, and most gates cannot see them**
 
@@ -721,17 +728,17 @@ tree with an external reference. Run it after every collapse.
 
 ## Git workflow and commit rules (2026-07-24)
 
-### Binding rules from user and co-maintainer Blackrobe
+### Current operating rule
 
-- **Always fetch, pull, and merge before any commit.** The remote may have changes from other developers. If the engine pin (`mod.config` `ENGINE_VERSION`) changed, always run `make all` to fetch and build the new engine before boot-gating. Never skip the boot-gate.
-- **Always boot-gate before committing.** Launch the game with `launch-game.cmd`, wait for the main menu (perf.log ends with `MenuPostProcessEffect.PostWorldLoaded`), kill the process, then check for NEW `exception-*.log` files in `%APPDATA%/OpenRA/Logs`. A commit that breaks the boot is not acceptable.
-- **`utility.cmd cameo --check-yaml` is a linting/YAML validation tool, NOT a boot-gate substitute.** Use it for: verifying cosmetic refactors (actor/template renames), checking broken prerequisites, and detecting gameplay-relevant YAML issues. **Goal: 0 errors AND 0 warnings.** The utility takes a VERY LONG TIME (10+ minutes) — only run it when you have completed ALL connected tasks from the last report and expect 0 errors/warnings to confirm. Do NOT run it repeatedly. Keep findings from the last report in ROADMAP and docs so they can be fixed without re-running. It is ABSOLUTELY NECESSARY — just choose wisely WHEN to run it.
-- **Always update ALL relevant documentation files BEFORE committing.** This includes `docs/design/ROADMAP.md`, `docs/DESIGN.md`, `docs/audit/SUMMARY.md`, `docs/LESSONS_LEARNED.md`, and any other docs affected by the change. Check old docs for outdated information, inconsistencies, and contradictions — fix them. A commit without updated docs is an incomplete commit.
-- **Do not spam commits on upstream master.** Use a pull request (PR) for cleaner commit history. Create a feature branch, push it, open a PR, and merge only after verification.
-- **Only merge a PR if either:** (a) you no longer detect regression caused by the changes, or (b) launching the game no longer results in a crash. Commits that do not break the master branch are a naturally acceptable outcome.
-- **Commit titles must be self-explanatory to all developers.** Terms like "Phase 5", "A2 audit", "Fix B5", or "X/Y law" are only understood internally by Aedis and their agent. If such internal pointers are necessary, elaborate where to find the definition (e.g. "see docs/audit/SUMMARY.md bug class B5") and what kind of project it links to.
-- **When a task is completely done, merge the feature branch to master.** Do not leave completed work stranded on a feature branch. Ensure boot-gate passes and docs are updated before merging.
-- See also: `docs/AGENT_WORKSPACE.md` § Git workflow and commit rules.
+Use `AGENTS.md` and `docs/AGENT_WORKSPACE.md` for claims, isolation, validation and publication.
+The 2026-07-24 recipe has been superseded: it no longer grants automatic pull/merge, engine-pin
+changes, or a game launch before every commit. Documentation-only work uses syntax/link checks.
+Do not run `--check-yaml`. Runtime changes require appropriate build/boot/behavior evidence,
+with pending checks disclosed. Humans decide publication and merge authority.
+
+Preserve the lessons that remain useful: stage named paths, use clear commit titles, update the
+affected canonical documentation, and keep unrelated work intact. A successful boot alone does
+not establish that a PR is correct. A finished implementation awaiting human review stays open.
 
 ## YAML lint rules learned (2026-07-24)
 
@@ -771,7 +778,7 @@ SpeedMultiplier@myupgrade:
 ### YAML lint cleanup header-removal bug (2026-07-24)
 
 - **The NegativeRemoval lint fix (commit d42ad53a1) accidentally removed weapon/warhead HEADERS, not just values.** When stripping values from `-Trait: value` lines, the lint script also deleted adjacent header lines (e.g., `RA2DiskSteal:`, `Warhead@Cloud: SpawnSmokeParticle`, `Warhead@LaserWeapon: SpreadDamage`). The bodies remained as orphaned child nodes, causing YAML parse errors and `MissingFieldsException` crashes.
-- **Always verify after lint cleanup**: After any bulk NegativeRemoval fix, run `utility.cmd cameo --check-yaml` and boot-gate test. The lint tool catches field errors but the game boot catches orphaned nodes.
+- **Verify after lint cleanup**: resolve the affected rules and check for orphaned headers and unknown fields with the existing targeted audits. Follow `AGENT_WORKSPACE.md` for authorized runtime checks; do not run `--check-yaml`.
 - **ContentPack migration must be complete**: When migrating weapons from `mods/cameo/weapons/*.yaml` to ContentPacks, ALL weapon definitions must be copied, not just templates. The RA2 ContentPack only had `^RA2*` templates but was missing 134 concrete weapon definitions, causing `Parent type not found` errors for weapons like `RA2CarrierTarget` that other weapons inherit from.
 - **UTF-8 encoding in YAML weapon names**: Weapon names with non-ASCII characters (e.g., `ü` in `Kübelwagen`) can become double-encoded (mojibake `Ã¼`) during file operations. Always verify encoding when files contain non-ASCII characters. The engine's YAML parser uses the file's byte-level encoding, so `NaxiWW2KÃ¼belwagenMachinegun` does not match `NaxiWW2KübelwagenMachinegun`.
 - **Engine shader files not tracked by mod git**: Custom shader files in `engine/glsl/` (e.g., `postprocess_nuclearflash.frag`) are inside the .gitignored engine directory. They must be recreated after `make all` fetches the engine. Document any custom shader requirements in the mod repo for post-fetch setup.
@@ -812,22 +819,21 @@ mid-run and a live instance locks the next build.
 
 ## The canonical engine update pipeline (binding, uniform process)
 
-The engine lives in TWO places that must stay in sync. Follow these steps IN ORDER for every engine change:
+Engine changes cross two repositories. The current procedure is governed by
+`AGENTS.md` and `docs/AGENT_WORKSPACE.md`:
 
-1. **Edit** engine C# source only in the local dev clone of the engine repository (the `cameo-engine` clone of `https://github.com/cameo-mod/OpenRA`, branch `cameo-engine`).
-2. **Commit and push** to `origin/cameo-engine`. Check `git status` for stray entries before committing (see the nested-clone pitfall below).
-3. **Get the full commit hash** with `git rev-parse cameo-engine` — never hand-type or truncate/pad a hash.
-4. **Update `mod.config`** in the mod repository: set `ENGINE_VERSION="<full-40-char-hash>"`. The engine pin lives in `mod.config`, NOT `mod.yaml`.
-5. **Run `make all`** (Windows: `make.cmd all`). Because `engine/VERSION` no longer matches, the SDK deletes `engine/`, downloads the source zip for the pinned commit from GitHub, and rebuilds everything.
-6. **Verify**: `engine/VERSION` must contain the new hash; the build must have 0 errors.
-7. **Boot-gate with `launch-game.cmd`** before committing the `mod.config` change (see AGENT_WORKSPACE.md git rules).
-   ⚠ **The old "recreate any custom `engine/glsl/` shaders, they are wiped" step is STALE — verified 2026-08-22.**
-   All 16 shaders (including `postprocess_nuclearflash.frag`) are now TRACKED in the engine repo, so the source
-   zipball carries them and the fetch restores them untouched. Measured by md5-summing `engine/glsl/*` before and
-   after a full `make.cmd all` on pin `462fc1fc4b`: identical, all 16. Still worth a `md5sum` before/after rather
-   than trusting either version of this line — if a shader is ever added WITHOUT committing it to the engine repo,
-   the wipe becomes real again.
-8. **Commit `mod.config`** together with the change's docs updates.
+1. Establish an approved engine task and isolated OpenRA checkout; verify its base and ownership.
+2. Preserve source edits in the OpenRA repository and mirror them to the intended Cameo engine
+   copy for local validation. Do not edit or publish an unrelated checkout.
+3. Run `tools/preflight-build.ps1` in the configured Cameo checkout before `make all`; stop on
+   failure. Preserve local engine work before any deliberately authorized refresh.
+4. Publish the engine change through its own reviewed PR when authorized. A Cameo pin update is
+   a separate human decision and must reference the full SHA actually merged upstream.
+5. Validate the intended engine/mod combination and record the source SHA and tested build.
+   Launch the game only when authorized, disclose missing runtime evidence, and preserve holds.
+
+The historical shader and OS observations below are evidence from the dated machine, not
+instructions to change security settings or permission to fetch over local source changes.
 
 Key facts verified 2026-07-30:
 
@@ -893,8 +899,8 @@ Applies to any script that renames a weapon/actor/condition identifier across th
 `.oramap` files are zip archives; editing a map means extracting it to a loose folder, editing `map.yaml`/`rules.yaml`/`*.lua`/etc., then **repacking it back into the same `.oramap`**. Found `mods/cameo/maps/survival_extracted/` sitting untracked in the tree with real, dated design edits in `script.lua` (2026-07-29: `RandomEventUnitScale` halving chaos/random-event spawn counts, simplified `SpawnAIBase` to MCV-only) that were **never repacked** — `survival.oramap` in the tree was a stale pre-2026-07-29 build the whole time, meaning the actual shipped map silently lacked the intended difficulty tuning.
 
 - **Always repack and delete the extraction folder in the same session as the edit.** Never leave a loose `*_extracted/` (or similarly named) folder next to its `.oramap` — OpenRA does not merge them; whichever one the engine picks up (the `.oramap`, per the packaging docs in `Cameo_Knowledge_Base_Manual.md` §"Package the map as an `.oramap`") is the only one that's actually live in-game, silently shadowing any edits left in the loose folder.
-- **Use `tools/repack-oramap.ps1 -dir <extracted_dir> -oramap <target.oramap>`, then always validate with `./utility.cmd cameo --check-yaml <absolute path to .oramap>`** before trusting the repack. Compare the error/warning counts against a `check-yaml` run on the untouched original — identical counts confirm no regression; a new `"Not a valid map"` / `InvalidDataException` means the repack corrupted the zip structure.
-- **Bug fixed in `tools/repack-oramap.ps1`**: it computed each zip entry's relative path as `$f.FullName.Substring($dir.Length + 1)`, but `Get-ChildItem`'s `.FullName` is always an absolute path while `$dir` was whatever string the caller passed in. Calling the script with a **relative** `-dir` (e.g. `mods/cameo/maps/survival_extracted` instead of the full `C:\...\survival_extracted`) silently produced zip entries with a garbage prefix baked in (e.g. `/Cameo-mod/mods/cameo/maps/survival_extracted/script.lua` instead of `script.lua`), which OpenRA's `Map` loader rejects outright as `"Not a valid map"` with no indication of why. Fixed by resolving both `-dir` and `-oramap` to absolute paths via `Resolve-Path` before computing the substring. **Always pass either path style now — the script normalizes internally — but still validate with `check-yaml` after every repack**, since a silent zip-entry corruption has no compile-time signal.
+- **Validate the repacked archive**: use `tools/repack-oramap.ps1`, inspect its zip entries and required map files, compare against the untouched original, and test the affected map when authorized. Use the current `AGENT_WORKSPACE.md` validation procedure.
+- **Bug fixed in `tools/repack-oramap.ps1`**: it computed each zip entry's relative path as `$f.FullName.Substring($dir.Length + 1)`, but `Get-ChildItem`'s `.FullName` is always an absolute path while `$dir` was whatever string the caller passed in. Calling the script with a **relative** `-dir` (e.g. `mods/cameo/maps/survival_extracted` instead of the full `C:\...\survival_extracted`) silently produced zip entries with a garbage prefix baked in (e.g. `/Cameo-mod/mods/cameo/maps/survival_extracted/script.lua` instead of `script.lua`), which OpenRA's `Map` loader rejects outright as `"Not a valid map"` with no indication of why. Fixed by resolving both `-dir` and `-oramap` to absolute paths via `Resolve-Path` before computing the substring. The script now normalizes either path style. Inspect the archive structure after every repack because zip-entry corruption has no compile-time signal.
 
 ## OpenRA Lua `Map` API: there is no `Map.Contains` (2026-07-31)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,10 @@
 > below — the list tells you what to read, the index tells you *when*, and which of it applies
 > to the thing you are about to do. Guarded by `tools/audit/audit_task_index.py`.
 
-**Picking up work? Start at [`HANDOFF.md`](HANDOFF.md).** Everything else is reference.
+**Picking up work?** Read [`../AGENTS.md`](../AGENTS.md) and
+[`AGENT_WORKSPACE.md`](AGENT_WORKSPACE.md) for the shared pilot and activation status, then
+[`HANDOFF.md`](HANDOFF.md) for project context. Live task claims follow the shared workflow once
+the team activates it; dated rosters do not grant new ownership.
 
 This file is the **sole reading-order definition** and the map of which document owns which
 topic. If two documents disagree, the precedence below decides; fix the loser, never both.
@@ -24,7 +27,7 @@ Everything else under `docs/` is either **generated** (regenerate it, never hand
 
 | # | document | what it is |
 |---|---|---|
-| 1 | [`../CLAUDE.md`](../CLAUDE.md) | the hard rules, loaded every session. Top authority. |
+| 1 | [`../AGENTS.md`](../AGENTS.md) | shared workflow entry point; human task instructions remain controlling. [`../CLAUDE.md`](../CLAUDE.md) adds provider-specific technical context. |
 | 2 | [`LESSONS_LEARNED.md`](LESSONS_LEARNED.md) | every trap someone already paid for |
 | 3 | [`AGENT_WORKSPACE.md`](AGENT_WORKSPACE.md) | workflow, evidence rules, commit gate |
 | 4 | [`HANDOFF.md`](HANDOFF.md) | **the entry point** — verified state + the priority queue |

--- a/docs/TASK_INDEX.md
+++ b/docs/TASK_INDEX.md
@@ -30,8 +30,8 @@ anchor validity is enforced separately by `audit_doc_health` (D3/D4).
 1. Find the row for what you are about to do.
 2. Open the **READ FIRST** document *at the named section*. Not the whole file — the section.
 3. Run the **ALREADY BUILT** tools with `--help` before you write anything new.
-4. If you still think something is missing, say so in `DEVELOPMENT_LOG.md` **before** building
-   it. Every duplicate so far would have been caught by that one sentence.
+4. If you still think something is missing, record the existing-work check in the authorized task
+   record before building it. `AGENT_WORKSPACE.md` defines intake; `DEVELOPMENT_LOG.md` is history.
 
 ---
 
@@ -42,6 +42,8 @@ anchor validity is enforced separately by `audit_doc_health` (D3/D4).
 | **Anything at all, first session** | [`README.md`](README.md) → [`LESSONS_LEARNED.md`](LESSONS_LEARNED.md) → [`AGENT_WORKSPACE.md`](AGENT_WORKSPACE.md) → [`HANDOFF.md`](HANDOFF.md) → [`DESIGN.md`](DESIGN.md) | — |
 | **Picking up work** | [`HANDOFF.md`](HANDOFF.md) §3.A, then [`design/ROADMAP.md`](design/ROADMAP.md) | — |
 | **Four-faction September balance continuation** | [`balance/GRAND_PLAN_20260911.md`](balance/GRAND_PLAN_20260911.md) §1 current authorization and §4 bounded tasks; [`balance/PROJECT_STATUS_20260911.md`](balance/PROJECT_STATUS_20260911.md) current state/ownership | Astra reviewed the Sol batch; GP-03 completion was withdrawn, original frozen ledger inputs recovered, and dependent proposal holds corrected. Continue from the status table and `astra_review_20260911` receipts. |
+| **Picking up work / coordination** | [`AGENT_WORKSPACE.md`](AGENT_WORKSPACE.md) § Cross-provider coordination, then [`HANDOFF.md`](HANDOFF.md) §3.A and [`design/ROADMAP.md`](design/ROADMAP.md) for technical context | Check the current task, reservations and linked PR before writing |
+| **Agent coordination / task claims / handoff** | [`../AGENTS.md`](../AGENTS.md) → [`AGENT_WORKSPACE.md`](AGENT_WORKSPACE.md) § Cross-provider coordination | GitHub Project item or linked issue → isolated worktree/branch → draft PR |
 | **Weapon structure (W24 / W23 / A5)** | [`design/BALANCE_PROGRAM_PLAN.md`](design/BALANCE_PROGRAM_PLAN.md) §0a **order of operations** and §1b **W24 diagnosis**; [`design/WEAPON_3WAY_SPLIT.md`](design/WEAPON_3WAY_SPLIT.md) | ⛔ **`tools/audit/audit_weapon_shape.py` FIRST** — the ONE-WARHEAD / THREE-INHERIT law (maintainer 2026-09-06). The exemption registry was retired; [`DESIGN.md`](DESIGN.md) §11b.2 preserves historical intent and taxonomy, not exemptions. Follow current §11b.1 and review ambiguous conversions; the old registry `--snapshot` command no longer exists · `tools/audit/audit_split_definitions.py` (is the weapon defined in TWO live files?) · `tools/audit/audit_warhead_split.py` · `tools/audit/audit_three_way_split.py` · `tools/audit/audit_unconverted_templates.py` · `tools/audit/review_resolve_diff.py` · `tools/audit/find_empty_warhead.py` · ⛔ **`tools/audit/audit_release_drift.py`** — the only gate that measures against a SHIPPED build instead of against the tree itself; run it after EVERY collapse |
 | **Warhead templates / families** | [`design/WEAPON_TYPE_SYSTEM.md`](design/WEAPON_TYPE_SYSTEM.md); [`DESIGN.md`](DESIGN.md) §12.0h MEAN-100, §12.0d class tilt, **the missile ROLE law** (ground->`MissileHE`, air->`MissileAA`, both->`MissileAP`; `MissileHE` never vs Air) | `tools/balance/gen_weapon_template.py` · `tools/balance/splice_templates.py` · `tools/balance/verify_generator_sync.py` · `tools/audit/audit_missile_role_family.py` |
 | **Spread / Falloff** | [`design/SPREAD_FALLOFF_PLAN.md`](design/SPREAD_FALLOFF_PLAN.md) | `tools/balance/gen_weapon_template.py` (`PHYSICS_SHAPES`) |
@@ -89,9 +91,10 @@ Put a new fact in exactly one of these. A fact in two places is a future contrad
 | binding law (naming, formulas, tiers, armor) | `DESIGN.md` |
 | a trap that cost someone time | `LESSONS_LEARNED.md` |
 | a number a decision rests on | `docs/audit/doc_claims.yaml` |
-| current state + priority queue | `HANDOFF.md` |
-| the granular task list | `design/ROADMAP.md` |
+| project state + priority rationale | `HANDOFF.md` |
+| live ownership/status after pilot activation | GitHub Project and linked task, per `AGENT_WORKSPACE.md` |
+| the program backlog and historical technical task list | `design/ROADMAP.md` |
 | a reference-pipeline ruling (R1–R15) | `design/REFERENCE_EXTRACTION_PLAN.md` |
 | the weapon/pricing board (W1–W26) | `design/BALANCE_PROGRAM_PLAN.md` |
-| what an agent did, and agent-to-agent messages | `DEVELOPMENT_LOG.md` |
+| historical implementation evidence | `DEVELOPMENT_LOG.md`; new task receipts go in the linked PR/task |
 | provenance only, never authority | `docs/history/**` |

--- a/tools/hooks/session_checklist.py
+++ b/tools/hooks/session_checklist.py
@@ -1,105 +1,23 @@
 #!/usr/bin/env python3
-"""SessionStart hook — inject the Cameo must-read + hard-rules checklist into
-context every session, so 'read the docs first' and the hard rules don't depend
-on the model choosing to read CLAUDE.md. Short and punchy on purpose."""
+"""SessionStart hook: point every Claude session to the shared Cameo workflow."""
 import json
 
 CHECKLIST = """\
-CAMEO — orient before acting this session (verify against the artifacts, don't trust summaries):
+CAMEO: read AGENTS.md, then docs/AGENT_WORKSPACE.md for coordination and activation status.
+Use docs/TASK_INDEX.md to find the task's exact technical reading route and existing tools.
+docs/README.md maps documentation; docs/HANDOFF.md provides project context, not a fresh claim.
 
-MUST-READ, in order: CLAUDE.md · docs/LESSONS_LEARNED.md · docs/AGENT_WORKSPACE.md ·
-docs/HANDOFF.md · **docs/DESIGN.md** · docs/design/ROADMAP.md · docs/audit/SUMMARY.md.
-docs/README.md defines that order and wins over any copy of it.
+Human task instructions remain controlling. The pilot is preparatory until the team activates
+it explicitly. Preserve existing reservations until their human owners reconcile them.
+Use the documented manual claim and recovery process. No Project field supplies an atomic lock.
+Every independent writer needs an isolated checkout. Inspect actual branch/diff state on restart.
 
-docs/HANDOFF.md is THE entry point: verified state + the priority-ordered queue. It supersedes
-every dated handoff — those are in docs/history/handoffs/ and must NOT be resumed from.
-For weapon work also: docs/design/WEAPON_3WAY_SPLIT.md · docs/design/WEAPON_TYPE_SYSTEM.md ·
-docs/design/BALANCE_PROGRAM_PLAN.md (the board + §0a's binding order of operations).
-
-⛔ BEFORE DESIGNING ANYTHING, GREP docs/DESIGN.md FOR THE CONCEPT. It is the BINDING contract
-and it is long, so nobody reads it end to end — grep it. On 2026-08-22 a whole session was spent
-re-deriving a weapon-tier model that §12.0h/§12.0c/§12.0d had already ruled AND shipped. A design
-question that feels novel usually is not. The rulings most often re-invented:
-
-  §12.0h MEAN-100      every ^Warhead_* MAIN warhead has its 16 armor rows normalised to
-                       arithmetic MEAN 100. Therefore K is SHAPE-ONLY, `Damage` is the SOLE
-                       magnitude knob, and a tilt is FREE. Weapon tier does NOT price via Versus.
-  §12.0c SHIELD LADDER Shield is its own compressed [100,400] ladder, Tesla top. NOT a normal armor.
-  §12.0d CLASS TILT    each LEVEL tilts toward one end of every armor ladder (Light->lightest rung,
-                       Medium->middle, Heavy->heaviest, Super->FLAT generalist). The tilt is applied
-                       to the VALUES and each armor is then given back the RANK it held, so it
-                       "can never invert" — WITHIN a ladder. LADDERS are INF/VEH/BLD/AIR, so
-                       `None` (INF) vs `Superheavy` (VEH) is a CROSS-ladder relation the tilt is
-                       DESIGNED to change. Comparing them proves nothing.
-  §12.0b HEROIC        a DERIVED cell: Heroic = Plate x Scout / PEAK. Never tilt it; recompute it.
-
-⛔ NEVER HAND-PARSE YAML. Read through `miniyaml.Ruleset.resolve_weapon` / `.resolve`, and pull
-Versus with `weapon_efficiency.versus_of(node)`. A bespoke line-scanner opened a dict on `Versus:`
-and never CLOSED it, so the `PercentageVersus:` rows sitting in the SAME warhead node overwrote the
-profile: every mean, spread, ratio and inversion count came out internally consistent and WRONG
-("0 of 125 obey MEAN-100"; the truth was 123 of 125). The near-miss sibling name is the trap — the
-OPEN guard was right, the CLOSE was missing. Guarded by tools/audit/audit_versus_profile.py.
-[hook-enforced: bash_guard blocks inline Versus scanning]
-
-⚠ A RESULT THAT CONTRADICTS A BINDING LAW IS A CONTRADICTION, NOT A FINDING. If the generator
-implements a law and verify_generator_sync reports 0 drift, "nothing conforms" means YOUR MEASURE
-is broken. Check the measurement before writing it up.
-
-HARD RULES (several are enforced by hooks — see .claude/settings.json):
- 1. Never commit without booting to the main menu (perf.log ends
-    MenuPostProcessEffect.PostWorldLoaded; no new %APPDATA%/OpenRA/Logs/exception-*.log). [hook-enforced]
- 2. Scoped `git add <files>` only — never -A/./--all (several contributors have live WIP). [hook-enforced]
- 3. Don't trust, verify — grep the data / ls the file (incl. ~/Downloads) / run the tool /
-    boot-gate before asserting done/pending/blocked/missing. When a summary and the artifact
-    disagree, the artifact wins — then fix the stale summary.
- 4. Never hand-edit balance numbers — use the pipeline (extract_stats -> ledger ->
-    apply_balance --confirm; --confirm needs maintainer order).
- 5. Versus lives ONLY in ^Warhead_* templates; never change a warhead / Burst / BurstDelays
-    without explicit permission.
- 6. Weapon 3-way split: preserve resolved behaviour (Damage verbatim, projectile fields),
-    find_empty_warhead.py = 0, boot-gate per batch. Verify with tools/audit/review_resolve_diff.py.
- 7. Multi-agent tree: one owner per file-set (boundaries in BALANCE_PROGRAM_PLAN.md §2);
-    re-verify others' commits before building on them (check mtimes + git log -3 <file> first).
- 8. Audit reports regen via `bash tools/audit/run_all.sh` ONLY (PowerShell > writes UTF-16),
-    and ONLY from a COMPLETE tree (engine/ built, clone not shallow) - otherwise a dozen
-    audits scan a smaller corpus, report FEWER findings and still say PASS. run_all diverts
-    to the untracked docs/audit/degraded/ in that case; --force-latest overrides.
- 9. Underscore-only naming — no hyphens in ids/files/fluent keys.
-10. Commit trailer = the ACTUAL author, with your REAL model name:
-    Co-Authored-By: Claude <your-model> <noreply@anthropic.com>  (a template, not a
-    literal - do not copy a version from a previous commit). Other agents sign as
-    themselves, e.g. Co-Authored-By: Devin AI <devin@cognition.ai>.
-
-ENGINE CHANGES — `engine/` IS NOT PART OF THIS REPO. It is .gitignored, has no .git and no
-.gitmodules, and `git ls-files engine` returns ZERO files; `git` run from inside it silently
-operates on the PARENT repo. Editing engine/**  produces work that CANNOT be committed here
-and is DELETED by the next `make all`. It is a build output, not source.
-Full procedure: docs/LESSONS_LEARNED.md "The canonical engine update pipeline". In short:
- 1. Edit C# in the SEPARATE clone of https://github.com/cameo-mod/OpenRA, branch cameo-engine.
- 2. Commit + push to origin/cameo-engine (check `git status` for stray nested-clone entries).
- 3. `git rev-parse cameo-engine` for the FULL 40-char hash — never hand-type or truncate it.
- 4. Set ENGINE_VERSION="<hash>" in **mod.config** (NOT mod.yaml) in this repo.
- 5. `make.cmd all` — VERSION mismatch makes the SDK delete engine/, refetch and rebuild.
- 6. Verify engine/VERSION == the hash, build has 0 errors, and recreate any engine/glsl/
-    shaders (the fetch WIPES them, e.g. postprocess_nuclearflash.frag).
- 7. Boot-gate, then commit mod.config with the docs updates.
-Before choosing that route, check whether the mod assembly can just SHADOW the engine trait:
-ObjectCreator.FindType takes the FIRST assembly in mod.yaml's Assemblies list holding the
-name, and the order is AS, CA, Cameo, Cnc, D2k, Common — so an OpenRA.Mods.Cameo type of the
-same name wins with ZERO yaml changes (precedent: ColorPickerColorShift, PlayerColorShift,
-SelectionDecorations). PROVE a shadow works by giving the Cameo Info a field the engine one
-lacks and booting with that field set — `--docs` lists BOTH types and proves nothing.
-
-CURRENT FRONT (2026-08-23): W24 (one damage warhead per weapon) -> W23 (retrofit the 47 legacy
-templates) -> A5 -> class anchors. Pricing is deliberately NOT running yet; apply_balance --confirm
-is a NO-OP until W11 sign-off writes targets into the ledger (signed-off anchors today: 0).
-Work queue: docs/design/ROADMAP.md · effort estimate: docs/design/BALANCE_PIPELINE_ESTIMATE.md.
-
-TWO THINGS YOU CANNOT RESOLVE FROM THE REPO:
- * commit hashes older than 2026-08-10 fail in a shallow checkout — `git fetch --unshallow`,
-   or verify the claim against the artifact instead (better).
- * `memory <name>` citations point at a private per-agent store. Provenance only, never
-   authority; promote anything binding into DESIGN.md.
+Use AGENT_WORKSPACE's scoped validation and engine procedure, including preflight before make all.
+Do not run --check-yaml or make test. Launch the game only when authorized.
+Use local validation and human review; disabled CI is not a pilot activation prerequisite.
+Never bypass OS security settings.
+Stage named files, preserve others' work, and distinguish static, build/boot and in-game evidence.
+Humans decide merges; agents may execute explicitly authorized steps and must preserve HOLDs.
 """
 
 print(json.dumps({"hookSpecificOutput": {

--- a/tools/hooks/session_checklist.py
+++ b/tools/hooks/session_checklist.py
@@ -17,7 +17,8 @@ Do not run --check-yaml or make test. Launch the game only when authorized.
 Use local validation and human review; disabled CI is not a pilot activation prerequisite.
 Never bypass OS security settings.
 Stage named files, preserve others' work, and distinguish static, build/boot and in-game evidence.
-Humans decide merges; agents may execute explicitly authorized steps and must preserve HOLDs.
+Aedis's designated coordinator agent approves claims and work reviews; Blackrobe is quota fallback.
+Record takeover and handback per AGENT_WORKSPACE; agents execute only authorized steps and preserve HOLDs.
 """
 
 print(json.dumps({"hookSpecificOutput": {


### PR DESCRIPTION
Cameo's agent entry points currently disagree about file claims, merge authority and engine updates. This proposal gives the three developers one shared coordination procedure, keeps each writer in an isolated checkout, and records recoverable task/session/branch evidence in the organization Project.

The canonical design is `docs/AGENT_WORKSPACE.md`. The new root `AGENTS.md`, Claude/GitHub/Windsurf entry points and startup hook route to it. An Issue Form and PR template capture scope, human ownership, validation and handoff. Dated rosters remain as historical evidence and do not silently release existing reservations.

Project: https://github.com/orgs/cameo-mod/projects/1 (private to the organization, linked to Cameo-mod and OpenRA).

## Review boundary

This is preparation for Aedis and Kmoney to review with their agents. Keep this PR in draft and unmerged until their feedback is recorded and the team agrees on the workflow and activation. Blackrobe has chosen Aedis's designated coordinator tool as primary approver for task claims, overlap resolution, work reviews and technical integration readiness; the session ID is provenance only. Blackrobe takes over when that coordinator exhausts quota, with explicit takeover/handback records so one approver is responsible at a time. Aedis still needs to identify the coordinator provider/tool. This delegation stays within human-authorized scope and preserves explicit holds and human-only decisions. Project statuses and expiry dates are conventions, not atomic locks or automatic leases.

Issues remain disabled in both repositories; draft Project items can support review. An administrator can enable Issues if the team chooses. OpenRA needs a separate reviewed adapter before engine tasks join the pilot. No Discord bot, shared-server agent service, automatic lock system, CODEOWNERS assignment or old-worktree migration is included.

## Validation and runtime impact

- No gameplay YAML, assets, C#, engine pin or generated balance data changed. The only executable change is a shorter Claude SessionStart context message with the same JSON output contract.
- `git diff --cached --check` passed.
- Issue Form YAML and GitHub agent frontmatter parsed; 16 form field IDs are unique.
- `audit_task_index.py` passed: all reading routes and referenced tools exist.
- `audit_doc_health.py` passed across 285 documents with zero structural findings. The pre-existing missing engine-pipeline Contents entry was repaired while updating that same section.
- The SessionStart hook emitted valid JSON with the expected hook event.
- Independent plan and final staged-diff review cleared draft publication.
- A write claim becomes externally verifiable only after its approved empty claim commit is pushed
  to the agreed remote; a local branch name alone does not establish ownership.
- Engine-content merges require applicable boot evidence; if launch authorization or the runtime
  environment is unavailable, the engine task stays on hold. The two-agent pilot may have mutual
  review rather than independent review; consequential tasks can request a third reviewer.

Continuous Integration is disabled in GitHub (`disabled_manually`, verified 2026-09-11). Deploy and Release Packaging remain active. No replacement CI or branch-protection change is included; CI is not an activation prerequisite. Neither `--check-yaml` nor `make test` was run. PR #343 changed the master branch filter only and did not enable the workflow.

Please review whether your agents can follow the pushed-claim, recovery and quota-handover process,
and what should change before activation. The primary approver and quota fallback are now chosen;
this does not grant blanket publication authority.
