### PR TITLE
fix(d2k): preserve Wraith warhead execution order

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1406,9 +1406,12 @@ DeviatorMissile_Artillery:
 		PercentageSpread: 50
 		InvalidTargets: Air
 
+^Warhead_MissileAP_Heavy_WraithOrder:
+	Inherits: ^Warhead_MissileAP_Heavy
+
 Wraith_ToxinMissiles:
+	Inherits@missilerole: ^Warhead_MissileAP_Heavy_WraithOrder
 	Inherits: DeviatorMissile_Artillery
-	Inherits@missilerole: ^Warhead_MissileAP_Heavy
 	Range: 8370
 	ReloadDelay: 125
 	Burst: 4


### PR DESCRIPTION
## Dependency
This is a focused follow-up to PR #354 and should be evaluated after that branch's boot fix.

## Problem
PR #354's direct inherit reorder fixes the duplicate-parent crash, but it moves `Wraith_ToxinMissiles`' `Warhead@MissileAP_Heavy` after `Warhead@OwnerChange`. That changes executable warhead order even though the sorted resolved-diff reports no value change.

## Change
Add a thin `^Warhead_MissileAP_Heavy_WraithOrder` alias that inherits the AP template first, then have Wraith inherit the alias before `DeviatorMissile_Artillery`. MiniYaml tracks the alias's ancestor inside its own branch, so the Deviator branch can still reach the AP template without a duplicate-parent exception. The resolved Wraith payload and executable warhead order match b235 exactly.

## Evidence
- Exact ordered resolved Wraith payload: equal to b235.
- Exact ordered resolved comparison against PR #354 head: only Wraith changes, as intended.
- `audit_duplicate_inherits.py`: exit 0; no blocking chain.
- `find_empty_warhead.py`: 0.
- `audit_weapon_shape.py`: W7 957 and W8 858, unchanged pre-existing ratchets; exit 0.
- Actual engine startup from the probe tree reached `MenuPostProcessEffect.PostWorldLoaded`; zero new `exception-*.log` files.
- YAML-only; no C# rebuild required.

This preserves the W7 debt (Wraith still inherits the concrete `DeviatorMissile_Artillery` weapon); it does not claim W24 completion.
