### PR TITLE
fix(balance): make R1/R3 diagnostics fail closed

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1025,13 +1025,14 @@ resolution is that four of them are inputs and the fifth is a check.
 
 `reference_targets.COMPONENT_STATS` / `VERIFIER_STATS`, `compose_dps`, `recover_burst_time`,
 `dps_guard` (+ `_guard_self_test`), and a **DPS verifier column** in the reference map, which
-now also carries **Damage/shot** and **Reload** as their own columns. Burst delay stays OUT of
-the map, as ruled, but IS in the arithmetic. Verdicts on TD GDI: 8 `DISAGREES`, 3 `EXTREME`,
-18 unchanged.
+now also carries the **source damage coordinate** and **Reload** as their own columns. Burst delay stays OUT of
+the map, as ruled. The verifier is diagnostic-only and is withheld unless the row carries an
+explicit damage convention plus a complete burst-delay sequence; the current peer corpus does
+not provide that compatible evidence.
 
-`EXTREME_RATIO` 2.00, `DISAGREE_RATIO` 1.25 — the latter deliberately BELOW the mammoth's own
-1.43x component-vs-aggregate gap, so the case that produced the ruling is flagged rather than
-waved through. The mammoth now reads **488, DISAGREES 122%** against the projection's 174%.
+`EXTREME_RATIO` 2.00, `DISAGREE_RATIO` 1.25 remain the proposed diagnostic thresholds; they are
+not currently producing verifier claims because the compatible convention and delay evidence is
+missing from the peer corpus.
 
 ⛔ **`w_damage` MEANS DIFFERENT THINGS IN DIFFERENT SOURCES, and reading it wrong
 double-counts burst.** `extract_peer_units` sets `w_damage = audit["damage_pos"]` — damage per
@@ -1040,12 +1041,11 @@ SHOT — with `w_dps = damage_pos x burst / cycle`. The frozen Cameo snapshot's 
 shipped rows: mammoth `32000/400 = 80` ticks against `w_reload 72`; MLRS
 `48000/352.94 = 136` against `w_reload 111`.
 
-So the cycle and the per-shot burst delay are **RECOVERED from each row's own identity**
-(`recover_burst_time`), never assumed — which makes the guard correct under either convention.
-The first implementation multiplied by burst regardless and gave the mammoth 800 DPS against a
-true 400, and reported the MLRS as `EXTREME 34%` when its real move is `+19%`. A projected
-target arrives in the SAME units as the Cameo row it was projected onto, so composing in
-Cameo's convention is correct by construction.
+The cycle is recoverable only after the row's damage convention is explicit: per-shot rows
+multiply by `Burst`, while burst-inclusive rows do not. A complete delay sequence is still
+required for composition because burst delays may vary. The first implementation inferred the
+convention from `damage / DPS` and could silently compare unlike rows; the corrected guard now
+withholds that case instead of manufacturing a verifier result.
 
 ⚠ **A burst change alone barely moves DPS, and must not read as extreme.** Burst reaches DPS
 only by lengthening the cycle through burst delays; under a burst-inclusive `w_damage` it is
@@ -1101,23 +1101,25 @@ Those are different questions; step 2 currently supplies the first to step 3.
 today; re-scaling every class baseline uniformly reaches only **271 (67%)**, short of the ≥80%
 target. **21 of 24 classes span more than the 2.5× envelope** — up to **33.7×** (`melee`).
 
-⭐ **But the spread is concentrated, and that is the finding.** Every class has a CORE — the
-largest subset able to share one baseline — and every core already fits: spans **1.4×–2.5×**,
-holding **290 of 404** members. The remaining **114** sit outside their own class core, and the
-extremes are plainly classification defects rather than pricing ones: `futuretech_blackwidow`
-is in **`melee`** with `Range: 9000`; `corrino_buggy` is in **`mbt`** (25k HP, 100 DPS, cost
-300); `cabal_enlighted` carries **11,184 DPS** in `heavy_infantry` against a flamer's 181.
-`steelconsortium_hoverboardgrenadier` prices at **3080%** of its class baseline.
+⭐ **But the spread is concentrated, and that is the finding.** Every class has a current-anchor
+ratio window — the largest observed subset inside the 2.5× envelope — and those windows span
+**1.4×–2.5×**, holding **290 of 404** members. The remaining **114** sit outside those
+current-anchor windows. The extremes are triage signals, not proofs of a role or pricing defect:
+`futuretech_blackwidow` is in **`melee`** with `Range: 9000`;
+`corrino_buggy` is in **`mbt`** (25k HP, 100 DPS, cost 300); `cabal_enlighted` carries
+**11,184 DPS** in `heavy_infantry` against a flamer's 181. `steelconsortium_hoverboardgrenadier`
+prices at **3080%** of its class baseline.
 
-**So the band is a MISCLASSIFICATION DETECTOR, and step 3 is blocked on membership triage, not
-on baseline arithmetic.** Each of the 114 is one of three things and only a maintainer can say
+**So the band is a CURRENT-ANCHOR TRIAGE SIGNAL, and step 3 is blocked on membership triage, not
+on arithmetic alone.** Each of the 114 is one of three things and only a maintainer can say
 which: misclassified, a legitimate higher tier needing a tech-tier gate, or genuinely
-mis-stated. Fitting a baseline before that triage fits it to a population that does not belong
-together. `anchor_readiness.py` says the same from the other end — its "statistically
+mis-stated. Uniform rescaling can change the nonlinear ratio spread, and an anisotropic baseline
+could change it further; both need their own evidence before the window is treated as a fit.
+`anchor_readiness.py` says the same from the other end — its "statistically
 indistinguishable" class pairs are *"separated by what they SHOOT AT, not by their stats"*.
 
