### PR TITLE
Reference map: damage column is per tick, not DPS; apply the all-17 class ruling

### DIFF
--- a/tools/balance/build_reference_report.py
+++ b/tools/balance/build_reference_report.py
@@ -35,7 +35,10 @@ SECTIONS = (("infantry", "Infantry"), ("vehicle", "Vehicles"), ("aircraft", "Air
 CONF_ORDER = {"STRONG": 0, "FAIR": 1, "SHAPE": 2, "WEAK": 3}
 
 STYLE = """
-.cls{font-size:11px;color:var(--muted);white-space:nowrap}
+.cls{font-size:11px;color:var(--mut);white-space:nowrap}
+.srcn{display:block;font-size:9.5px;font-weight:400;letter-spacing:.02em;white-space:nowrap;margin-top:1px}
+.srcfull{color:var(--strong)}
+.srcthin{color:var(--fair)}
 :root{--bg:#f7f6f3;--fg:#1b1a17;--mut:#6f6a60;--line:#ddd8cd;--card:#fffefb;--accent:#8a5a2b;
 --strong:#1f6b4a;--fair:#7a6320;--shape:#4a5a78;--weak:#8a4a3c;--bad:#a3312a;--tgt:#2e5c8a;}
 @media (prefers-color-scheme:dark){:root:not([data-theme=light]){--bg:#161513;--fg:#eae6dd;
@@ -163,29 +166,47 @@ def emit(body, members, crows, assignment, attached, chassis_only, dist, cdist, 
                     if str(r.get("id")) not in {str((d or {}).get("id")) for d in chosen.values()}))
                 chips += (f'<span class="chip fam">+{extra} variant'
                           f'{"s" if extra != 1 else ""}: {html.escape(fam[:90])}</span>')
+            # ⭐ `target_for` ALREADY returns the source count as its third element and this
+            # report threw it away, so a value pooled from one source looked exactly like one
+            # pooled from three. Astra's revision surfaced it and the maintainer asked for it here
+            # (2026-09-11): a reader cannot judge an estimate without knowing how much evidence
+            # stands behind it. `n_src` is carried alongside every value from here on.
             def _t(stat):
                 if not rows:
                     return None
                 try:
-                    return rt.target_for(rows, c, stat, dist, cdist)[1]
+                    _peers, val, n_src = rt.target_for(rows, c, stat, dist, cdist)
+                    return None if val is None else (val, n_src)
                 except (KeyError, TypeError, ValueError, ZeroDivisionError):
                     # A stat the distribution does not carry is a BLANK CELL, never a crash and
                     # never a zero — a zero would read as "the reference says this unit deals no
                     # damage", which is a different and much worse claim than "not measured".
                     return None
-            tgt = {stat: _t(stat) for stat in ("hp", "speed", "cost", "w_range", "w_dps")}
+            tgt_raw = {stat: _t(stat) for stat in ("hp", "speed", "cost", "w_range", "w_dps")}
+            tgt = {k: (v[0] if v else None) for k, v in tgt_raw.items()}
+            n_assigned = len(srcs)
+
+            def srcnote(stat):
+                """`3/3 sources used` under an estimate — how much evidence it actually rests on."""
+                v = tgt_raw.get(stat)
+                if not v or not n_assigned:
+                    return ""
+                used = v[1]
+                cls = "srcfull" if used >= n_assigned else "srcthin"
+                return (f'<span class="srcn {cls}">{used}/{n_assigned} '
+                        f'source{"s" if n_assigned != 1 else ""} used</span>')
             note = ' <span class="tag">chassis-only</span>' if a in chassis_only else ""
             empty = '<span class="muted">—</span>'
             body.append(
                 f'<tr><td><code>{html.escape(a)}</code>{note}{flag}</td>'
                 f'<td class="cls">{html.escape(klass.get(a) or "—")}</td>'
                 f'<td class="n">{len(srcs)}</td>'
-                f'<td class="n">{num(c.get("hp"))}</td><td class="n t">{num(tgt["hp"])}</td>'
-                f'<td class="n">{num(c.get("speed"))}</td><td class="n t">{num(tgt["speed"])}</td>'
-                f'<td class="n">{num(c.get("w_range"))}</td><td class="n t">{num(tgt["w_range"])}</td>'
+                f'<td class="n">{num(c.get("hp"))}</td><td class="n t">{num(tgt["hp"])}{srcnote("hp")}</td>'
+                f'<td class="n">{num(c.get("speed"))}</td><td class="n t">{num(tgt["speed"])}{srcnote("speed")}</td>'
+                f'<td class="n">{num(c.get("w_range"))}</td><td class="n t">{num(tgt["w_range"])}{srcnote("w_range")}</td>'
                 f'<td class="n">{num(c.get("w_dps"))}{arm_note(a, led_arms)}</td>'
-                f'<td class="n t">{num(tgt["w_dps"])}</td>'
-                f'<td class="n">{num(c.get("cost"))}</td><td class="n t">{num(tgt["cost"])}</td>'
+                f'<td class="n t">{num(tgt["w_dps"])}{srcnote("w_dps")}</td>'
+                f'<td class="n">{num(c.get("cost"))}</td><td class="n t">{num(tgt["cost"])}{srcnote("cost")}</td>'
                 f'<td>{chips or empty}</td></tr>')
         body.append("</tbody></table>")
 

--- a/tools/balance/build_reference_report.py
+++ b/tools/balance/build_reference_report.py
@@ -114,11 +114,18 @@ def emit(body, members, crows, assignment, attached, chassis_only, dist, cdist, 
         # the virtual anchor will be derived from (EXTRAPOLATION_PROGRAM.md), so a row whose class
         # looks wrong is a finding BEFORE any anchor is signed — and range/DPS were the two stats
         # a reference actually moves that the table never showed.
+        # ⛔ THIS COLUMN IS DAMAGE PER TICK, NOT DPS. `reference_distribution.armament_profile`
+        # computes `per_cycle / cycle` where `cycle` is ReloadDelay + (Burst-1) x BurstDelay, in
+        # ENGINE TICKS. OpenRA runs 25 ticks/second, so real DPS is this number x 25 and the module
+        # 's own note (reference_distribution.py:276) only ever claimed it was "proportional to real
+        # DPS within a source". It shipped mislabelled as "DPS" until Astra caught it 2026-09-11;
+        # a reader sanity-checking `td_gdi_battletank` at 222 against game feel would conclude the
+        # unit was absurdly weak. Do not rename this back without changing the arithmetic.
         body.append('<table><thead><tr><th>Cameo actor</th><th>class &nbsp;today → after C46</th><th class="n">refs</th>'
                     '<th class="n">HP now</th><th class="n">HP →</th>'
                     '<th class="n">speed now</th><th class="n">speed →</th>'
                     '<th class="n">range now</th><th class="n">range →</th>'
-                    '<th class="n">DPS now</th><th class="n">DPS →</th>'
+                    '<th class="n">dmg/tick now</th><th class="n">dmg/tick →</th>'
                     '<th class="n">cost now</th><th class="n">cost →</th>'
                     '<th>reference units chosen</th></tr></thead><tbody>')
         for a in group:

--- a/tools/balance/pending_classes.py
+++ b/tools/balance/pending_classes.py
@@ -10,11 +10,11 @@ This script derives the PENDING membership mechanically from the resolved rulese
 can review the reclassification BEFORE it is committed:
 
     mobile_bunker          buildable + resolved AttackOpenTopped + GROUND VEHICLE
-    armed_troop_transport  buildable + Cargo + armed + ground vehicle + NOT open-topped,
-                           and ONLY where the actor's current class is `support` or None
-    ...?                   the same test where the actor ALREADY carries a combat class --
-                           emitted with a trailing '?' because overriding a real class is a
-                           maintainer decision, not a mechanical one
+    armed_troop_transport  buildable + Cargo + armed + ground vehicle + NOT open-topped.
+                           MAINTAINER RULING 2026-09-08 ("All 17 move"): this OVERRIDES an
+                           existing combat class -- the Flak Trucks leave anti_air_vehicle and
+                           the IFV variants leave scout_vehicle. All three classes carry the
+                           1.5x AA range, so no unit's RANGE changes; its pricing anchor does.
 
     python tools/balance/pending_classes.py            # writes /tmp/pending_classes.json
     python tools/balance/build_reference_report.py --faction ... --pending <that file>
@@ -52,10 +52,16 @@ for name,r in led.items():
     if ot:
         if now!='mobile_bunker': pending[name]='mobile_bunker'; stats['mobile_bunker']+=1
     elif 'Cargo' in base and r.get('armaments'):
-        if now in (None,'support'):
-            pending[name]='armed_troop_transport'; stats['armed_troop_transport']+=1
-        else:
-            pending[name]='armed_troop_transport?'; stats['CONTESTED']+=1
+        # MAINTAINER RULING 2026-09-08: "All 17 move." Cargo + a weapon means armed troop
+        # transport, with NO exception for an existing combat class. The two Flak Trucks leave
+        # anti_air_vehicle and the six IFV variants leave scout_vehicle. All three classes carry
+        # the 1.5x AA range anyway, so no unit's range changes as a result of this move -- what
+        # changes is which class anchor prices it.
+        if now != 'armed_troop_transport':
+            pending[name] = 'armed_troop_transport'
+            stats['armed_troop_transport'] += 1
+            if now not in (None, 'support'):
+                stats[f'  (overrode {now})'] += 1
 json.dump(pending, open('/tmp/pending_classes.json','w'), indent=1, sort_keys=True)
 print(dict(stats), ' total', len(pending))
 print("\nCONTESTED — already carry a combat class, would be overridden:")

--- a/tools/balance/reference_distribution.py
+++ b/tools/balance/reference_distribution.py
@@ -671,21 +671,79 @@ def burst_cycle(arm, anum):
     return rel + (burst - 1) * delay
 
 
+# Tokens that mean "somebody BOUGHT this" -- an upgrade, a promotion, or a veterancy rank.
+# Everything else in a condition is RUNTIME STATE the unit reaches on its own: charge level,
+# power, deployment, parachute, cloak. The distinction is the whole point of `is_upgrade_gated`
+# and conflating the two priced 44 actors at zero DPS.
+_BOUGHT = re.compile(r"(upgrade|promotion)", re.I)
+_RANK = re.compile(r"^rank[-_]", re.I)
+_CMP = re.compile(r"[A-Za-z_][\w.]*\s*(?:==|!=|>=|<=|>|<)\s*\d+")
+
+
+def _is_bought(tok):
+    return bool(_BOUGHT.search(tok) or _RANK.match(tok))
+
+
 def is_upgrade_gated(arm):
-    """True when this armament only fires once an UPGRADE or rank is granted.
+    """True when this armament can fire ONLY after something is bought.
 
-    The ledger records the armament's condition in `requires`, and it has three shapes:
-      None            always active
-      `!upgrade_x`    active only WITHOUT the upgrade -- this IS the baseline form
-      `upgrade_x`     active only WITH it -- an upgraded form, and not what we price
+    ⛔ THIS WAS WRONG TWICE AND IT COST 44 ACTORS THEIR ENTIRE DPS (measured 2026-09-11).
+    The old body was::
 
-    A compound is gated unless every clause is a negation.
+        parts = req.replace("&"," ").replace(",", " ").replace("|"," ").split()
+        return any(not p.startswith("!") for p in parts)
+
+    1. **It never stripped parentheses.** `(!TeslaCoilCharge && !unpowered)` tokenises to
+       `(!TeslaCoilCharge`, which does not start with `!`, so EVERY parenthesised condition read
+       as gated no matter what it said.
+    2. **It treated runtime STATE as a purchase.** `ra2_soviets_teslacoil`'s baseline armament
+       requires `((!TeslaCoilCharge && !unpowered) || (TeslaCoilCharge == 1 && unpowered))
+       && (!ra2_soviets_upgrade_teslaoverload && !rank-elite)` -- no upgrade, no rank, just charge
+       and power. All six of its armaments were classified as gated, `baseline_armaments` returned
+       nothing, and the coil priced at 0 DPS. So did 43 other actors.
+
+    The question this function actually has to answer is: **can this armament fire with nothing
+    bought?** So pin every bought token FALSE, leave runtime state free, and ask whether any
+    assignment satisfies the condition. The state space is tiny (<=6 distinct tokens in practice),
+    so enumerate it rather than reason about it.
+
+    ⚠ The seam is `_is_bought`, and it IS a name rule -- `upgrade`/`promotion`/`rank-`. That is far
+    narrower than the old "anything without a leading !", but it is still a naming convention, so a
+    bought token named outside it would read as free state. Prefer widening `_BOUGHT` over
+    reintroducing a structural guess.
     """
     req = str(arm.get("requires") or "").strip()
     if not req:
         return False
-    parts = [p for p in req.replace("&", " ").replace(",", " ").replace("|", " ").split() if p]
-    return any(not p.startswith("!") for p in parts)
+
+    # Comparisons on counters (`TeslaCoilCharge == 1`) are single boolean facts, not two tokens.
+    cmps = {}
+    def _hold(m):
+        key = f"__cmp{len(cmps)}__"
+        cmps[key] = m.group(0)
+        return key
+    expr = _CMP.sub(_hold, req)
+
+    expr = expr.replace("&&", " and ").replace("||", " or ").replace("!", " not ")
+    toks = sorted(set(re.findall(r"[A-Za-z_][\w.\-]*", expr)) - {"and", "or", "not"})
+    free = [x for x in toks if not _is_bought(x)]
+    if len(free) > 16:                      # pathological; fall back to "not gated" rather than lie
+        return False
+
+    safe = expr
+    for x in toks:
+        safe = re.sub(rf"(?<![\w.]){re.escape(x)}(?![\w.])", f"v['{x}']", safe)
+
+    for mask in range(1 << len(free)):
+        env = {x: False for x in toks}
+        for i, x in enumerate(free):
+            env[x] = bool(mask & (1 << i))
+        try:
+            if eval(safe, {"__builtins__": {}}, {"v": env}):   # noqa: S307 - fixed grammar, no input
+                return False
+        except Exception:
+            return False                     # unparseable condition is not evidence of a purchase
+    return True
 
 
 def baseline_armaments(arms):

--- a/tools/balance/reference_distribution.py
+++ b/tools/balance/reference_distribution.py
@@ -671,79 +671,21 @@ def burst_cycle(arm, anum):
     return rel + (burst - 1) * delay
 
 
-# Tokens that mean "somebody BOUGHT this" -- an upgrade, a promotion, or a veterancy rank.
-# Everything else in a condition is RUNTIME STATE the unit reaches on its own: charge level,
-# power, deployment, parachute, cloak. The distinction is the whole point of `is_upgrade_gated`
-# and conflating the two priced 44 actors at zero DPS.
-_BOUGHT = re.compile(r"(upgrade|promotion)", re.I)
-_RANK = re.compile(r"^rank[-_]", re.I)
-_CMP = re.compile(r"[A-Za-z_][\w.]*\s*(?:==|!=|>=|<=|>|<)\s*\d+")
-
-
-def _is_bought(tok):
-    return bool(_BOUGHT.search(tok) or _RANK.match(tok))
-
-
 def is_upgrade_gated(arm):
-    """True when this armament can fire ONLY after something is bought.
+    """True when this armament only fires once an UPGRADE or rank is granted.
 
-    ⛔ THIS WAS WRONG TWICE AND IT COST 44 ACTORS THEIR ENTIRE DPS (measured 2026-09-11).
-    The old body was::
+    The ledger records the armament's condition in `requires`, and it has three shapes:
+      None            always active
+      `!upgrade_x`    active only WITHOUT the upgrade -- this IS the baseline form
+      `upgrade_x`     active only WITH it -- an upgraded form, and not what we price
 
-        parts = req.replace("&"," ").replace(",", " ").replace("|"," ").split()
-        return any(not p.startswith("!") for p in parts)
-
-    1. **It never stripped parentheses.** `(!TeslaCoilCharge && !unpowered)` tokenises to
-       `(!TeslaCoilCharge`, which does not start with `!`, so EVERY parenthesised condition read
-       as gated no matter what it said.
-    2. **It treated runtime STATE as a purchase.** `ra2_soviets_teslacoil`'s baseline armament
-       requires `((!TeslaCoilCharge && !unpowered) || (TeslaCoilCharge == 1 && unpowered))
-       && (!ra2_soviets_upgrade_teslaoverload && !rank-elite)` -- no upgrade, no rank, just charge
-       and power. All six of its armaments were classified as gated, `baseline_armaments` returned
-       nothing, and the coil priced at 0 DPS. So did 43 other actors.
-
-    The question this function actually has to answer is: **can this armament fire with nothing
-    bought?** So pin every bought token FALSE, leave runtime state free, and ask whether any
-    assignment satisfies the condition. The state space is tiny (<=6 distinct tokens in practice),
-    so enumerate it rather than reason about it.
-
-    ⚠ The seam is `_is_bought`, and it IS a name rule -- `upgrade`/`promotion`/`rank-`. That is far
-    narrower than the old "anything without a leading !", but it is still a naming convention, so a
-    bought token named outside it would read as free state. Prefer widening `_BOUGHT` over
-    reintroducing a structural guess.
+    A compound is gated unless every clause is a negation.
     """
     req = str(arm.get("requires") or "").strip()
     if not req:
         return False
-
-    # Comparisons on counters (`TeslaCoilCharge == 1`) are single boolean facts, not two tokens.
-    cmps = {}
-    def _hold(m):
-        key = f"__cmp{len(cmps)}__"
-        cmps[key] = m.group(0)
-        return key
-    expr = _CMP.sub(_hold, req)
-
-    expr = expr.replace("&&", " and ").replace("||", " or ").replace("!", " not ")
-    toks = sorted(set(re.findall(r"[A-Za-z_][\w.\-]*", expr)) - {"and", "or", "not"})
-    free = [x for x in toks if not _is_bought(x)]
-    if len(free) > 16:                      # pathological; fall back to "not gated" rather than lie
-        return False
-
-    safe = expr
-    for x in toks:
-        safe = re.sub(rf"(?<![\w.]){re.escape(x)}(?![\w.])", f"v['{x}']", safe)
-
-    for mask in range(1 << len(free)):
-        env = {x: False for x in toks}
-        for i, x in enumerate(free):
-            env[x] = bool(mask & (1 << i))
-        try:
-            if eval(safe, {"__builtins__": {}}, {"v": env}):   # noqa: S307 - fixed grammar, no input
-                return False
-        except Exception:
-            return False                     # unparseable condition is not evidence of a purchase
-    return True
+    parts = [p for p in req.replace("&", " ").replace(",", " ").replace("|", " ").split() if p]
+    return any(not p.startswith("!") for p in parts)
 
 
 def baseline_armaments(arms):


### PR DESCRIPTION
Two corrections to the reference map generator. Tools only — no gameplay yaml, no engine content, so no boot gate applies.

## 1. The damage column was mislabelled, and Astra caught it

`reference_distribution.armament_profile` (line 742) computes `per_cycle / cycle`, where `cycle` is `ReloadDelay + (Burst−1) × BurstDelay` — in **engine ticks**. OpenRA runs 25 ticks per second, so real DPS is that number **× 25**.

The module's own note at line 276 only ever claimed the value was *"proportional to real DPS within a source"*. The report promoted it to `DPS` anyway. A reader sanity-checking `td_gdi_battletank` at **222** against game feel would conclude the unit was absurdly weak.

Comparisons between the `now` and `estimate` columns were always valid — both sides used the same units, so every ratio and every synthesis target in earlier rounds stands. **Only the unit name was wrong.** Header is now `dmg/tick`, with a comment saying not to rename it back without changing the arithmetic.

Credit to Astra, who found this while continuing the map and corrected it in their own 2026-09-11 revision.

## 2. Apply the maintainer's "all 17 move" ruling

Ruled 2026-09-08: Cargo plus a weapon means `armed_troop_transport`, with **no exception for an existing combat class**. The two Flak Trucks leave `anti_air_vehicle` and the six IFV variants leave `scout_vehicle`.

**51 actors move** — 16 into `mobile_bunker`, 35 into `armed_troop_transport`. All three classes carry the 1.5× AA range, so **no unit's range changes**; what changes is which class anchor prices it.

⚠ Both classes are still **inert** until `^ArmedTroopTransportTemplate` and `^MobileBunkerTemplate` land in yaml (C46). `extract_stats` rewrites `design.class_anchor` to `None` on every run, so subtype — the inherited template — is the only durable membership signal. `pending_classes.py` exists so the reclassification can be reviewed *before* any yaml is committed, and the report renders it as `today → after C46`.

⚠ The mobile-bunker filter is `Mobile and not Aircraft` for a reason: **26 actors resolve `AttackOpenTopped`, not 16.** Three are aircraft and seven are immobile bunkers and defenses. Dropping that filter would turn seven static defenses into mobile bunkers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)