### PR TITLE
fix(d2k): restore master boot without reordering Wraith payload

### DIFF
--- a/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
+++ b/mods/cameo/ContentPacks/D2k/Ordos/yaml/weapons.yaml
@@ -1413,8 +1413,11 @@ DeviatorMissile_Artillery:
 		PercentageSpread: 50
 		InvalidTargets: Air
 
+^Warhead_MissileAP_Heavy_WraithOrder:
+	Inherits: ^Warhead_MissileAP_Heavy
+
 Wraith_ToxinMissiles:
-	Inherits@missilerole: ^Warhead_MissileAP_Heavy
+	Inherits@missilerole: ^Warhead_MissileAP_Heavy_WraithOrder
 	Inherits: DeviatorMissile_Artillery
 	Range: 8370
 	ReloadDelay: 125

--- a/tools/audit/audit_duplicate_inherits.py
+++ b/tools/audit/audit_duplicate_inherits.py
@@ -58,6 +58,47 @@ def audit(rs, templates_too: bool = False) -> dict[str, list[list[tuple[str, tup
     return dupes
 
 
+
+# ── THE BLOCKING CLASS, SIMULATED THE WAY THE ENGINE ACTUALLY DOES IT ─────────
+# `audit()` above reports every parent reached by more than one path. Most of those
+# are DIAMONDS through sibling branches, which boot fine, so the report was advisory
+# and `main()` always returned 0. Two things made that insufficient on 2026-09-12:
+#
+#   1. it walked ACTORS ONLY. Weapons are a separate namespace and the crash class is
+#      identical there. Current master `b235c698` ships one blocking weapon and this
+#      audit exited 0 on it; the game did not reach the menu.
+#   2. "reached twice" is not the engine's rule, so it could not be gated.
+#
+# MiniYaml.cs:463-476 is the rule. Resolving a node, `inherited` accumulates each
+# DIRECT parent at that level and is threaded DOWN into each parent's own resolution;
+# a sibling's subtree does NOT contribute back. So the error fires exactly when one
+# name appears twice along a single ROOT-TO-ANCESTOR PATH — which is why a diamond
+# through two siblings is legal and a direct-plus-inherited repeat is not.
+#
+# `-` overrides are irrelevant here: the throw happens during inherit expansion,
+# before any removal is applied.
+def blocking(rs, lookup, names):
+    """[(name, parent, path)] for every node the engine would refuse to resolve."""
+    out = []
+
+    def walk(node, inherited, path, origin):
+        for key, target in rs.inherits_of(node):
+            if target.lower() in inherited:
+                out.append((origin, target, path + [f"{key}:{target}"]))
+                continue                       # report once; do not recurse into the loop
+            parent = lookup(target)
+            nxt = inherited | {target.lower()}
+            if parent is not None:
+                walk(parent, nxt, path + [f"{key}:{target}"], origin)
+            inherited = nxt                    # accumulates across SIBLINGS, like the engine
+
+    for name in names:
+        node = lookup(name)
+        if node is not None:
+            walk(node, frozenset(), [name], name)
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--templates", action="store_true", help="include ^ templates too")
@@ -65,6 +106,22 @@ def main() -> int:
     args = ap.parse_args()
 
     m = Model()
+
+    # ⛔ THE GATE. Actors AND weapons — the crash class is namespace-agnostic and this
+    # audit was blind to weapons until 2026-09-12.
+    hard = (blocking(m.rs, m.rs.actor, sorted(m.rs.actors))
+            + blocking(m.rs, m.rs.weapon, sorted(m.rs.weapons)))
+    if hard:
+        print(f"# BLOCKING — {len(hard)} node(s) the engine will REFUSE to resolve "
+              f"(boot crash: 'Parent type X was already inherited by this yaml tree')")
+        for name, parent, path in hard:
+            print(f"  {name}  ->  {parent}")
+            print(f"      {' -> '.join(path)}")
+        print()
+    else:
+        print("_clean_ — no node reaches the same parent twice on one chain "
+              "(actors and weapons).")
+
     dupes = audit(m.rs, templates_too=args.templates)
     if args.parent:
         dupes = {n: [chains for chains in chains_list if chains[0][0] == args.parent.lower()]
@@ -73,7 +130,7 @@ def main() -> int:
 
     if not dupes:
         print("_clean_ — no duplicate inheritance paths found.")
-        return 0
+        return 1 if hard else 0
 
     print(f"# audit_duplicate_inherits — {len(dupes)} actor(s)/template(s) reach a parent through more than one path")
     for name in sorted(dupes):
@@ -84,10 +141,9 @@ def main() -> int:
             for _, chain in chains:
                 print(f"    -> {' -> '.join(chain)}")
 
-    # Report-only by default: the tree currently contains many historical
-    # case-different and base/direct duplicates that boot successfully, so this
-    # is a diagnostic pass for now. Use --parent for a targeted gate.
-    return 0
+    # The DIAMOND report above is advisory: sibling-path duplicates boot fine. Only the
+    # BLOCKING list gates, because only it is what the engine refuses.
+    return 1 if hard else 0
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_duplicate_inherits_blocking.py
+++ b/tools/tests/test_duplicate_inherits_blocking.py
@@ -1,0 +1,55 @@
+"""Focused fixtures for the engine-blocking inheritance audit."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "audit"))
+
+from audit_duplicate_inherits import blocking  # noqa: E402
+
+
+class Node:
+    def __init__(self, name):
+        self.name = name
+
+
+class Ruleset:
+    def __init__(self, parents):
+        self.nodes = {name: Node(name) for name in parents}
+        self.parents = parents
+
+    def inherits_of(self, node):
+        return [(f"Inherits@{i}", target)
+                for i, target in enumerate(self.parents[node.name])]
+
+    def lookup(self, name):
+        return self.nodes.get(name)
+
+
+def findings(parents):
+    rules = Ruleset(parents)
+    return blocking(rules, rules.lookup, ["Root"])
+
+
+def test_sibling_diamond_is_legal():
+    assert findings({"Root": ["Left", "Right"], "Left": ["Shared"],
+                     "Right": ["Shared"], "Shared": []}) == []
+
+
+def test_accumulated_parent_repeat_is_blocking():
+    found = findings({"Root": ["Shared", "Base"], "Base": ["Shared"], "Shared": []})
+    assert [(name, parent) for name, parent, _path in found] == [("Root", "Shared")]
+
+
+def test_thin_alias_preserves_legal_paths():
+    assert findings({"Root": ["Alias", "Base"], "Alias": ["Shared"],
+                     "Base": ["Shared"], "Shared": []}) == []
+
+
+if __name__ == "__main__":
+    test_sibling_diamond_is_legal()
+    test_accumulated_parent_repeat_is_blocking()
+    test_thin_alias_preserves_legal_paths()
+    print("duplicate-inheritance blocking fixtures: PASS")


### PR DESCRIPTION
Master `b235c698` fails before the menu because `Wraith_ToxinMissiles` reaches `^Warhead_MissileAP_Heavy` twice on one inheritance path.

This narrow rescue uses the Astra-reviewed thin alias from #356 instead of the earlier reorder. The alias avoids the duplicate-parent exception while preserving the fully resolved Wraith warhead sequence, including keeping the AP main before `OwnerChange`. The duplicate-inheritance audit now gates the engine-blocking class across actors and weapons, with fixtures for a legal sibling diamond, an illegal accumulated-parent repeat, and the legal alias arrangement.

Static evidence:

- corrected audit identifies Wraith as the sole blocker on `b235c698` and exits 0 on this candidate;
- ordered full-resolution comparison: 2,448 concrete weapons, 0 changed; Wraith order identical;
- `find_empty_warhead`: 0;
- `find_orphan_old_keys`: Bug B 0;
- focused fixtures, `py_compile`, and `git diff --check`: pass.

Exact-head runtime evidence:

- commit `0f908e7ad5764e465635027740b6f95db6348900`;
- pinned engine `462fc1fc4bfc490c42b88b429670c7f0c64c7aca`;
- fresh `MenuPostProcessEffect.PostWorldLoaded` marker reached in 78.7 seconds;
- zero new `exception-*.log` files;
- only the owned OpenRA process was stopped after the marker.

No C# rebuild is required. This PR is the standalone master rescue; #354 contains the same thin alias, so this becomes redundant only after another rescue actually reaches master.