-**The 114 triaged, 2026-09-12 (`fit_baseband.py --triage`).** ⛔ **A stat-based test cannot
-say where an outlier belongs, only that it does not belong here.** Measured: the median member
+**The 114 triaged, 2026-09-12 (`fit_baseband.py --triage`).** ⛔ **A stat-based test does not
+determine class membership or baseline feasibility.** Measured: the median member
 is accepted by **6 of the 27** class baselines (mean 5.6, max 9), so "another class would take
 it" is true of nearly everything and is worth nothing as evidence. The first version of the
 triage used the best-fitting class as its deciding signal and labelled **81 of 114

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -42,10 +42,12 @@ summary. The maintainer-approved WORK ORDER, all four confirmed in one answer:
    "all members in band" requires the baseline at or below the weakest member. A **median**
    baseline therefore cannot satisfy the band — and medians are what `derive_virtual_anchor.py`
    proposes. 115/404 in band today; re-scaling every baseline reaches only 271/404 (67%).
-   ⭐ **Every class already has a core that fits** (span 1.4×–2.5×, 290 of 404 members). The
-   **114** outside their core are the real work, and the extremes are classification defects,
-   not pricing ones: `futuretech_blackwidow` is in `melee` with `Range: 9000`, `corrino_buggy`
-   is in `mbt`, `cabal_enlighted` has 11,184 DPS in `heavy_infantry`.
+   ⭐ **Every class already has a current-anchor ratio window** (span 1.4×–2.5×, 290 of 404
+   members). The **114** outside those windows are the real work. They are triage signals, not
+   proof of a classification defect: `futuretech_blackwidow` is in `melee` with `Range: 9000`,
+   `corrino_buggy` is in `mbt`, `cabal_enlighted` has 11,184 DPS in `heavy_infantry`.
+   Uniform rescaling changes the nonlinear spread, and an anisotropic baseline or role split
+   requires separate design evidence.
    **The 114 are triaged** (`fit_baseband.py --triage`, table in `baseband_fit.md`):
    80 AXIS OUTLIER, 30 ROLE REVIEW, 2 NO CLASS ACCEPTS, 1 ONE CLASS ACCEPTS, 1 LATER TECH.
    ⛔ **A stat test cannot say where an outlier belongs.** The median member is accepted by
@@ -95,17 +97,15 @@ sorted by flat share — `TSPistola` 9% (worst armor ×0.91), `TSGrenadeAA` 17% 
 65% (×0.64), `TSVulcan2` 71% (×0.56), `TSTurretLaserFire` 79% (×0.37). Nothing written until
 the maintainer picks a share threshold.
 
-4. ✅ **DONE — separate weapon-stat targets with DPS as a verifier** (R1). Four inputs, one
+4. ⚠ **R1 tooling is present, but the DPS verifier remains diagnostic-only.** Four inputs, one
    guard rail. `reference_targets.COMPONENT_STATS` / `VERIFIER_STATS` + `compose_dps`,
-   `recover_burst_time`, `dps_guard`; the reference map gains **Damage/shot** and **Reload**
-   columns and a **DPS verifier** column. Burst delay stays out of the map as ruled, but is in
-   the arithmetic. TD GDI: 8 `DISAGREES`, 3 `EXTREME`, 18 unchanged; the mammoth reads
-   **488, DISAGREES 122%** against the projection's 174%.
+   `recover_burst_time`, `dps_guard`; the reference map gains a **source damage coordinate** and
+   **Reload** columns. A verifier result is emitted only when the damage convention and complete burst-delay
+   sequence are explicit; the current peer corpus does not provide that compatible evidence, so
+   the map withholds the previous `DISAGREES`/`EXTREME` claims.
    ⛔ **`w_damage` means different things in different sources** — per-SHOT in
-   `extract_peer_units`, burst-INCLUSIVE in the frozen Cameo snapshot. The cycle and per-shot
-   burst delay are now RECOVERED from each row's own identity, never assumed. Getting this
-   wrong gave the mammoth 800 DPS against a true 400 and called the MLRS `EXTREME 34%` when
-   its real move is `+19%`. See `DESIGN.md` "R1 implemented" and `LESSONS_LEARNED.md`.
+   `extract_peer_units`, burst-INCLUSIVE in the frozen Cameo snapshot. The corrected guard refuses
+   to infer a convention from `damage / DPS`, and it refuses to reuse a partial delay model.
 
 ⛔ **Blocked on nothing but sequencing:** merge **#356** (Codex's Wraith order fix — my reorder
 put the 60,000-damage main *after* `Warhead@OwnerChange`, so the Wraith captured a unit and then

--- a/docs/balance/baseband_fit.md
+++ b/docs/balance/baseband_fit.md
@@ -7,37 +7,37 @@ recomputation cross-check against check_band: 404/404 ratios identical
 
 | class | members | in band now | best single-k | k* | min% | max% | span | verdict |
 |---|--:|--:|--:|--:|--:|--:|--:|---|
-| `melee` | 35 | 15 (43%) | 21 (60%) | 1.111 | 24% | 680% | 33.7x | CANNOT FIT — span > 2.5 |
-| `heavy_infantry` | 35 | 19 (54%) | 22 (63%) | 0.745 | 81% | 4079% | 31.6x | CANNOT FIT — span > 2.5 |
-| `pure_sniper` | 9 | 2 (22%) | 6 (67%) | 1.284 | 38% | 861% | 31.5x | CANNOT FIT — span > 2.5 |
-| `artillery` | 30 | 9 (30%) | 20 (67%) | 0.752 | 26% | 956% | 24.3x | CANNOT FIT — span > 2.5 |
-| `rocket_trooper` | 39 | 15 (38%) | 21 (54%) | 1.168 | 78% | 1401% | 22.0x | CANNOT FIT — span > 2.5 |
-| `special_forces` | 16 | 3 (19%) | 10 (62%) | 1.215 | 68% | 960% | 18.3x | CANNOT FIT — span > 2.5 |
-| `scout_vehicle` | 16 | 11 (69%) | 11 (69%) | 0.887 | 36% | 673% | 15.2x | CANNOT FIT — span > 2.5 |
-| `fire_support` | 28 | 1 (4%) | 17 (61%) | 0.475 | 38% | 1138% | 13.6x | CANNOT FIT — span > 2.5 |
-| `scout` | 27 | 13 (48%) | 14 (52%) | 1.145 | 53% | 560% | 12.6x | CANNOT FIT — span > 2.5 |
-| `grenadier` | 7 | 2 (29%) | 4 (57%) | 1.433 | 101% | 895% | 12.6x | CANNOT FIT — span > 2.5 |
-| `mbt` | 42 | 1 (2%) | 32 (76%) | 0.580 | 48% | 1164% | 11.9x | CANNOT FIT — span > 2.5 |
-| `missile_vehicle` | 14 | 1 (7%) | 9 (64%) | 0.432 | 64% | 1231% | 10.7x | CANNOT FIT — span > 2.5 |
-| `artillery_tank` | 7 | 1 (14%) | 5 (71%) | 0.667 | 47% | 487% | 8.3x | CANNOT FIT — span > 2.5 |
-| `closecombat` | 4 | 1 (25%) | 3 (75%) | 0.811 | 101% | 526% | 4.6x | CANNOT FIT — span > 2.5 |
-| `anti_air_vehicle` | 9 | 0 (0%) | 7 (78%) | 0.458 | 46% | 372% | 4.5x | CANNOT FIT — span > 2.5 |
-| `mortar` | 5 | 2 (40%) | 4 (80%) | 0.896 | 58% | 249% | 3.9x | CANNOT FIT — span > 2.5 |
-| `high_tech_tank` | 24 | 3 (12%) | 21 (88%) | 0.657 | 89% | 442% | 3.9x | CANNOT FIT — span > 2.5 |
-| `light_tank` | 15 | 6 (40%) | 12 (80%) | 0.839 | 96% | 413% | 3.8x | CANNOT FIT — span > 2.5 |
-| `line_breaker` | 16 | 0 (0%) | 9 (56%) | 0.423 | 81% | 948% | 3.7x | CANNOT FIT — span > 2.5 |
-| `archer` | 4 | 2 (50%) | 3 (75%) | 1.384 | 101% | 287% | 3.6x | CANNOT FIT — span > 2.5 |
-| `flying_infantry` | 9 | 6 (67%) | 7 (78%) | 1.057 | 98% | 330% | 3.6x | CANNOT FIT — span > 2.5 |
+| `melee` | 35 | 15 (43%) | 21 (60%) | 1.111 | 24% | 680% | 33.7x | CURRENT-ANCHOR SPAN > 2.5 |
+| `heavy_infantry` | 35 | 19 (54%) | 22 (63%) | 0.745 | 81% | 4079% | 31.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `pure_sniper` | 9 | 2 (22%) | 6 (67%) | 1.284 | 38% | 861% | 31.5x | CURRENT-ANCHOR SPAN > 2.5 |
+| `artillery` | 30 | 9 (30%) | 20 (67%) | 0.752 | 26% | 956% | 24.3x | CURRENT-ANCHOR SPAN > 2.5 |
+| `rocket_trooper` | 39 | 15 (38%) | 21 (54%) | 1.168 | 78% | 1401% | 22.0x | CURRENT-ANCHOR SPAN > 2.5 |
+| `special_forces` | 16 | 3 (19%) | 10 (62%) | 1.215 | 68% | 960% | 18.3x | CURRENT-ANCHOR SPAN > 2.5 |
+| `scout_vehicle` | 16 | 11 (69%) | 11 (69%) | 0.887 | 36% | 673% | 15.2x | CURRENT-ANCHOR SPAN > 2.5 |
+| `fire_support` | 28 | 1 (4%) | 17 (61%) | 0.475 | 38% | 1138% | 13.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `scout` | 27 | 13 (48%) | 14 (52%) | 1.145 | 53% | 560% | 12.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `grenadier` | 7 | 2 (29%) | 4 (57%) | 1.433 | 101% | 895% | 12.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `mbt` | 42 | 1 (2%) | 32 (76%) | 0.580 | 48% | 1164% | 11.9x | CURRENT-ANCHOR SPAN > 2.5 |
+| `missile_vehicle` | 14 | 1 (7%) | 9 (64%) | 0.432 | 64% | 1231% | 10.7x | CURRENT-ANCHOR SPAN > 2.5 |
+| `artillery_tank` | 7 | 1 (14%) | 5 (71%) | 0.667 | 47% | 487% | 8.3x | CURRENT-ANCHOR SPAN > 2.5 |
+| `closecombat` | 4 | 1 (25%) | 3 (75%) | 0.811 | 101% | 526% | 4.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `anti_air_vehicle` | 9 | 0 (0%) | 7 (78%) | 0.458 | 46% | 372% | 4.5x | CURRENT-ANCHOR SPAN > 2.5 |
+| `mortar` | 5 | 2 (40%) | 4 (80%) | 0.896 | 58% | 249% | 3.9x | CURRENT-ANCHOR SPAN > 2.5 |
+| `high_tech_tank` | 24 | 3 (12%) | 21 (88%) | 0.657 | 89% | 442% | 3.9x | CURRENT-ANCHOR SPAN > 2.5 |
+| `light_tank` | 15 | 6 (40%) | 12 (80%) | 0.839 | 96% | 413% | 3.8x | CURRENT-ANCHOR SPAN > 2.5 |
+| `line_breaker` | 16 | 0 (0%) | 9 (56%) | 0.423 | 81% | 948% | 3.7x | CURRENT-ANCHOR SPAN > 2.5 |
+| `archer` | 4 | 2 (50%) | 3 (75%) | 1.384 | 101% | 287% | 3.6x | CURRENT-ANCHOR SPAN > 2.5 |
+| `flying_infantry` | 9 | 6 (67%) | 7 (78%) | 1.057 | 98% | 330% | 3.6x | CURRENT-ANCHOR SPAN > 2.5 |
 | `heavy_sniper` | 3 | 2 (67%) | 3 (100%) | 0.942 | 101% | 231% | 2.2x | fits fully |
 | `dreadnought` | 5 | 0 (0%) | 5 (100%) | 0.440 | 100% | 231% | 1.7x | fits fully |
 | `tank_destroyer` | 5 | 0 (0%) | 5 (100%) | 0.795 | 101% | 154% | 1.6x | fits fully |
 
 **115/404 (28%) of priced members sit in the sweet spot today; re-scaling each class baseline alone reaches 271/404 (67%).**
 
-**21 of 24 classes cannot fit the band as currently constituted** — their own spread exceeds the 2.5x baseline-to-verifier envelope.
-But the spread is concentrated, not general: below is each class's CORE (the largest set that can share one baseline) and the members that cannot join it.
+**21 of 24 classes exceed the 2.5x envelope at the recorded current anchor** — this is a current-anchor observation, not a feasibility proof.
+The spread is concentrated, not general: below is each class's current-anchor ratio window and the members outside that window.
 
-| class | core | core span | members that cannot share the core baseline |
+| class | current-anchor window | window span | members outside the current-anchor ratio window |
 |---|--:|--:|---|
 | `melee` | 21/35 | 2.4x | `naxis_slave` (27%), `zerg_zergling` (64%), `td_nod_flamethrower` (92%), `asianalliance_japanesesamurai` (120%), `asianalliance_alligator` (127%) +9 more |
 | `heavy_infantry` | 24/35 | 2.4x | `naxis_naxiflamer` (50%), `ixian_shockinfantry` (55%), `ra1_soviets_flamethrower` (57%), `ixian_storminfantry` (60%), `tkm_juggernaut` (66%) +6 more |
@@ -61,12 +61,12 @@ But the spread is concentrated, not general: below is each class's CORE (the lar
 | `archer` | 3/4 | 1.9x | `wc2_humans_highelvenarcher` (744%) |
 | `flying_infantry` | 7/9 | 2.2x | `zerg_shriek` (110%), `naxis_skymage` (390%) |
 
-**114 members across those classes sit outside their own class core.** Each is one of three things, and only a maintainer can say which:
+**114 members across those classes sit outside their current-anchor ratio window.** Each is one of three things, and only a maintainer can say which:
   * misclassified — `futuretech_blackwidow` is in `melee` with a range of 9000, and `corrino_buggy` is in `mbt`;
   * a legitimate higher tier that needs a tech-tier gate rather than a wider band;
   * genuinely mis-stated, which is what the pipeline exists to fix.
 
-⛔ Until that triage happens, no baseline for these classes can be signed: the band would be fitted to a population that does not belong together.
+⛔ Until that triage happens, no baseline for these classes can be signed: the current-anchor window does not determine class membership or baseline feasibility.
 
 ## The fitted baselines, on the grid
 
@@ -99,9 +99,9 @@ But the spread is concentrated, not general: below is each class's CORE (the lar
 
 ## Per-outlier evidence — FOR A MAINTAINER DECISION, never applied
 
-A member is listed when it cannot share one baseline with its class core.
+A member is listed when it sits outside its current-anchor ratio window.
 
-⛔ **The band cannot say where a member belongs, only that it does not belong here.** Measured: the median member is accepted by **6 of 27** class baselines (mean 5.6, max 9), so "another class would take it" is true of nearly everything and is not evidence. `anchor_readiness.py` says why — these classes are *"separated by what they SHOOT AT, not by their stats. No stat-based check can police these boundaries."* An earlier version of this table used the best-fitting class as the deciding signal and labelled 81 of these MISCLASSIFIED, which put `terran_ghost` in `artillery` on one arbitrary pick out of six. The `accepts` column is therefore a COUNT, and only 0 or 1 discriminates.
+⛔ **The band does not determine class membership or baseline feasibility.** Measured: the median member is accepted by **6 of 27** class baselines (mean 5.6, max 9), so "another class would take it" is true of nearly everything and is not evidence. `anchor_readiness.py` says why — these classes are *"separated by what they SHOOT AT, not by their stats. No stat-based check can police these boundaries."* An earlier version of this table used the best-fitting class as the deciding signal and labelled 81 of these MISCLASSIFIED, which put `terran_ghost` in `artillery` on one arbitrary pick out of six. The `accepts` column is therefore a COUNT, and only 0 or 1 discriminates.
 
 | class | actor | % of own baseline | worst axis vs core | accepts | signal | evidence |
 |---|---|--:|---|--:|---|---|

--- a/tools/balance/build_reference_report.py
+++ b/tools/balance/build_reference_report.py
@@ -121,10 +121,10 @@ def dps_verifier_cell(cameo_row, rows, tgt):
       EXTREME              the composed move alone exceeds EXTREME_RATIO.
 
     Burst delays are deliberately NOT a column (maintainer: "the burst delay should be
-    referenced but not in the reference map"), but they ARE in the cycle. They are RECOVERED
-    from each row's own identity rather than looked up, which also makes the cell immune to
-    the per-shot-vs-burst-inclusive `w_damage` difference between sources — see
-    `reference_targets.recover_burst_time`.
+    referenced but not in the reference map"). The verifier is therefore shown only when the
+    row carries an explicit damage convention and a complete burst-delay sequence. The source
+    corpus currently lacks that compatible evidence, so a missing guard is an honest hold rather
+    than an inferred conversion between per-shot and burst-inclusive damage.
     """
     keys = ("w_damage", "w_burst", "w_reload")
     cur = {k: cameo_row.get(k) for k in keys}
@@ -132,9 +132,10 @@ def dps_verifier_cell(cameo_row, rows, tgt):
     comp = {k: _cell_value(tgt.get(k)) for k in keys}
     g = rt.dps_guard(cur, comp, _cell_value(tgt.get("w_dps")))
     if g is None:
-        return '<span class="muted">—</span>'
+        return ('<span class="muted" title="withheld: explicit damage convention and complete '
+                'burst-delay evidence required">WITHHELD</span>')
     pct = f'{g["composed_ratio"] * 100:.0f}%'
-    bd = f'burst delay {g["burst_delay_per_shot"]:.0f}t/shot (recovered, not a column)'
+    bd = f'burst delays {g["burst_delays"]!r} (evidence, not a column)'
     if g["verdict"] == "ok":
         tag = (f'<span class="tag" title="{bd}">no change</span>'
                if abs(g["composed_ratio"] - 1) < 0.02
@@ -251,7 +252,7 @@ def weapon_calculation_details(rows, cameo_actor=None):
         proof = profile.get((row.get('source'), row.get('id')))
         cycle = row.get('w_cycle_evidence')
         fields = [('weapon', row.get('weapon')),
-                  ('damage per shot (raw source units)', row.get('w_damage')),
+            ('source damage coordinate (legacy armament-profile burst aggregate; not per-shot)', row.get('w_damage')),
                   ('reload delay / ROF (source ticks)', row.get('w_reload')),
                   ('burst', row.get('w_burst'))]
         if proof:
@@ -360,7 +361,7 @@ def emit(body, members, crows, assignment, attached, chassis_only, dist, cdist, 
                     '<th class="n">HP (now → reference)</th>'
                     '<th class="n">Speed (now → reference)</th>'
                     '<th class="n">Range (now → reference)</th>'
-                    '<th class="n">Damage/shot (now → reference)</th>'
+                    '<th class="n">Damage coordinate (now → reference)</th>'
                     '<th class="n">Reload (now → reference)</th>'
                     '<th class="n">Burst (now → reference)</th>'
                     '<th class="n">DPS verifier</th>'

--- a/tools/balance/fit_baseband.py
+++ b/tools/balance/fit_baseband.py
@@ -36,11 +36,10 @@ no gentle shoulder.
 
 WHAT THIS TOOL COMPUTES, per class:
 
-  span      max_ratio / min_ratio at the CURRENT baseline. Near-invariant under a uniform
-            baseline rescale, so it decides FEASIBILITY before any fitting: a class whose
-            span exceeds 2.5 cannot fit 100%-250% under ANY baseline, and needs splitting or
-            a tech-tier gate on its outliers. Reporting that is the point — it is not a
-            failure of the fit.
+  span      max_ratio / min_ratio at the CURRENT anchor. The formula is nonlinear in the
+            baseline axes, so this span can change under a uniform rescale; it is a current-
+            anchor observation only. `best_k` reports the result of the bounded scalar scan,
+            while neither value proves that an anisotropic baseline or role split cannot fit.
   k*        the single scale applied to all four stat axes that maximises sweet-spot
             occupancy (ties broken toward the weakest member landing on 100%).
   fitted    occupancy at k*, and the members still outside.
@@ -92,17 +91,16 @@ def ratio_of(inp, spec, anchor_tier, k=1.0):
 
 
 def core_window(ratios, span_cap=SWEET_HI):
-    """(lo_index, hi_index) of the largest set of members that CAN share one baseline.
+    """(lo_index, hi_index) of the longest current-anchor ratio window.
 
-    The band ratio is one-dimensional, so sort and take the longest contiguous run whose
-    max/min fits the envelope; anything outside it cannot be priced from the same baseline as
-    the rest. Contiguity loses nothing here — a member between two in-window members is in
-    the window by construction.
+    The current-anchor ratios are one-dimensional, so sort and take the longest contiguous run
+    whose max/min fits the envelope. This is a descriptive window at the recorded anchor;
+    it is not a proof of the largest feasible subset after re-fitting the axes.
 
-    This is what makes the span number actionable. A class that "cannot fit" usually has a
-    tight core plus two or three members that do not belong in it at all: `futuretech_blackwidow`
-    is in `melee` with a range of 9000, and `corrino_buggy` is in `mbt`. The band is reading
-    out a CLASSIFICATION defect, not arguing with the band law.
+    This is what makes the span number actionable. A class with a wide current-anchor spread
+    usually has a tight observed window plus members that need a role or tier review;
+    `futuretech_blackwidow` is in `melee` with a range of 9000, and `corrino_buggy` is in `mbt`.
+    The band is reporting a triage signal, not proving a classification defect.
     """
     rs = sorted(ratios)
     best = (0, 0, 0)
@@ -197,14 +195,14 @@ def propose(band_ratio, axis, factor, cands, tier, core_tier):
 
     Deliberately NOT a recommendation of a target class. Class membership is a role judgement
     (what a unit shoots at) and no stat test can make it — see `candidate_classes`. What the
-    band can honestly contribute is: this member cannot share its class's baseline, here is
-    the axis responsible, and here is whether anything else would even accept it.
+    band can honestly contribute is: this member sits outside its current-anchor class window,
+    here is the axis responsible, and here is whether anything else would even accept it.
     """
     off = factor is not None and (factor > 2.0 or factor < 0.5)
     if not cands:
         return "NO CLASS ACCEPTS", (
-            f"outside every class baseline" +
-            (f"; {axis} {factor:.1f}x its own core" if off else ""))
+            f"outside every current-anchor class window" +
+            (f"; {axis} {factor:.1f}x its current-anchor window" if off else ""))
     if len(cands) == 1:
         return "ONE CLASS ACCEPTS", f"only `{cands[0][0]}` takes it at {cands[0][1] * 100:.0f}%"
     if off:
@@ -301,8 +299,8 @@ def main() -> int:
     print("| class | members | in band now | best single-k | k* | min% | max% | span | verdict |")
     print("|---|--:|--:|--:|--:|--:|--:|--:|---|")
     for cls, n, n0, nk, span, k, lo, hi, _spec in sorted(rows, key=lambda r: -r[4]):
-        verdict = ("CANNOT FIT — span > 2.5" if span > SWEET_HI
-                   else "fits fully" if nk == n else "partial")
+        verdict = ("fits fully" if nk == n
+                   else "CURRENT-ANCHOR SPAN > 2.5" if span > SWEET_HI else "partial")
         print(f"| `{cls}` | {n} | {n0} ({n0/n:.0%}) | {nk} ({nk/n:.0%}) | {k:.3f} | "
               f"{lo*100:.0f}% | {hi*100:.0f}% | {span:.1f}x | {verdict} |")
 
@@ -311,12 +309,13 @@ def main() -> int:
     fit = sum(r[3] for r in rows)
     print(f"\n**{now}/{tot} ({now/tot:.0%}) of priced members sit in the sweet spot today; "
           f"re-scaling each class baseline alone reaches {fit}/{tot} ({fit/tot:.0%}).**")
-    print(f"\n**{len(infeasible)} of {len(rows)} classes cannot fit the band as currently "
-          f"constituted** — their own spread exceeds the 2.5x baseline-to-verifier envelope.")
-    print("But the spread is concentrated, not general: below is each class's CORE (the "
-          "largest set that can share one baseline) and the members that cannot join it.\n")
+    print(f"\n**{len(infeasible)} of {len(rows)} classes exceed the 2.5x envelope at the "
+          "recorded current anchor** — this is a current-anchor observation, not a feasibility "
+          "proof.")
+    print("The spread is concentrated, not general: below is each class's current-anchor ratio "
+          "window and the members outside that window.\n")
 
-    print("| class | core | core span | members that cannot share the core baseline |")
+    print("| class | current-anchor window | window span | members outside the current-anchor ratio window |")
     print("|---|--:|--:|---|")
     triage_total = 0
     for cls, span, _n in sorted(infeasible, key=lambda r: -r[1]):
@@ -330,14 +329,14 @@ def main() -> int:
         cspan = core[-1][0] / core[0][0] if core else 0
         print(f"| `{cls}` | {len(core)}/{len(paired)} | {cspan:.1f}x | {shown}{more} |")
 
-    print(f"\n**{triage_total} members across those classes sit outside their own class core.**"
-          " Each is one of three things, and only a maintainer can say which:")
+    print(f"\n**{triage_total} members across those classes sit outside their current-anchor "
+          "ratio window.** Each is one of three things, and only a maintainer can say which:")
     print("  * misclassified — `futuretech_blackwidow` is in `melee` with a range of 9000, "
           "and `corrino_buggy` is in `mbt`;")
     print("  * a legitimate higher tier that needs a tech-tier gate rather than a wider band;")
     print("  * genuinely mis-stated, which is what the pipeline exists to fix.")
     print("\n⛔ Until that triage happens, no baseline for these classes can be signed: the "
-          "band would be fitted to a population that does not belong together.")
+          "current-anchor window does not determine class membership or baseline feasibility.")
 
     print("\n## The fitted baselines, on the grid\n")
     print("| class | hp0 | speed0 | range0_wdist | dps0 | (cost0 unchanged — it cannot move the band) |")
@@ -355,10 +354,10 @@ def main() -> int:
         print()
         print("## Per-outlier evidence — FOR A MAINTAINER DECISION, never applied")
         print()
-        print("A member is listed when it cannot share one baseline with its class core.")
+        print("A member is listed when it sits outside its current-anchor ratio window.")
         print()
-        print("⛔ **The band cannot say where a member belongs, only that it does not belong "
-              "here.** Measured: the median member is accepted by **6 of 27** class baselines "
+        print("⛔ **The band does not determine class membership or baseline feasibility.** "
+              "Measured: the median member is accepted by **6 of 27** class baselines "
               "(mean 5.6, max 9), so \"another class would take it\" is true of nearly "
               "everything and is not evidence. `anchor_readiness.py` says why — these classes "
               "are *\"separated by what they SHOOT AT, not by their stats. No stat-based check "

--- a/tools/balance/reference_targets.py
+++ b/tools/balance/reference_targets.py
@@ -133,44 +133,55 @@ EXTREME_RATIO = 2.00
 DISAGREE_RATIO = 1.25
 
 
-def recover_burst_time(damage, dps, reload_ticks):
-    """The ticks spent INSIDE the burst, recovered from the row's own identity.
+# `w_damage` has two live meanings in the source corpus.  Keep the convention explicit at
+# the guard boundary instead of trying to infer it from damage / DPS: the same quotient is a
+# cycle for a burst-inclusive row and a per-shot cycle for a per-shot row.
+DAMAGE_PER_SHOT = "per_shot"
+DAMAGE_BURST_INCLUSIVE = "burst_inclusive"
 
-    ⛔ DO NOT TAKE `w_damage` AS DAMAGE PER SHOT. The convention differs by source and reading
-    it wrong double-counts burst:
-      * `extract_peer_units` sets `w_damage = audit["damage_pos"]`, damage per SHOT, and its
-        `w_dps = damage_pos * burst / cycle`.
-      * the frozen Cameo snapshot's `w_damage` is BURST-INCLUSIVE, and its identity is
-        `w_dps = w_damage / cycle` with no burst factor at all.
-    Proven on the shipped rows: mammoth `32000/400 = 80` ticks against `w_reload 72`, and
-    MLRS `48000/352.94 = 136` against `w_reload 111`. Multiplying by burst as well gives the
-    mammoth 800 dps against a true 400, and reported a bogus "EXTREME" verdict for the MLRS.
 
-    This is safe across both conventions because it never assumes one: the cycle comes out of
-    `damage / dps`, whatever those two mean, and the burst time is what is left after reload.
-    A target projected by `target_for` arrives in the SAME units as the Cameo row it is
-    projected onto, so composing in Cameo's convention is correct by construction.
+def recover_burst_time(damage, dps, reload_ticks, *, burst=1, damage_convention=None):
+    """Recover total burst-delay ticks only when the damage convention is explicit.
+
+    `extract_peer_units` stores per-shot damage while the frozen Cameo snapshot stores the
+    whole burst.  Without an explicit convention, `damage / dps` is ambiguous and this
+    function refuses to manufacture a delay.  The returned value is the sum of all delays in
+    the burst; individual delays must still be supplied separately when composing a target.
     """
-    if not damage or not dps:
+    if not damage or not dps or damage_convention not in {DAMAGE_PER_SHOT,
+                                                          DAMAGE_BURST_INCLUSIVE}:
         return None
-    return max(0.0, float(damage) / float(dps) - float(reload_ticks or 0))
+    shots = max(int(burst or 1), 1)
+    cycle_damage = float(damage) * (shots if damage_convention == DAMAGE_PER_SHOT else 1.0)
+    remaining = cycle_damage / float(dps) - float(reload_ticks or 0)
+    # A negative remainder means the row's own DPS identity is shorter than ReloadDelay;
+    # clamping that contradiction to zero would certify an impossible timing model.
+    if remaining < -1e-6:
+        return None
+    return max(0.0, remaining)
 
 
-def compose_dps(damage, reload_ticks, burst=1, burst_delay_per_shot=0.0):
-    """`damage / (reload + (burst - 1) * burst_delay)` — the engine's cycle.
+def compose_dps(damage, reload_ticks, burst=1, burst_delay_per_shot=0.0,
+                burst_delays=None, damage_convention=DAMAGE_BURST_INCLUSIVE):
+    """Compose a DPS value from an explicit damage convention and delay sequence.
 
-    `damage` is whatever `w_damage` means for the row it came from (see `recover_burst_time`);
-    burst is NOT a multiplier here. It reaches DPS only by lengthening the cycle, which is
-    also why a burst change alone barely moves DPS while it changes how the damage lands.
-
-    Recovered per-shot delays on the shipped rows: mammoth 8 ticks, MLRS 5 (the engine
-    default). Verified: mammoth `32000 / (72 + 1*8) = 400`.
+    A sequence is preferred because burst delays can vary.  The scalar argument remains a
+    convenience for a known constant-delay row.  Per-shot damage is multiplied by `burst`;
+    burst-inclusive damage is not.
     """
-    shots_gap = max(float(burst or 1) - 1.0, 0.0)
-    cycle = float(reload_ticks or 0) + shots_gap * float(burst_delay_per_shot or 0)
+    shots = max(int(burst or 1), 1)
+    if burst_delays is not None:
+        delays = [float(x) for x in burst_delays]
+        if len(delays) != max(shots - 1, 0):
+            return None
+        delay_total = sum(delays)
+    else:
+        delay_total = max(shots - 1, 0) * float(burst_delay_per_shot or 0)
+    cycle = float(reload_ticks or 0) + delay_total
     if cycle <= 0 or not damage:
         return None
-    return float(damage) / cycle
+    numerator = float(damage) * (shots if damage_convention == DAMAGE_PER_SHOT else 1.0)
+    return numerator / cycle
 
 
 def dps_guard(current, component_targets, dps_target):
@@ -193,16 +204,45 @@ def dps_guard(current, component_targets, dps_target):
         return v if v not in (None, 0) else current.get(key)
 
     cur_dps = current.get("w_dps")
-    bt = recover_burst_time(current.get("w_damage"), cur_dps, current.get("w_reload"))
+    convention = current.get("w_damage_convention")
+    target_damage = component_targets.get("w_damage")
+    target_convention = component_targets.get("w_damage_convention")
+    delays = current.get("w_burst_delays")
+    # A target without an explicit convention and delay sequence is not comparable.  Do not
+    # silently mix a peer per-shot target with Cameo's burst-inclusive coordinate.
+    if convention not in {DAMAGE_PER_SHOT, DAMAGE_BURST_INCLUSIVE}:
+        return None
+    if target_damage not in (None, 0) and target_convention != convention:
+        return None
+    if not isinstance(delays, (list, tuple)):
+        return None
+    burst = current.get("w_burst") or 1
+    bt = recover_burst_time(current.get("w_damage"), cur_dps, current.get("w_reload"),
+                            burst=burst, damage_convention=convention)
     if cur_dps is None or bt is None:
         return None
-    per_shot = bt / max(float(current.get("w_burst") or 1) - 1.0, 1.0)
+    if len(delays) != max(int(burst) - 1, 0) or abs(sum(float(x) for x in delays) - bt) > 1e-6:
+        return None
 
-    new = compose_dps(pick("w_damage"), pick("w_reload"), pick("w_burst"), per_shot)
+    target_burst = pick("w_burst")
+    # A changed burst needs its own delay evidence.  Reusing the current delay sequence would
+    # turn a real cadence change into a fabricated verifier result.
+    target_delays = component_targets.get("w_burst_delays")
+    if target_burst != burst and not isinstance(target_delays, (list, tuple)):
+        return None
+    if target_delays is None and target_burst == burst:
+        target_delays = delays
+    if not isinstance(target_delays, (list, tuple)):
+        return None
+    if len(target_delays) != max(int(target_burst or 1) - 1, 0):
+        return None
+
+    new = compose_dps(pick("w_damage"), pick("w_reload"), target_burst,
+                      burst_delays=target_delays, damage_convention=convention)
     if not new or not cur_dps:
         return None
     out = dict(current_dps=float(cur_dps), composed_dps=new, composed_ratio=new / cur_dps,
-               burst_delay_per_shot=per_shot, projected_dps=dps_target,
+               burst_delays=list(target_delays), projected_dps=dps_target,
                projected_ratio=None, disagreement=None, verdict="ok")
     if out["composed_ratio"] > EXTREME_RATIO or out["composed_ratio"] < 1 / EXTREME_RATIO:
         out["verdict"] = "extreme"
@@ -217,41 +257,62 @@ def dps_guard(current, component_targets, dps_target):
 
 def _guard_self_test():
     """The shipped mammoth and MLRS rows are the regression cases — both were got wrong once."""
-    # conventions recovered from the frozen snapshot, not assumed
-    assert recover_burst_time(32000, 400, 72) == 8.0, "mammoth burst time"
-    assert abs(recover_burst_time(48000, 352.94117647058823, 111) - 25.0) < 1e-6, "MLRS"
-    assert compose_dps(32000, 72, 2, 8) == 400, "the shipped mammoth identity"
-    assert abs(compose_dps(48000, 111, 6, 5) - 352.941) < 0.01, "the shipped MLRS identity"
+    assert recover_burst_time(32000, 400, 72, burst=2,
+                              damage_convention=DAMAGE_BURST_INCLUSIVE) == 8.0
+    assert recover_burst_time(16000, 400, 72, burst=2,
+                              damage_convention=DAMAGE_PER_SHOT) == 8.0
+    assert recover_burst_time(32000, 400, 72) is None, "unknown convention must withhold"
+    assert recover_burst_time(100, 20, 10, burst=1,
+                              damage_convention=DAMAGE_BURST_INCLUSIVE) is None
+    assert compose_dps(32000, 72, 2, burst_delays=[8]) == 400
+    assert abs(compose_dps(48000, 111, 6, burst_delay_per_shot=5) - 352.941) < 0.01
 
-    mam = dict(w_damage=32000, w_burst=2, w_reload=72, w_dps=400)
+    mam = dict(w_damage=32000, w_burst=2, w_reload=72, w_dps=400,
+               w_damage_convention=DAMAGE_BURST_INCLUSIVE, w_burst_delays=[8])
     # components: damage +9.1%, reload -11.1%, burst unanimous at 2 (a DIRECT stat)
-    g = dps_guard(mam, dict(w_damage=34915, w_burst=2, w_reload=64), dps_target=695)
-    assert abs(g["burst_delay_per_shot"] - 8) < 1e-9, g
+    g = dps_guard(mam, dict(w_damage=34915, w_burst=2, w_reload=64,
+                            w_damage_convention=DAMAGE_BURST_INCLUSIVE), dps_target=695)
+    assert g["burst_delays"] == [8], g
     assert abs(g["composed_dps"] - 485) < 1, g["composed_dps"]
     assert abs(g["projected_ratio"] - 1.7375) < 0.01, g["projected_ratio"]
     assert g["verdict"] == "disagrees", g          # ~1.43x apart, the documented gap
     assert abs(1 / g["disagreement"] - 1.43) < 0.02, g["disagreement"]
 
+    # Same burst count, different delay evidence must change the composed verifier.
+    delayed = dps_guard(mam, dict(w_damage=32000, w_burst=2, w_reload=72,
+                                  w_burst_delays=[12],
+                                  w_damage_convention=DAMAGE_BURST_INCLUSIVE), None)
+    assert delayed["burst_delays"] == [12], delayed
+    assert delayed["composed_ratio"] < 1.0, delayed
+
     # ⚠ A BURST CHANGE ALONE MUST NOT LOOK EXTREME. The MLRS target drops burst 6 -> 2, which
     # SHORTENS the cycle and nudges DPS up; the first version multiplied damage by burst and
     # called this "EXTREME 34%", a pure artifact of the wrong convention.
-    mlrs = dict(w_damage=48000, w_burst=6, w_reload=111, w_dps=352.94117647058823)
-    m = dps_guard(mlrs, dict(w_damage=46534, w_burst=2, w_reload=106), dps_target=None)
-    assert abs(m["burst_delay_per_shot"] - 5) < 1e-6, m
+    mlrs = dict(w_damage=48000, w_burst=6, w_reload=111,
+                w_dps=352.94117647058823,
+                w_damage_convention=DAMAGE_BURST_INCLUSIVE,
+                w_burst_delays=[5, 5, 5, 5, 5])
+    m = dps_guard(mlrs, dict(w_damage=46534, w_burst=6, w_reload=106,
+                             w_damage_convention=DAMAGE_BURST_INCLUSIVE), dps_target=None)
     assert 1.0 < m["composed_ratio"] < 1.3, m["composed_ratio"]
     assert m["verdict"] == "ok", m
 
     # a component set that agrees with the aggregate passes
-    ok = dps_guard(mam, dict(w_damage=32000 * 1.7, w_reload=72), 680)
+    ok = dps_guard(mam, dict(w_damage=32000 * 1.7, w_reload=72,
+                             w_damage_convention=DAMAGE_BURST_INCLUSIVE), 680)
     assert ok["verdict"] == "ok", ok
 
     # a genuine 2.5x move through the components alone is flagged
-    ex = dps_guard(mam, dict(w_damage=32000 * 2.5, w_reload=72), None)
+    ex = dps_guard(mam, dict(w_damage=32000 * 2.5, w_reload=72,
+                             w_damage_convention=DAMAGE_BURST_INCLUSIVE), None)
     assert ex["verdict"] == "extreme", ex
 
     # a missing component is the CURRENT value, never zero
-    same = dps_guard(mam, dict(w_damage=None, w_burst=None, w_reload=None), None)
+    same = dps_guard(mam, dict(w_damage=None, w_burst=None, w_reload=None,
+                               w_damage_convention=DAMAGE_BURST_INCLUSIVE), None)
     assert same["composed_ratio"] == 1.0, same
+    assert dps_guard(dict(w_damage=32000, w_burst=2, w_reload=72, w_dps=400),
+                     dict(w_damage=32000), None) is None
     return "reference_targets R1 guard self-test: PASS (mammoth 1.43x gap; MLRS burst not extreme)"
 
 

--- a/tools/tests/test_fit_baseband.py
+++ b/tools/tests/test_fit_baseband.py
@@ -1,0 +1,26 @@
+"""Regression for R3's nonlinear baseline scaling."""
+
+import math
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "balance"))
+
+import fit_baseband as fit  # noqa: E402
+
+
+def test_uniform_rescale_changes_current_anchor_span():
+    spec = {"hp0": 2.0, "speed0": 2.0, "range0_wdist": 2.0, "dps0": 2.0, "cost0": 1.0}
+    members = [(10.0, 0.1, 10.0, 0.1, False, 1.0), (1.0, 1.0, 1.0, 1.0, False, 1.0)]
+    at_anchor = [fit.ratio_of(member, spec, 1.0, 1.0) for member in members]
+    rescaled = [fit.ratio_of(member, spec, 1.0, 0.5) for member in members]
+    span_at_anchor = max(at_anchor) / min(at_anchor)
+    span_rescaled = max(rescaled) / min(rescaled)
+    assert not math.isclose(span_at_anchor, span_rescaled), (at_anchor, rescaled)
+
+
+if __name__ == "__main__":
+    test_uniform_rescale_changes_current_anchor_span()
+    print("fit_baseband R3 scaling regression: PASS")


### PR DESCRIPTION
R1/R3 review corrections for PR #354, based on Astra High's audit.

Changes:
- require an explicit per-shot vs burst-inclusive damage convention and complete burst-delay sequence before composing a DPS verifier;
- support variable burst delays, preserve supplied target delay changes, and reject impossible `damage / DPS < ReloadDelay` identities;
- label the aggregate coordinate honestly instead of `Damage/shot`;
- describe R3 spread/core output as current-anchor diagnostics, not proof of infeasibility or class membership;
- add the uniform-rescale regression for the nonlinear band formula.

Validation:
- `reference_targets._guard_self_test()` PASS;
- `python tools/tests/test_fit_baseband.py` PASS;
- focused `py_compile` and `git diff --check` PASS.

No YAML, ledger, pricing, or gameplay changes.
